### PR TITLE
VCD generation pass first take

### DIFF
--- a/pymtl3/datatypes/BitStruct_test.py
+++ b/pymtl3/datatypes/BitStruct_test.py
@@ -108,7 +108,7 @@ def test_component():
       @s.update
       def up_bit_struct():
         # TODO:We have to use deepcopy here as a temporary workaround
-        # to prevent s.in_ beingmutated by the following operations.
+        # to prevent s.in_ being mutated by the following operations.
         s.out = deepcopy( s.in_ )
         s.out.pt0.x += 1
         s.out.pt0.y -= 1
@@ -118,8 +118,8 @@ def test_component():
 
   dut = A()
   dut.apply( SimpleSim )
-  dut.in_ = NestedSimple( StaticPoint(1,2), StaticPoint(3,4) )
+  dut.in_ = NestedSimple( StaticPoint(Bits4(1),Bits4(2)), StaticPoint(Bits4(3),Bits4(4)) )
   dut.tick()
-  assert dut.out == NestedSimple( StaticPoint(2,1), StaticPoint(4,3) )
+  assert dut.out == NestedSimple( StaticPoint(Bits4(2),Bits4(1)), StaticPoint(Bits4(4),Bits4(3)) )
   print( dut.out_pt )
-  assert dut.out_pt == StaticPoint(3,4)
+  assert dut.out_pt == StaticPoint(Bits4(3),Bits4(4))

--- a/pymtl3/dsl/ComponentLevel1.py
+++ b/pymtl3/dsl/ComponentLevel1.py
@@ -42,20 +42,8 @@ class ComponentLevel1( NamedObject ):
 
     return inst
 
-  def _declare_vars( s ):
-    """ Convention: the top level component on which we call elaborate
-    declare variables in _declare_vars; it shouldn't have them before
-    elaboration.
-
-    Convention: the variables that hold all metadata of descendants
-    should have _all prefix."""
-
-    s._dsl.all_upblks = set()
-    s._dsl.all_upblk_hostobj = {}
-    s._dsl.all_U_U_constraints = set()
-
   def _collect_vars( s, m ):
-    """ Called on individual objects during elaboration.
+    """ Called on individual objects during elaboration/addcomponent.
     The general format resembles "s._all_X.update/append( s._X ). """
 
     if isinstance( m, ComponentLevel1 ):
@@ -101,15 +89,31 @@ class ComponentLevel1( NamedObject ):
   # elaborate
   #-----------------------------------------------------------------------
 
-  def elaborate( s ):
-    # Directly use the base class elaborate
-    NamedObject.elaborate( s )
+  # We refactor the monolithic elaborate function into smaller functions
 
-    s._declare_vars()
+  def _elaborate_declare_vars( s ):
+    """ Convention: the top level component on which we call elaborate
+    declare variables in _declare_vars; it shouldn't have them before
+    elaboration.
+
+    Convention: the variables that hold all metadata of descendants
+    should have _all prefix."""
+
+    s._dsl.all_upblks = set()
+    s._dsl.all_upblk_hostobj = {}
+    s._dsl.all_U_U_constraints = set()
+
+  def _elaborate_collect_all_vars( s ):
     for c in s._dsl.all_named_objects:
       if isinstance( c, ComponentLevel1 ):
         s._collect_vars( c )
 
+  def elaborate( s ):
+    # Directly use the base class elaborate
+    NamedObject.elaborate( s )
+
+    s._elaborate_declare_vars()
+    s._elaborate_collect_all_vars()
   #-----------------------------------------------------------------------
   # Public APIs (only can be called after elaboration)
   #-----------------------------------------------------------------------

--- a/pymtl3/dsl/ComponentLevel3.py
+++ b/pymtl3/dsl/ComponentLevel3.py
@@ -44,11 +44,6 @@ class ComponentLevel3( ComponentLevel2 ):
     return inst
 
   # Override
-  def _declare_vars( s ):
-    super( ComponentLevel3, s )._declare_vars()
-    s._dsl.all_adjacency = defaultdict(set)
-
-  # Override
   def _collect_vars( s, m ):
     super( ComponentLevel3, s )._collect_vars( m )
     if isinstance( m, ComponentLevel3 ):
@@ -672,28 +667,20 @@ class ComponentLevel3( ComponentLevel2 ):
   # elaborate
   #-----------------------------------------------------------------------
 
