### PR TITLE
Run tests on multiple Python versions

### DIFF
--- a/.isort.cfg
+++ b/.isort.cfg
@@ -1,4 +1,5 @@
 [settings]
+known_third_party = greenlet
 add_imports = from __future__ import absolute_import, from __future__ import division, from __future__ import print_function
 multi_line_output=3
 include_trailing_comma=True

--- a/.travis.yml
+++ b/.travis.yml
@@ -15,13 +15,6 @@ python:
  - "3.7"
  - "pypy3.5"
 
-matrix:
-  fast_finish: true
-  allow_failures:
-    - python: "3.6"
-    - python: "3.7"
-    - python: "pypy3.5"
-
 env:
  - CONFIG=""
  #- CONFIG="--test-verilog"

--- a/.travis.yml
+++ b/.travis.yml
@@ -6,9 +6,21 @@
 # language and build matrix
 #------------------------------------------------------------------------
 
+dist: xenial
 language: python
 python:
  - "2.7"
+ - "pypy"
+ - "3.6"
+ - "3.7"
+ - "pypy3.5"
+
+matrix:
+  fast_finish: true
+  allow_failures:
+    - python: "3.6"
+    - python: "3.7"
+    - python: "pypy3.5"
 
 env:
  - CONFIG=""
@@ -43,7 +55,7 @@ install:
 #------------------------------------------------------------------------
 
 script:
- - futurize --write --stage1 .
+ - futurize --write --stage1 . &> /dev/null
  # - futurize --write --stage2 .
  - autoflake --in-place --remove-duplicate-keys $(find . -name '*.py')
  - pyupgrade --keep-percent-format $(find . -name '*.py')
@@ -51,6 +63,7 @@ script:
  # - black .
  # - flake8 .
  - git diff --exit-code
+ - python --version | grep "Python 3" && futurize --write --stage2 . &> /dev/null || true
  - mkdir -p build
  - cd build
  - py.test --cov-report xml --cov=pymtl3 .. $CONFIG

--- a/.travis.yml
+++ b/.travis.yml
@@ -46,6 +46,7 @@ script:
  - futurize --write --stage1 .
  # - futurize --write --stage2 .
  - autoflake --in-place --remove-duplicate-keys $(find . -name '*.py')
+ - pyupgrade --keep-percent-format $(find . -name '*.py')
  - isort --apply --recursive .
  # - black .
  # - flake8 .

--- a/pymtl3/datatypes/BitStruct.py
+++ b/pymtl3/datatypes/BitStruct.py
@@ -86,6 +86,9 @@ class {name}( BitStruct ):
   def __init__( s, {args_str} ):
 {assign_str}
 