+  # Since the spawned signals are handled by the updated elaborate
+  # template in ComponentLevel2, we just need to add a bit more
+  # functionalities to handle nets.
+
   # Override
-  def elaborate( s ):
+  def _elaborate_declare_vars( s ):
+    super( ComponentLevel3, s )._elaborate_declare_vars()
+    s._dsl.all_adjacency = defaultdict(set)
 
-    NamedObject.elaborate( s )
-
-    s._declare_vars()
-
-    for c in s._dsl.all_named_objects:
-
-      if isinstance( c, Signal ):
-        s._dsl.all_signals.add( c )
-
-      if isinstance( c, ComponentLevel2 ):
-        c._elaborate_read_write_func()
-
-      if isinstance( c, ComponentLevel1 ):
-        s._collect_vars( c )
-
+  # Override
+  def _elaborate_collect_all_vars( s ):
+    super( ComponentLevel3, s )._elaborate_collect_all_vars()
     s._dsl.all_value_nets = s._resolve_value_connections()
     s._dsl.has_pending_connections = False
-
-    s.check()
 
   #-----------------------------------------------------------------------
   # Public APIs (only can be called after elaboration)

--- a/pymtl3/dsl/ComponentLevel4.py
+++ b/pymtl3/dsl/ComponentLevel4.py
@@ -50,8 +50,8 @@ class ComponentLevel4( ComponentLevel3 ):
     return inst
 
   # Override
-  def _declare_vars( s ):
-    super( ComponentLevel4, s )._declare_vars()
+  def _elaborate_declare_vars( s ):
+    super( ComponentLevel4, s )._elaborate_declare_vars()
     s._dsl.all_M_constraints = set()
 
   # Override

--- a/pymtl3/dsl/ComponentLevel5.py
+++ b/pymtl3/dsl/ComponentLevel5.py
@@ -79,12 +79,16 @@ class ComponentLevel5( ComponentLevel4 ):
   # elaborate
   #-----------------------------------------------------------------------
 
+  # We still reuse the elaborate template by adding functionalities to
+  # sub-functions called by elaborate
   # Override
   def _elaborate_declare_vars( s ):
     super( ComponentLevel5, s )._elaborate_declare_vars()
 
     s._dsl.all_method_ports = set()
 
+  # However, we need to override the whole function here because we want
+  # to add some fine-grained functionalities to avoid reduntant isinstance
   # Override
   def _elaborate_collect_all_vars( s ):
     for c in s._dsl.all_named_objects:

--- a/pymtl3/dsl/ComponentLevel5.py
+++ b/pymtl3/dsl/ComponentLevel5.py
@@ -61,12 +61,6 @@ class ComponentLevel5( ComponentLevel4 ):
 
       s._dsl.constructed = True
 
-  # Override
-  def _declare_vars( s ):
-    super( ComponentLevel5, s )._declare_vars()
-
-    s._dsl.all_method_ports = set()
-
   def _connect_method_ports( s, o1, o2 ):
     assert isinstance( o1, MethodPort ) and isinstance( o2, MethodPort )
 
@@ -86,31 +80,27 @@ class ComponentLevel5( ComponentLevel4 ):
   #-----------------------------------------------------------------------
 
   # Override
-  def elaborate( s ):
+  def _elaborate_declare_vars( s ):
+    super( ComponentLevel5, s )._elaborate_declare_vars()
 
-    NamedObject.elaborate( s )
+    s._dsl.all_method_ports = set()
 
-    s._declare_vars()
-
+  # Override
+  def _elaborate_collect_all_vars( s ):
     for c in s._dsl.all_named_objects:
 
       if isinstance( c, Signal ):
         s._dsl.all_signals.add( c )
-
-      if isinstance( c, ComponentLevel2 ):
-        c._elaborate_read_write_func()
-
-      if isinstance( c, ComponentLevel1 ):
+      elif isinstance( c, ComponentLevel1 ):
         s._collect_vars( c )
-
-      if isinstance( c, MethodPort ):
+      # Added here
+      elif isinstance( c, MethodPort ):
         s._dsl.all_method_ports.add( c )
 
     s._dsl.all_value_nets  = s._resolve_value_connections()
+    # Added here
     s._dsl.all_method_nets = s._resolve_method_connections()
     s._dsl.has_pending_connections = False
-
-    s.check()
 
   def _resolve_method_connections( s ):
 

--- a/pymtl3/dsl/ComponentLevel7.py
+++ b/pymtl3/dsl/ComponentLevel7.py
@@ -39,9 +39,13 @@ class ComponentLevel7( ComponentLevel6 ):
 
     return inst
 
+  #-----------------------------------------------------------------------
+  # elaborate
+  #-----------------------------------------------------------------------
+
   # Override
-  def _declare_vars( s ):
-    super( ComponentLevel7, s )._declare_vars()
+  def _elaborate_declare_vars( s ):
+    super( ComponentLevel7, s )._elaborate_declare_vars()
 
     s._dsl.all_blocking_methods = set()
 

--- a/pymtl3/dsl/Connectable.py
+++ b/pymtl3/dsl/Connectable.py
@@ -194,6 +194,12 @@ class Signal( NamedObject, Connectable ):
   def is_interface( s ):
     return False
 
+  def is_sliced_signal( s ):
+    return s._dsl.slice is not None
+
+  def is_top_level_signal( s ):
+    return s._dsl.top_level_signal is None
+
   def get_top_level_signal( s ):
     top = s._dsl.top_level_signal
     return s if top is None else top

--- a/pymtl3/dsl/NamedObject.py
+++ b/pymtl3/dsl/NamedObject.py
@@ -187,7 +187,15 @@ class NamedObject(object):
     if x not in current_dict:
       current_dict[ x ] = value
 
-  def elaborate( s ):
+  # There are two reason I refactored this function into two separate
+  # functions. First of all in later levels of components, named objects
+  # can be spawned after the previous monolithic elaborate and hence this
+  # collect part won't capture them. Second, later levels can override
+  # this function and simply call construct at the beginning and call
+  # collect at the middle/end.
+
+  def _elaborate_construct( s ):
+
     if s._dsl.constructed:
       print("Don't elaborate the same model twice. \
              Use APIs to mutate the model.")
@@ -214,9 +222,14 @@ class NamedObject(object):
 
     del NamedObject.__setattr__
 
+  def _elaborate_collect_and_mark_all_named_objects( s ):
     s._dsl.all_named_objects = s._collect_all()
     for c in s._dsl.all_named_objects:
       c._dsl.elaborate_top = s
+
+  def elaborate( s ):
+    s._elaborate_construct()
+    s._elaborate_collect_and_mark_all_named_objects()
 
   # The following APIs can only be called after elaboration
 

--- a/pymtl3/dsl/test/ComponentLevel3_test.py
+++ b/pymtl3/dsl/test/ComponentLevel3_test.py
@@ -607,6 +607,11 @@ def test_multiple_fields_are_net_writers():
 
   a = A()
   a.elaborate()
+  simple_sim_pass( a )
+
+  a.in_ = SomeMsg1(4, 5)
+  a.tick()
+  assert a.out1.c == 4
 
 # The counterpart of the above test
 
@@ -643,3 +648,8 @@ def test_multiple_fields_are_assigned():
 
   a = A()
   a.elaborate()
+  simple_sim_pass( a )
+
+  a.in_ = SomeMsg1(4, 5)
+  a.tick()
+  assert a.out1.c == 4

--- a/pymtl3/dsl/test/ComponentLevel3_test.py
+++ b/pymtl3/dsl/test/ComponentLevel3_test.py
@@ -575,3 +575,71 @@ def test_multiple_slices_are_net_writers():
 
   a = A()
   a.elaborate()