+  def __hash__( s ):
+    return hash(({hash_str}))
+
 _struct_dict[\"{name}\"] = {name}
 """
 
@@ -109,11 +112,13 @@ def mk_bit_struct( name, fields, str_func=None ):
 
     args_str   = ""
     assign_str = ""
+    hash_str = name + ", "
     nbits      = 0
     for field_name, FieldType in fields:
       nbits += FieldType.nbits
       args_str   += "{}={}(), ".format( field_name, FieldType.__name__ )
       assign_str += "    s.{} = {}\n".format( field_name, field_name )
+      hash_str += "s.{}, ".format(field_name)
     args_str = args_str[:-2]
 
     tmpl = _struct_tmpl.format( **locals() )

--- a/pymtl3/datatypes/PythonBits.py
+++ b/pymtl3/datatypes/PythonBits.py
@@ -112,6 +112,9 @@ class Bits( object ):
       return False
     return Bits( 1, int(self.value) == other )
 
+  def __hash__( self ):
+    return hash((self.nbits, self.value))
+
   def __ne__( self, other ):
     try:
       other = int(other)

--- a/pymtl3/datatypes/benchmarking/Bits_v2.py
+++ b/pymtl3/datatypes/benchmarking/Bits_v2.py
@@ -103,7 +103,7 @@ class Bits( object ):
   #---------------------------------------------------------------------
 
   def __repr__(self):
-    return "Bits( {0}, {1} )".format(self.nbits, self.hex())
+    return "Bits( {}, {} )".format(self.nbits, self.hex())
 
   def __str__(self):
     num_chars = (((self.nbits-1)/4)+1)

--- a/pymtl3/datatypes/bits_import.py
+++ b/pymtl3/datatypes/bits_import.py
@@ -59,7 +59,7 @@ class Bits{nbits}(Bits):
 _bits_types[{nbits}] = Bits{nbits}
 """
 
-_bitwidths     = range(1, 256) + [ 384, 512, 768, 1024, 1536, 2048, 4096 ]
+_bitwidths     = list(range(1, 256)) + [ 384, 512, 768, 1024, 1536, 2048, 4096 ]
 _bits_types    = dict()
 
 exec(py.code.Source( "".join([ bits_template.format( **vars() ) \

--- a/pymtl3/dsl/Component.py
+++ b/pymtl3/dsl/Component.py
@@ -452,7 +452,7 @@ class Component( ComponentLevel7 ):
   def get_all_object_filter( s, filt ):
     assert callable( filt )
     try:
-      return set( [ x for x in s._dsl.all_named_objects if filt(x) ] )
+      return { x for x in s._dsl.all_named_objects if filt(x) }
     except AttributeError:
       return s._collect_all( [ filt ] )[0]
 

--- a/pymtl3/dsl/ComponentLevel3.py
+++ b/pymtl3/dsl/ComponentLevel3.py
@@ -51,8 +51,9 @@ class ComponentLevel3( ComponentLevel2 ):
   def _collect_vars( s, m ):
     super( ComponentLevel3, s )._collect_vars( m )
     if isinstance( m, ComponentLevel3 ):
-      for k in m._dsl.adjacency:
-        s._dsl.all_adjacency[k] |= m._dsl.adjacency[k]
+      all_ajd = s._dsl.all_adjacency
+      for k, v in m._dsl.adjacency.items():
+        all_ajd[k] |= v
 
   # Override
   def _construct( s ):

--- a/pymtl3/dsl/ComponentLevel3.py
+++ b/pymtl3/dsl/ComponentLevel3.py
@@ -480,7 +480,7 @@ class ComponentLevel3( ComponentLevel2 ):
       # Each node is a writer when we expand it to other nodes
 
       S = deque( [ writer ] )
-      visited = set( [ writer ] )
+      visited = {  writer  }
 
       while S:
         u = S.pop() # u is the writer

--- a/pymtl3/dsl/NamedObject.py
+++ b/pymtl3/dsl/NamedObject.py
@@ -76,6 +76,8 @@ class ord_dict( object ):
     for k, v in self.data:
       yield k, v
 
+  items = iteritems
+
 # Special data structure for constructing the parameter tree.
 class ParamTreeNode(object):
   def __init__( self ):

--- a/pymtl3/dsl/test/ComponentLevel2_test.py
+++ b/pymtl3/dsl/test/ComponentLevel2_test.py
@@ -156,12 +156,6 @@ def test_variable_not_declared():
       s.a = int( a )
       s.b = Bits32( b )
 
-    def __eq__( s, other ):
-      return s.a == other.a and s.b == other.b
-
-    def __hash__( s ):
-      return hash((type(s), s.a, s.b))
-
   class A(ComponentLevel2):
     def construct( s ):
       s.a = Wire( SomeMsg )
@@ -307,13 +301,6 @@ def test_wr_A_b_rd_A_impl():
     def __init__( s, a=0, b=0 ):
       s.a = int(a)
       s.b = Bits32(b)
-
-    def __eq__( s, other ):
-      return s.a == other.a and s.b == other.b
-
-    def __hash__( s ):
-      return hash((type(s), s.a, s.b))
-
 
   class Top(ComponentLevel2):
     def construct( s ):

--- a/pymtl3/dsl/test/ComponentLevel2_test.py
+++ b/pymtl3/dsl/test/ComponentLevel2_test.py
@@ -159,6 +159,9 @@ def test_variable_not_declared():
     def __eq__( s, other ):
       return s.a == other.a and s.b == other.b
 
+    def __hash__( s ):
+      return hash((type(s), s.a, s.b))
+
   class A(ComponentLevel2):
     def construct( s ):
       s.a = Wire( SomeMsg )
@@ -307,6 +310,9 @@ def test_wr_A_b_rd_A_impl():
 
     def __eq__( s, other ):
       return s.a == other.a and s.b == other.b
+
+    def __hash__( s ):
+      return hash((type(s), s.a, s.b))
 
 
   class Top(ComponentLevel2):

--- a/pymtl3/dsl/test/ComponentLevel3_test.py
+++ b/pymtl3/dsl/test/ComponentLevel3_test.py
@@ -585,21 +585,9 @@ def test_multiple_fields_are_net_writers():
       s.a = Bits8(a)
       s.b = Bits32(b)
 
-    def __eq__( s, other ):
-      return s.a == other.a and s.b == other.b
-
-    def __hash__( s ):
-      return hash((type(s), s.a, s.b))
-
   class SomeMsg2( object ):
     def __init__( s, a=0 ):
       s.c = Bits8(a)
-
-    def __eq__( s, other ):
-      return s.c == other.c
-
-    def __hash__( s ):
-      return hash((type(s), s.c))
 
   class A( ComponentLevel3 ):
 
@@ -628,21 +616,9 @@ def test_multiple_fields_are_assigned():
       s.a = Bits8(a)
       s.b = Bits32(b)
 
-    def __eq__( s, other ):
-      return s.a == other.a and s.b == other.b
-
-    def __hash__( s ):
-      return hash((type(s), s.a, s.b))
-
   class SomeMsg2( object ):
     def __init__( s, a=0 ):
       s.c = Bits8(a)
-
-    def __eq__( s, other ):
-      return s.c == other.c
-
-    def __hash__( s ):
-      return hash((type(s), s.c))
 
   class A( ComponentLevel3 ):
 

--- a/pymtl3/dsl/test/ComponentLevel3_test.py
+++ b/pymtl3/dsl/test/ComponentLevel3_test.py
@@ -588,12 +588,18 @@ def test_multiple_fields_are_net_writers():
     def __eq__( s, other ):
       return s.a == other.a and s.b == other.b
 
+    def __hash__( s ):
+      return hash((type(s), s.a, s.b))
+
   class SomeMsg2( object ):
     def __init__( s, a=0 ):
       s.c = Bits8(a)
 
     def __eq__( s, other ):
-      return s.a == other.a
+      return s.c == other.c
+
+    def __hash__( s ):
+      return hash((type(s), s.c))
 
   class A( ComponentLevel3 ):
 
@@ -625,12 +631,18 @@ def test_multiple_fields_are_assigned():
     def __eq__( s, other ):
       return s.a == other.a and s.b == other.b
 
+    def __hash__( s ):
+      return hash((type(s), s.a, s.b))
+
   class SomeMsg2( object ):
     def __init__( s, a=0 ):
       s.c = Bits8(a)
 
     def __eq__( s, other ):
-      return s.a == other.a
+      return s.c == other.c
+
+    def __hash__( s ):
+      return hash((type(s), s.c))
 
   class A( ComponentLevel3 ):
 

--- a/pymtl3/dsl/test/DataStruct_test.py
+++ b/pymtl3/dsl/test/DataStruct_test.py
@@ -22,12 +22,6 @@ class SomeMsg( object ):
     s.a = int(a)
     s.b = Bits32(b)
 
-  def __eq__( s, other ):
-    return s.a == other.a and s.b == other.b
-
-  def __hash__( s ):
-    return hash((type(s), s.a, s.b))
-
 def _test_model( cls ):
   A = cls()
   A.elaborate()

--- a/pymtl3/dsl/test/DataStruct_test.py
+++ b/pymtl3/dsl/test/DataStruct_test.py
@@ -25,6 +25,9 @@ class SomeMsg( object ):
   def __eq__( s, other ):
     return s.a == other.a and s.b == other.b
 
+  def __hash__( s ):
+    return hash((type(s), s.a, s.b))
+
 def _test_model( cls ):
   A = cls()
   A.elaborate()

--- a/pymtl3/dsl/test/sim_utils.py
+++ b/pymtl3/dsl/test/sim_utils.py
@@ -291,7 +291,7 @@ def simple_sim_pass( s, seed=0xdeadbeef ):
         equiv[yy].add( xx )
 
     for method, assoc_blks in method_blks.iteritems():
-      visited = set( [ (method, 0) ] )
+      visited = {  (method, 0)  }
       Q = deque( [ (method, 0) ] ) # -1: pred, 0: don't know, 1: succ
 
       if verbose: print()

--- a/pymtl3/passes/DynamicSchedulePass.py
+++ b/pymtl3/passes/DynamicSchedulePass.py
@@ -157,8 +157,7 @@ class DynamicSchedulePass( BasePass ):
           for (u, v) in E: # u -> v
             if u in scc and v in scc:
               InD[ v ] += 1
-          in_degree_ranking = sorted( [ (InD[v], v) for v in InD ] )
-          Q.append( in_degree_ranking[0][1] )
+          Q.append( max(InD, key=InD.get) )
 
         else:
           # We start bfs with the blocks that are successors of the

--- a/pymtl3/passes/GenDAGPass.py
+++ b/pymtl3/passes/GenDAGPass.py
@@ -108,8 +108,8 @@ class GenDAGPass( BasePass ):
                     .replace( "(", "_" ).replace( ")", "" )
       gen_src = """
 @update
-def {0}():
-  {1} = {2}""".format( upblk_name, " = ".join( rstrs ), wstr )
+def {}():
+  {} = {}""".format( upblk_name, " = ".join( rstrs ), wstr )
 
       hostobj_allsrc[ lca ] += gen_src
       blkname_meta[ upblk_name ] = (gen_src, writer, readers)
@@ -371,7 +371,7 @@ def {0}():
 
     # flood-fill to find out all equivalent classes
 
-    visited = set( [] )
+    visited = set()
     for x in equiv:
       if x not in visited:
         equiv_class = set()
@@ -433,7 +433,7 @@ def {0}():
     all_upblks = top.get_all_update_blocks()
 
     for method, assoc_blks in method_blks.iteritems():
-      visited = set( [ (method, 0) ] )
+      visited = {  (method, 0)  }
       Q = deque( [ (method, 0) ] ) # -1: pred, 0: don't know, 1: succ
 
       if verbose: print()

--- a/pymtl3/passes/SimpleSchedulePass.py
+++ b/pymtl3/passes/SimpleSchedulePass.py
@@ -104,9 +104,9 @@ def dump_dag( top, V, E ):
 def check_schedule( top, schedule, V, E, in_degree ):
 
   if len(schedule) != len(V):
-    V_leftovers = set( [ v for v in V if in_degree[v] ] )
-    E_leftovers = set( [ (x,y) for (x,y) in E
-                         if x in V_leftovers and y in V_leftovers ] )
+    V_leftovers = {  v for v in V if in_degree[v]  }
+    E_leftovers = {  (x,y) for (x,y) in E
+                         if x in V_leftovers and y in V_leftovers  }
     dump_dag( top, V_leftovers, E_leftovers )
 
     raise UpblkCyclicError( """

--- a/pymtl3/passes/mamba/HeuristicTopoPass.py
+++ b/pymtl3/passes/mamba/HeuristicTopoPass.py
@@ -10,13 +10,17 @@ Date   : Dec 26, 2018
 from __future__ import absolute_import, division, print_function
 
 import ast
-from Queue import PriorityQueue
 
 from graphviz import Digraph
 
 from pymtl3.passes.BasePass import BasePass, PassMetadata
 from pymtl3.passes.errors import PassOrderError
 from pymtl3.passes.SimpleSchedulePass import check_schedule
+
+try:
+  from Queue import PriorityQueue
+except ImportError:
+  from queue import PriorityQueue
 
 
 class CountBranches( ast.NodeVisitor ):

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRGenL1Pass.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRGenL1Pass.py
@@ -64,9 +64,9 @@ class BehavioralRTLIRGeneratorL1( ast.NodeVisitor ):
     return ret
 
   def get_call_obj( s, node ):
-    if node.starargs:
+    if getattr(node, "starargs", False):
       raise PyMTLSyntaxError( s.blk, node, 'star argument is not supported!')
-    if node.kwargs:
+    if getattr(node, "kwargs", False):
       raise PyMTLSyntaxError( s.blk, node,
         'double-star argument is not supported!')
     if node.keywords:

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRImplGen.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRImplGen.py
@@ -361,7 +361,7 @@ def implement_module( module_str ):
   string."""
   start = 0
   node_type = set()
-  built_in_node_type = set( ['identifier', 'int', 'string', 'bool', 'object'] )
+  built_in_node_type = { 'identifier', 'int', 'string', 'bool', 'object' }
   constr_list = []
   # constr_list = set()
 

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRL1Pass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRL1Pass_test.py
@@ -11,6 +11,7 @@ generation pass results are verified against a reference AST.
 
 from __future__ import absolute_import, division, print_function
 
+import sys
 from copy import copy, deepcopy
 
 import pytest
@@ -35,6 +36,15 @@ from pymtl3.passes.rtlir.behavioral.BehavioralRTLIRTypeCheckL1Pass import (
 )
 from pymtl3.passes.rtlir.errors import PyMTLSyntaxError, PyMTLTypeError
 from pymtl3.passes.rtlir.util.test_utility import do_test, expected_failure
+
+# TODO: fix all tests with this mark, including in other files (grep!).
+# (we use the mark instead of allowing failure more generally because this
+#  prevents regressions in all the other tests that *pass* on Python 3)
+# If a test passes despite the mark, just remove it from that test!
+if sys.version_info[0] == 3:
+  XFAIL_ON_PY3 = pytest.mark.xfail(strict=True)
+else:
+  XFAIL_ON_PY3 = lambda f: f
 
 
 def local_do_test( m ):
@@ -470,6 +480,7 @@ def test_L1_tmpvar( do_test ):
 # Call-related syntax errors
 #-------------------------------------------------------------------------
 
+@XFAIL_ON_PY3
 def test_L1_call_star_arg( do_test ):
   class A( Component ):
     def construct( s ):
@@ -479,6 +490,7 @@ def test_L1_call_star_arg( do_test ):
   with expected_failure( PyMTLSyntaxError, "star argument" ):
     do_test( A() )
 
+@XFAIL_ON_PY3
 def test_L1_call_double_star_arg( do_test ):
   class A( Component ):
     def construct( s ):
@@ -742,6 +754,7 @@ def test_Raise( do_test ):
   with expected_failure( PyMTLSyntaxError, "invalid operation: raise" ):
     do_test( A() )
 
+@XFAIL_ON_PY3
 def test_TryExcept( do_test ):
   class A( Component ):
     def construct( s ):
@@ -752,6 +765,7 @@ def test_TryExcept( do_test ):
   with expected_failure( PyMTLSyntaxError, "invalid operation: try-except" ):
     do_test( A() )
 
+@XFAIL_ON_PY3
 def test_TryFinally( do_test ):
   class A( Component ):
     def construct( s ):

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
@@ -21,6 +21,7 @@ from pymtl3.passes.rtlir.behavioral import (
     BehavioralRTLIRVisualizationPass,
 )
 from pymtl3.passes.rtlir.behavioral.BehavioralRTLIR import *
+from pymtl3.passes.rtlir.behavioral.test.BehavioralRTLIRL1Pass_test import XFAIL_ON_PY3
 from pymtl3.passes.rtlir.util.test_utility import do_test, expected_failure
 
 
@@ -297,6 +298,7 @@ def test_if_basic( do_test ):
 
   do_test( a )
 
+@XFAIL_ON_PY3
 def test_for_basic( do_test ):
   class for_basic( Component ):
     def construct( s ):

--- a/pymtl3/passes/rtlir/structural/StructuralRTLIRGenL1Pass.py
+++ b/pymtl3/passes/rtlir/structural/StructuralRTLIRGenL1Pass.py
@@ -59,7 +59,7 @@ class StructuralRTLIRGenL1Pass( BasePass ):
 
     for writer, net in nets:
       S = deque( [ writer ] )
-      visited = set( [ writer ] )
+      visited = {  writer  }
       while S:
         u = S.pop()
         writer_host        = u.get_host_component()

--- a/pymtl3/passes/rtlir/structural/StructuralRTLIRSignalExpr.py
+++ b/pymtl3/passes/rtlir/structural/StructuralRTLIRSignalExpr.py
@@ -29,6 +29,9 @@ class BaseSignalExpr( object ):
   def __ne__( s, other ):
     return not s.__eq__( other )
 
+  def __hash__( s ):
+    return hash((type(s), s.rtype))
+
 class _Index( BaseSignalExpr ):
   def __init__( s, index_base, index, rtype ):
     super( _Index, s ).__init__( rtype )
@@ -39,6 +42,9 @@ class _Index( BaseSignalExpr ):
     return type(s) is type(other) and s.rtype == other.rtype and\
            s.index == other.index and \
            s.base == other.base
+
+  def __hash__( s ):
+    return hash((type(s), s.rtype, s.index, s.base))
 
   def get_index( s ):
     return s.index
@@ -134,6 +140,9 @@ class _Slice( BaseSignalExpr ):
     return type(s) is type(other) and s.rtype == other.rtype and \
            s.slice == other.slice and s.base == other.base
 
+  def __hash__( s ):
+    return hash((type(s), s.rtype, s.slice, s.base))
+
   def get_slice( s ):
     return s.slice
 
@@ -160,6 +169,9 @@ class _Attribute( BaseSignalExpr ):
     return type(s) is type(other) and s.rtype == other.rtype and \
            s.attr == other.attr and \
            s.base == other.base
+
+  def __hash__( s ):
+    return hash((type(s), s.rtype, s.attr, s.base))
 
   def get_base( s ):
     return s.base
@@ -213,6 +225,9 @@ class ConstInstance( BaseSignalExpr ):
     return isinstance(other, ConstInstance) and s.rtype == other.rtype and \
            s.value == other.value
 
+  def __hash__( s ):
+    return hash((type(s), s.rtype, s.value))
+
   def get_value( s ):
     return s.value
 
@@ -225,6 +240,9 @@ class CurComp( BaseSignalExpr ):
   def __eq__( s, other ):
     return isinstance(other, CurComp) and s.rtype == other.rtype and \
            s.comp_id == other.comp_id
+
+  def __hash__( s ):
+    return hash((type(s), s.rtype, s.comp_id))
 
   def get_component_id( s ):
     return s.comp_id

--- a/pymtl3/passes/test/DynamicSchedulePass_test.py
+++ b/pymtl3/passes/test/DynamicSchedulePass_test.py
@@ -11,6 +11,7 @@ from pymtl3.dsl import *
 from pymtl3.dsl.errors import UpblkCyclicError
 from pymtl3.passes.DynamicSchedulePass import DynamicSchedulePass
 from pymtl3.passes.GenDAGPass import GenDAGPass
+from pymtl3.passes.rtlir.behavioral.test.BehavioralRTLIRL1Pass_test import XFAIL_ON_PY3
 from pymtl3.passes.SimpleTickPass import SimpleTickPass
 
 
@@ -28,6 +29,7 @@ def _test_model( cls ):
     print(A.line_trace())
     T += 1
 
+@XFAIL_ON_PY3
 def test_false_cyclic_dependency():
 
   class Top(Component):
@@ -86,6 +88,7 @@ def test_false_cyclic_dependency():
 
   _test_model( Top )
 
+@XFAIL_ON_PY3
 def test_combinational_loop():
 
   class Top(Component):

--- a/pymtl3/passes/translator/structural/test/StructuralTranslatorL1_test.py
+++ b/pymtl3/passes/translator/structural/test/StructuralTranslatorL1_test.py
@@ -692,4 +692,4 @@ endcomponent
 """.format( a._ref_name )
   do_test( a )
 
-__all__ = filter(lambda s: s.startswith('test_'), dir())
+__all__ = list(filter(lambda s: s.startswith('test_'), dir()))

--- a/pymtl3/passes/translator/structural/test/StructuralTranslatorL2_test.py
+++ b/pymtl3/passes/translator/structural/test/StructuralTranslatorL2_test.py
@@ -415,4 +415,4 @@ endcomponent
 """
   do_test( a )
 
-__all__ = filter(lambda s: s.startswith('test_'), dir())
+__all__ = list(filter(lambda s: s.startswith('test_'), dir()))

--- a/pymtl3/passes/translator/structural/test/StructuralTranslatorL3_test.py
+++ b/pymtl3/passes/translator/structural/test/StructuralTranslatorL3_test.py
@@ -317,4 +317,4 @@ endcomponent
 """
   do_test( a )
 
-__all__ = filter(lambda s: s.startswith('test_'), dir())
+__all__ = list(filter(lambda s: s.startswith('test_'), dir()))

--- a/pymtl3/passes/translator/structural/test/StructuralTranslatorL4_test.py
+++ b/pymtl3/passes/translator/structural/test/StructuralTranslatorL4_test.py
@@ -223,4 +223,4 @@ endcomponent
 """
   do_test( a )
 
-__all__ = filter(lambda s: s.startswith('test_'), dir())
+__all__ = list(filter(lambda s: s.startswith('test_'), dir()))

--- a/pymtl3/stdlib/cl/MemoryCL_test.py
+++ b/pymtl3/stdlib/cl/MemoryCL_test.py
@@ -322,7 +322,7 @@ def test_read_write_mem( dump_vcd ):
 
   # Run the test
 
-  run_sim( th, dump_vcd )
+  run_sim( th )
 
   # Read the data back out of the test memory
 

--- a/pytest.ini
+++ b/pytest.ini
@@ -1,7 +1,7 @@
 #=========================================================================
 # pytest.ini
 #=========================================================================
-# Configuration file for py.test.
+# Configuration file for pytest
 
 [pytest]
 
@@ -20,10 +20,10 @@ python_functions = test test_*
 #-------------------------------------------------------------------------
 # default commandline arguments
 #-------------------------------------------------------------------------
-# By default do not show any traceback. This means by deafult py.test
+# By default do not show any traceback. This means by deafult pytest
 # gives an overview of the results but not any details. Users can use
 # --tb=long to get more information on a failing test. We also display
 # error/warnings at the end; otherwise syntax errors won't really show
 # up.
 
-addopts = --tb=no -r Ew
+addopts = --tb=native -r Ew

--- a/requirements.txt
+++ b/requirements.txt
@@ -11,4 +11,5 @@ autoflake
 future
 isort
 pytest-cov
+pyupgrade
 codecov

--- a/setup.py
+++ b/setup.py
@@ -27,6 +27,8 @@ def get_version():
   cmd = "git describe --dirty"
   try:
     result = check_output( cmd.split(),  ).strip()
+    if not isinstance(result, str):
+      result = result.decode()
   except:
     result = "?"
   return result


### PR DESCRIPTION
A quick approach to #22:  we can run the tests under Python 3 on Travis by inserting a transformer step, without (yet) requiring the code to be Python-3 compatible.

I've also added a `pypy` job, to catch any regressions on that side.