+
+# A similar case for struct
+
+def test_multiple_fields_are_net_writers():
+
+  class SomeMsg1( object ):
+    def __init__( s, a=0, b=0 ):
+      s.a = Bits8(a)
+      s.b = Bits32(b)
+
+    def __eq__( s, other ):
+      return s.a == other.a and s.b == other.b
+
+  class SomeMsg2( object ):
+    def __init__( s, a=0 ):
+      s.c = Bits8(a)
+
+    def __eq__( s, other ):
+      return s.a == other.a
+
+  class A( ComponentLevel3 ):
+
+    def construct( s ):
+      s.in_  = InPort( SomeMsg1 )
+      s.out1 = OutPort( SomeMsg2 )
+      s.out2 = OutPort( SomeMsg2 )
+
+      s.connect( s.in_.a, s.out1.c )
+      s.connect( s.in_.b[0:8], s.out2.c )
+
+  a = A()
+  a.elaborate()
+
+# The counterpart of the above test
+
+def test_multiple_fields_are_assigned():
+
+  class SomeMsg1( object ):
+    def __init__( s, a=0, b=0 ):
+      s.a = Bits8(a)
+      s.b = Bits32(b)
+
+    def __eq__( s, other ):
+      return s.a == other.a and s.b == other.b
+
+  class SomeMsg2( object ):
+    def __init__( s, a=0 ):
+      s.c = Bits8(a)
+
+    def __eq__( s, other ):
+      return s.a == other.a
+
+  class A( ComponentLevel3 ):
+
+    def construct( s ):
+      s.in_  = InPort( SomeMsg1 )
+      s.out1 = OutPort( SomeMsg2 )
+      s.out2 = OutPort( SomeMsg2 )
+
+      # s.connect( s.in_.a, s.out1.c )
+      # s.connect( s.in_.b[0:8], s.out2.c )
+      @s.update
+      def up_pass():
+        s.out1.c = s.in_.a
+        s.out2.c = s.in_.b[0:8]
+
+  a = A()
+  a.elaborate()

--- a/pymtl3/passes/PassGroups.py
+++ b/pymtl3/passes/PassGroups.py
@@ -21,7 +21,6 @@ SimpleSim = [
   SimpleSchedulePass(),
   CLLineTracePass(),
   SimpleTickPass(),
-  VcdGenerationPass(),
   Component.lock_in_simulation
 ]
 

--- a/pymtl3/passes/PassGroups.py
+++ b/pymtl3/passes/PassGroups.py
@@ -11,6 +11,7 @@ from .mamba.UnrollTickPass import UnrollTickPass
 from .OpenLoopCLPass import OpenLoopCLPass
 from .SimpleSchedulePass import SimpleSchedulePass
 from .SimpleTickPass import SimpleTickPass
+from .VcdGenerationPass import VcdGenerationPass
 from .WrapGreenletPass import WrapGreenletPass
 
 SimpleSim = [
@@ -20,6 +21,7 @@ SimpleSim = [
   SimpleSchedulePass(),
   CLLineTracePass(),
   SimpleTickPass(),
+  VcdGenerationPass(),
   Component.lock_in_simulation
 ]
 

--- a/pymtl3/passes/VcdGenerationPass.py
+++ b/pymtl3/passes/VcdGenerationPass.py
@@ -8,15 +8,16 @@ Date   : May 29, 2019
 """
 from __future__ import absolute_import, division, print_function
 
+import time
 from collections import defaultdict
+from copy import deepcopy
+
+import py
 
 from pymtl3.passes.BasePass import BasePass, PassMetadata
-from copy import deepcopy
 
 from .errors import PassOrderError
 
-import py
-import time
 
 class VcdGenerationPass( BasePass ):
 
@@ -106,7 +107,7 @@ class VcdGenerationPass( BasePass ):
 
     # Generate symbol for existing nets
 
-    net_symbol_mapping = [ vcd_symbols.next() for x in trimmed_value_nets ]
+    net_symbol_mapping = [ next(vcd_symbols) for x in trimmed_value_nets ]
     signal_net_mapping = {}
 
     for i in range(len(trimmed_value_nets)):
@@ -155,7 +156,7 @@ class VcdGenerationPass( BasePass ):
 
           trimmed_value_nets.append( [ signal ] )
           signal_net_mapping[signal] = len(signal_net_mapping)
-          symbol = vcd_symbols.next()
+          symbol = next(vcd_symbols)
           net_symbol_mapping.append( symbol )
 
         # This signal can be a part of an interface so we have to
@@ -221,6 +222,8 @@ class VcdGenerationPass( BasePass ):
         symbol = net_symbol_mapping[i]
         vcd_srcs.append( dump_vcd_per_signal.format( i, net[0], symbol ) )
 
+    deepcopy # I have to do this to circumvent the tools
+
     src =  """
 def dump_vcd():
 
@@ -241,5 +244,5 @@ def dump_vcd():
 """.format( net_symbol_mapping[ vcdmeta.clock_net_idx ], "", "".join(vcd_srcs) )
 
     s = top
-    exec compile( src, filename="vcd_generation", mode="exec") in globals().update(locals())
+    exec(compile( src, filename="vcd_generation", mode="exec"), globals().update(locals()))
     return dump_vcd

--- a/pymtl3/passes/VcdGenerationPass.py
+++ b/pymtl3/passes/VcdGenerationPass.py
@@ -1,0 +1,225 @@
+"""
+========================================================================
+VcdGenerationPass.py
+========================================================================
+
+Author : Shunning Jiang
+Date   : May 29, 2019
+"""
+from __future__ import absolute_import, division, print_function
+
+from pymtl3.passes.BasePass import BasePass, PassMetadata
+
+from .errors import PassOrderError
+
+import time
+import sys
+
+#-----------------------------------------------------------------------
+# _gen_vcd_symbol
+#-----------------------------------------------------------------------
+# Utility generator to create new symbols for each VCD signal.
+# Code inspired by MyHDL 0.7.
+# Shunning: I just reuse it from pymtl v2
+def _gen_vcd_symbol():
+
+  # Generate a string containing all valid vcd symbol characters
+  _codechars = ''.join([chr(i) for i in range(33, 127)])
+  _mod       = len(_codechars)
+
+  # Function to map an integer n to a new vcd symbol
+  def next_vcd_symbol(n):
+    q, r = divmod(n, _mod)
+    code = _codechars[r]
+    while q > 0:
+      q, r = divmod(q, _mod)
+      code = _codechars[r] + code
+    return code
+
+  # Generator logic
+  n = 0
+  while 1:
+    yield next_vcd_symbol(n)
+    n += 1
+
+#-----------------------------------------------------------------------
+# write_vcd_signal_defs
+#-----------------------------------------------------------------------
+def write_vcd_signal_defs( o, model ):
+
+  vcd_symbol = _gen_vcd_symbol()
+  all_nets   = []
+
+  # Inner utility function to perform recursive descent of the model.
+  def recurse_models( model, level ):
+
+    # Create a new scope for this module
+    print( "$scope module {name} $end".format( name=model.name ), file=o )
+
+    # Define all signals for this model.
+    for i in model.get_ports() + model.get_wires():
+
+      # Multiple signals may be collapsed into a single net in the
+      # simulator if they are connected. Generate new vcd symbols per
+      # net, not per signal as an optimization.
+      net = i._signalvalue
+      if not hasattr( net, '_vcd_symbol' ):
+        net._vcd_symbol = vcd_symbol.next()
+        net._vcd_is_clk = i.name == 'clk'
+        all_nets.append( net )
+      symbol = net._vcd_symbol
+
+      print( "$var {type} {nbits} {symbol} {name} $end".format(
+          type='reg', nbits=i.nbits, symbol=symbol, name=i.name,
+      ), file=o )
+
+    # Recursively visit all submodels.
+    for submodel in model.get_submodules():
+      recurse_models( submodel, level+1 )
+
+    print( "$upscope $end", file=o )
+
+  # Begin recursive descent from the top-level model.
+  recurse_models( model, 0 )
+
+  # Once all models and their signals have been defined, end the
+  # definition section of the vcd and print the initial values of all
+  # nets in the design.
+  print( "$enddefinitions $end\n", file=o )
+  for net in all_nets:
+    print( "b{value} {symbol}".format(
+        value=net.bin(), symbol=net._vcd_symbol,
+    ), file=o )
+
+  return all_nets
+
+#-----------------------------------------------------------------------
+# insert_vcd_callbacks
+#-----------------------------------------------------------------------
+# Add callbacks which write the vcd file for each net in the design.
+def insert_vcd_callbacks( sim, nets ):
+
+  # A utility function which creates callbacks that write a nets current
+  # value to the vcd file. The returned callback function is a closure
+  # which is executed by the simulator whenever the net's value changes.
+  def create_vcd_callback( sim, net ):
+
+    # Each signal writes its binary value and unique identifier to the
+    # specified vcd file
+    if not net._vcd_is_clk:
+      cb = lambda: print( 'b%s %s\n' % (net.bin(), net._vcd_symbol),
+                          file=sim.vcd )
+
+    # The clock signal additionally must update the vcd time stamp
+    else:
+      cb = lambda: print( '#%s\nb%s %s\n' % (100*sim.ncycles+50*net.uint(),
+                          net.bin(), net._vcd_symbol),
+                          file=sim.vcd )
+
+    # Return the callback
+    return cb
+
+  # For each net in the simulator, create a callback and register it with
+  # the net to be fired whenever the value changes. We repurpose the
+  # existing callback facilities designed for slices (these execute
+  # immediately), rather than the default callback mechanism (these are
+  # put on the event queue to execute later).
+  for net in nets:
+    net.register_slice( create_vcd_callback( sim, net ) )
+
+
+class VcdGenerationPass( BasePass ):
+
+  def __call__( self, top ):
+    if not hasattr( top._sched, "schedule" ):
+      raise PassOrderError( "schedule" )
+
+    if hasattr( top, "_cl_trace" ):
+      schedule = top._cl_trace.schedule
+    else:
+      schedule = top._sched.schedule
+
+    top._vcd = PassMetadata()
+
+    self.append_vcd_func_to_schedule( top )
+
+  def append_vcd_func_to_schedule( self, top ):
+
+    top._vcd.vcd_file_name = str(top.__class__) + ".vcd"
+    top._vcd.vcd_file = open( top._vcd.vcd_file_name, "w" )
+
+    # Get vcd timescale
+
+    try:                    vcd_timescale = top.vcd_timescale
+    except AttributeError:  vcd_timescale = "10ps"
+
+    # Print vcd header
+
+    print( "$date\n    {}\n$end\n$version\n     PyMTL 3 (Mamba)\n$end\n"
+           "$timescale {}\n$end\n".format( time.asctime(), vcd_timescale ),
+           file=top._vcd.vcd_file )
+
+    # Preprocessing some metadata
+
+    vcd_symbols = _gen_vcd_symbol()
+
+    component_signals = defaultdict(list)
+
+    all_components = set()
+    for x in top._dsl.all_signals:
+      host = x.get_host_component()
+      component_signals[ host ].append(x)
+
+    all_value_nets = top.get_all_value_nets()
+
+    net_symbol_mapping = [ vcd_symbols.next() for x in all_value_nets ]
+    signal_net_mapping = {}
+
+    for i in range(len(all_value_nets)):
+      for x in all_value_nets[i][1]:
+        signal_net_mapping[x] = i
+
+    # Inner utility function to perform recursive descent of the model.
+    # Shunning: I mostly follow v2's implementation
+
+    def recurse_models( m ):
+
+      # Create a new scope for this module
+      print( "$scope module {name} $end".format( name=repr(m) ), file=top._vcd.vcd_file )
+
+      # Define all signals for this model.
+      for signal in component_signals[m]:
+        # Multiple signals may be collapsed into a single net in the
+        # simulator if they are connected. Generate new vcd symbols per
+        # net, not per signal as an optimization.
+
+        if signal in signal_net_mapping:
+          net = i._signalvalue
+        if not hasattr( net, '_vcd_symbol' ):
+          net._vcd_symbol = vcd_symbol.next()
+          net._vcd_is_clk = i.name == 'clk'
+          all_nets.append( net )
+        symbol = net._vcd_symbol
+
+        print( "$var {type} {nbits} {symbol} {name} $end".format(
+            type='reg', nbits=i.nbits, symbol=symbol, name=i.name,
+        ), file=top._vcd.vcd_file )
+
+      # Recursively visit all submodels.
+      for submodel in model.get_child_components():
+        recurse_models( submodel )
+
+      print( "$upscope $end", file=top._vcd.vcd_file )
+
+    # Begin recursive descent from the top-level model.
+    recurse_models( top )
+
+    # Once all models and their signals have been defined, end the
+    # definition section of the vcd and print the initial values of all
+    # nets in the design.
+    print( "$enddefinitions $end\n", file=top._vcd.vcd_file )
+
+    for net in all_nets:
+      print( "b{value} {symbol}".format(
+          value=net.bin(), symbol=net._vcd_symbol,
+      ), file=o )

--- a/pymtl3/stdlib/ifcs/SendRecvIfc.py
+++ b/pymtl3/stdlib/ifcs/SendRecvIfc.py
@@ -126,7 +126,7 @@ class RecvCL2SendRTL( Component ):
 
     s.recv_called = False
     s.recv_rdy    = False
-    s.msg_to_send = 0
+    s.msg_to_send = MsgType()
 
     @s.update
     def up_send_rtl():

--- a/pymtl3/stdlib/rtl/Crossbar_test.py
+++ b/pymtl3/stdlib/rtl/Crossbar_test.py
@@ -14,7 +14,11 @@ from .Crossbar import Crossbar
 #-----------------------------------------------------------------------
 # run_test_crossbar
 #-----------------------------------------------------------------------
-def run_test_crossbar( model, test_vectors ):
+def run_test_crossbar( cls, args, test_vectors ):
+
+  model = cls( *args )
+
+  n, T = args
 
   # Define functions mapping the test vector to ports in model
 
@@ -22,14 +26,14 @@ def run_test_crossbar( model, test_vectors ):
     n = len( model.in_ )
 
     for i in range(n):
-      model.in_[i] = test_vector[i]
-      model.sel[i] = test_vector[n+i]
+      model.in_[i] = T(test_vector[i])
+      model.sel[i] = T(test_vector[n+i])
 
   def tv_out( model, test_vector ):
     n = len( model.in_ )
 
     for i in range(n):
-      assert model.out[i] == test_vector[n*2+i]
+      assert model.out[i] == T(test_vector[n*2+i])
 
   # Run the test
 
@@ -42,7 +46,7 @@ def run_test_crossbar( model, test_vectors ):
 
 def test_crossbar3():
   model = Crossbar( 3, Bits16 )
-  run_test_crossbar( model, [
+  run_test_crossbar( Crossbar, (3, Bits16), [
     [ 0xdead, 0xbeef, 0xcafe, 0, 1, 2, 0xdead, 0xbeef, 0xcafe ],
     [ 0xdead, 0xbeef, 0xcafe, 0, 2, 1, 0xdead, 0xcafe, 0xbeef ],
     [ 0xdead, 0xbeef, 0xcafe, 1, 2, 0, 0xbeef, 0xcafe, 0xdead ],

--- a/pymtl3/stdlib/rtl/Encoder.py
+++ b/pymtl3/stdlib/rtl/Encoder.py
@@ -18,8 +18,11 @@ class Encoder( Component ):
 
     # Interface
 
-    s.in_ =  InPort( mk_bits( in_nbits  ) )
-    s.out = OutPort( mk_bits( out_nbits ) )
+    InType  = mk_bits(in_nbits)
+    OutType = mk_bits(out_nbits)
+
+    s.in_ =  InPort( InType )
+    s.out = OutPort( OutType )
 
     # Constants
 
@@ -30,9 +33,10 @@ class Encoder( Component ):
 
     @s.update
     def encode():
-      s.out = 0
+      s.out = OutType( 0 )
       for i in range( s.in_nbits ):
-        s.out = i if s.in_[i] else s.out
+        if s.in_[i]:
+          s.out = OutType( i )
 
   def line_trace( s ):
     return "in:{:0>{n}b} | out:{}".format(

--- a/pymtl3/stdlib/rtl/arbiters.py
+++ b/pymtl3/stdlib/rtl/arbiters.py
@@ -50,7 +50,7 @@ class RoundRobinArbiter( Component ):
       s.kills[0] = 1
 
       s.priority_int[    0:nreqs  ] = s.priority_reg.out
-      s.priority_int[nreqs:nreqsX2] = 0
+      s.priority_int[nreqs:nreqsX2] = mk_bits( nreqs )(0)
       s.reqs_int    [    0:nreqs  ] = s.reqs
       s.reqs_int    [nreqs:nreqsX2] = s.reqs
 
@@ -124,7 +124,7 @@ class RoundRobinArbiterEn( Component ):
       s.kills[0] = 1
 
       s.priority_int[    0:nreqs  ] = s.priority_reg.out
-      s.priority_int[nreqs:nreqsX2] = 0
+      s.priority_int[nreqs:nreqsX2] = mk_bits( nreqs )(0)
       s.reqs_int    [    0:nreqs  ] = s.reqs
       s.reqs_int    [nreqs:nreqsX2] = s.reqs
 

--- a/pymtl3/stdlib/rtl/arbiters_test.py
+++ b/pymtl3/stdlib/rtl/arbiters_test.py
@@ -71,15 +71,11 @@ def test_rr_arb_4():
 # Test driver for RoundRobinArbiterEn
 def run_en_test( model, test_vectors ):
 
-  # Instantiate and elaborate the model
-
-  # model.elaborate()
-
   # Define functions mapping the test vector to ports in model
 
   def tv_in( model, test_vector ):
-    model.en   = test_vector[0]
-    model.reqs = test_vector[1]
+    model.en   = Bits1( test_vector[0] )
+    model.reqs = Bits4( test_vector[1] )
 
   def tv_out( model, test_vector ):
     assert model.grants == test_vector[2]

--- a/pymtl3/stdlib/rtl/arbiters_test.py
+++ b/pymtl3/stdlib/rtl/arbiters_test.py
@@ -12,15 +12,19 @@ from pymtl3.stdlib.test import TestVectorSimulator
 from .arbiters import RoundRobinArbiter, RoundRobinArbiterEn
 
 
-def run_test( model, test_vectors ):
+def run_test( cls, args, test_vectors ):
+
+  model = cls( *args )
+
+  BitsN = mk_bits( args[0] )
 
   # Define functions mapping the test vector to ports in model
 
   def tv_in( model, test_vector ):
-    model.reqs = test_vector[0]
+    model.reqs = BitsN(test_vector[0])
 
   def tv_out( model, test_vector ):
-    assert model.grants == test_vector[1]
+    assert model.grants == BitsN(test_vector[1])
 
   # Run the test
 
@@ -34,8 +38,7 @@ def run_test( model, test_vectors ):
 # RoundRobinArbiter with four requesters
 def test_rr_arb_4():
 
-  model = RoundRobinArbiter( 4 )
-  run_test( model, [
+  run_test( RoundRobinArbiter, (4,), [
 
     # reqs     grants
     [ 0b0000,  0b0000 ],
@@ -69,16 +72,20 @@ def test_rr_arb_4():
 # run_en_test
 #------------------------------------------------------------------------------
 # Test driver for RoundRobinArbiterEn
-def run_en_test( model, test_vectors ):
+def run_en_test( cls, args, test_vectors ):
+
+  model = cls( *args )
+
+  BitsN = mk_bits( args[0] )
 
   # Define functions mapping the test vector to ports in model
 
   def tv_in( model, test_vector ):
     model.en   = Bits1( test_vector[0] )
-    model.reqs = Bits4( test_vector[1] )
+    model.reqs = BitsN( test_vector[1] )
 
   def tv_out( model, test_vector ):
-    assert model.grants == test_vector[2]
+    assert model.grants == BitsN(test_vector[2])
 
   # Run the test
 
@@ -91,8 +98,7 @@ def run_en_test( model, test_vectors ):
 # RoundRobinArbiterEn with four requesters
 def test_rr_arb_en_4( dump_vcd, test_verilog ):
 
-  model = RoundRobinArbiterEn( 4 )
-  run_en_test( model, [
+  run_en_test( RoundRobinArbiterEn, (4,), [
 
     # reqs     grants
     [ 0, 0b0000,  0b0000 ],

--- a/pymtl3/stdlib/rtl/queues.py
+++ b/pymtl3/stdlib/rtl/queues.py
@@ -95,8 +95,8 @@ class NormalQueueCtrlRTL( Component ):
 
     @s.update
     def up_next():
-      s.head_next = s.head - Bits1(1) if s.head > 0 else s.last_idx
-      s.tail_next = s.tail + Bits1(1) if s.tail < s.last_idx else 0
+      s.head_next = s.head - 1 if s.head > 0 else PtrType( s.last_idx )
+      s.tail_next = s.tail + 1 if s.tail < s.last_idx else PtrType(0)
 
     @s.update_on_edge
     def up_reg():


### PR DESCRIPTION
VCD generation pass is almost done and works for some stdlib components. I'm opening this PR to collect more opinions on how we should push it forward. I found a few action items.

1. I think I have thought through (a.k.a. nailed) how we should work with nested structs (TODO) and sliced signals (done) . Need to implement the nested structs by simply focusing on leaf signal objects thanks to the way I handle nested Bit struct right now. 
2. Should we make it general such that we can easily plug in another vcd format? For now, I'm generating the vcd dumping function because I don't want to deal with for loop and list (that would be slow). I would imagine it can be very easy to dump another format of VCD just by tweaking the string template for generating code snippet of each signal.
3. Note that we can also implement type checking before dumping VCD because you literally have the Type information and the variable object. The more exciting fact is from the idea of focusing on leaf signal objects. If we just throw away non-leaf signals which in my opinion is very elegant, we always deal with Bits types. This means we don't even need isinstance/issubclass at run time to check the type equality! We just throw exception if we cannot call X._get_nbits() from the variable!
4. The above point actually pushed me to think about PassGroup implementation. I guess we should have a top level pass group (which should be a Pass) that takes arguments like debug=True to decide whether it should apply this VCD pass with type checking on or line trace passes.

