### PR TITLE
Kernel bug fix: explicit reset signal, disconnecting consts, connecting Bits to signal

### DIFF
--- a/pymtl3/dsl/Component.py
+++ b/pymtl3/dsl/Component.py
@@ -51,12 +51,10 @@ class Component( ComponentLevel7 ):
       # We hook up the added clk and reset signals here. NOTE THAT if the
       # user overwrites clk/reset inside the component, we still get the
       # correct connection.
-      try:
-        parent = s.get_parent_object()
+      parent = s.get_parent_object()
+      if parent is not None:
         parent.connect( s.clk, parent.clk )
         parent.connect( s.reset, parent.reset )
-      except AttributeError:
-        pass
 
       if s._dsl.call_kwargs is not None: # s.a = A()( b = s.b )
         s._continue_call_connect()

--- a/pymtl3/dsl/Component.py
+++ b/pymtl3/dsl/Component.py
@@ -15,7 +15,7 @@ from pymtl3.datatypes import Bits1
 
 from .ComponentLevel1 import ComponentLevel1
 from .ComponentLevel7 import ComponentLevel7
-from .Connectable import InPort, Interface, MethodPort, OutPort, Signal, Wire
+from .Connectable import Const, InPort, Interface, MethodPort, OutPort, Signal, Wire
 from .errors import InvalidAPICallError, InvalidConnectionError, NotElaboratedError
 from .NamedObject import NamedObject
 from .Placeholder import Placeholder
@@ -45,16 +45,18 @@ class Component( ComponentLevel7 ):
 
       s._handle_decorated_methods()
 
-      # We hook up the added clk and reset signals here.
+      # Same as parent class _construct
+      s.construct( *s._dsl.args, **kwargs )
+
+      # We hook up the added clk and reset signals here. NOTE THAT if the
+      # user overwrites clk/reset inside the component, we still get the
+      # correct connection.
       try:
         parent = s.get_parent_object()
         parent.connect( s.clk, parent.clk )
         parent.connect( s.reset, parent.reset )
       except AttributeError:
         pass
-
-      # Same as parent class _construct
-      s.construct( *s._dsl.args, **kwargs )
 
       if s._dsl.call_kwargs is not None: # s.a = A()( b = s.b )
         s._continue_call_connect()
@@ -258,21 +260,16 @@ class Component( ComponentLevel7 ):
       removed_connectables = removed_signals | removed_method_ports
       top._dsl.all_named_objects -= removed_connectables
 
+      removed_consts = set()
       if isinstance( foo, Placeholder ):
         # No need to uncollect vars from a placeholder
         assert not foo._dsl.consts
       else:
         for x in removed_components:
           # remove consts
-          for y in x._dsl.consts:
-            del y._dsl.parent_obj
+          removed_consts |= x._dsl.consts
           # uncollect variables
           top._uncollect_vars( x )
-
-      for x in removed_components:
-        del x._dsl.parent_obj
-      for x in removed_connectables:
-        del x._dsl.parent_obj
 
       saved_connections = []
 
@@ -282,7 +279,7 @@ class Component( ComponentLevel7 ):
           for other in top._dsl.all_adjacency[x]:
             # other must be in the dict
             # If other will be removed, we don't need to remove it here ..
-            if other not in removed_connectables:
+            if other not in removed_connectables and other not in removed_consts:
               top._dsl.all_adjacency[other].remove( x )
               saved_connections.append( (other, "top"+repr(x)[1:]) ) # other is from outside
           del top._dsl.all_adjacency[x]
@@ -294,6 +291,13 @@ class Component( ComponentLevel7 ):
             if other not in removed_connectables:
               parent._dsl.adjacency[other].remove( x )
           del parent._dsl.adjacency[x]
+
+      for x in removed_components:
+        del x._dsl.parent_obj
+      for x in removed_connectables:
+        del x._dsl.parent_obj
+      for y in removed_consts:
+        del y._dsl.parent_obj
 
       # We don't break nets anymore. Instead, we set the flags to true so
       # that the next get_xxx_net will immediately recollect nets.

--- a/pymtl3/dsl/test/ComponentLevel3_test.py
+++ b/pymtl3/dsl/test/ComponentLevel3_test.py
@@ -653,3 +653,100 @@ def test_multiple_fields_are_assigned():
   a.in_ = SomeMsg1(4, 5)
   a.tick()
   assert a.out1.c == 4
+
+def test_const_connect_struct_signal_to_int():
+
+  class SomeMsg1( object ):
+    def __init__( s, a=0, b=0 ):
+      s.a = Bits8(a)
+      s.b = Bits32(b)
+
+    def __eq__( s, other ):
+      return s.a == other.a and s.b == other.b
+
+  class Top( ComponentLevel3 ):
+    def construct( s ):
+      s.wire = Wire(SomeMsg1)
+      s.connect( s.wire, 1 )
+
+  try:
+    x = Top()
+    x.elaborate()
+  except InvalidConnectionError as e:
+    print("{} is thrown\n{}".format( e.__class__.__name__, e ))
+    return
+  raise Exception("Should've thrown InvalidConnectionError.")
+
+def test_const_connect_struct_signal_to_Bits():
+
+  class SomeMsg1( object ):
+    def __init__( s, a=0, b=0 ):
+      s.a = Bits8(a)
+      s.b = Bits32(b)
+
+    def __eq__( s, other ):
+      return s.a == other.a and s.b == other.b
+
+  class Top( ComponentLevel3 ):
+    def construct( s ):
+      s.wire = Wire(SomeMsg1)
+      s.connect( s.wire, Bits32(1) )
+
+  try:
+    x = Top()
+    x.elaborate()
+  except InvalidConnectionError as e:
+    print("{} is thrown\n{}".format( e.__class__.__name__, e ))
+    return
+  raise Exception("Should've thrown InvalidConnectionError.")
+
+def test_const_connect_Bits_signal_to_int():
+
+  class Top( ComponentLevel3 ):
+    def construct( s ):
+      s.wire = Wire(Bits32)
+      s.connect( s.wire, 1 )
+
+  x = Top()
+  x.elaborate()
+  print(x._dsl.consts)
+  assert len(x._dsl.consts) == 1
+
+def test_const_connect_int_signal_to_int():
+
+  class Top( ComponentLevel3 ):
+    def construct( s ):
+      s.wire = Wire(int)
+      s.connect( s.wire, 1 )
+
+  x = Top()
+  x.elaborate()
+  print(x._dsl.consts)
+  assert len(x._dsl.consts) == 1
+
+def test_const_connect_Bits_signal_to_Bits():
+
+  class Top( ComponentLevel3 ):
+    def construct( s ):
+      s.wire = Wire(Bits32)
+      s.connect( s.wire, Bits32(0) )
+
+  x = Top()
+  x.elaborate()
+  print(x._dsl.consts)
+  assert len(x._dsl.consts) == 1
+
+def test_const_connect_Bits_signal_to_mismatch_Bits():
+
+  class Top( ComponentLevel3 ):
+    def construct( s ):
+      s.wire = Wire(Bits32)
+      s.connect( s.wire, Bits8(8) )
+
+  try:
+    x = Top()
+    x.elaborate()
+  except InvalidConnectionError as e:
+    print("{} is thrown\n{}".format( e.__class__.__name__, e ))
+    return
+  raise Exception("Should've thrown InvalidConnectionError.")


### PR DESCRIPTION
This PR fixed three bugs:

1. We connect the parent clk/reset to implicit reset signal before we call construct on the component. However, when the user declares a reset/clk signal in construct block, it overrides the previously declared signals, and we will instead collect the new signal later, but the connection is with the old signal. To solve this we postpone connecting the clk/reset to parent after we call construct (note that we cannot move the declaration below construct because the user may use the reset signal inside the construct block).

2. Previously I didn't handle the case where a constant connection needs to be saved when you delete a component.

3.I implemented connecting a Bits/int object to a Bits/int signal and add tests to catch the failed cases. Currently we hard-code int/Bits -- we allow an int const to be connected to int/Bits signals, and a Bits const to be connected to Bits signals **with the same bitwidth**. We throw an error when we connect Bits/int to a struct signal. In the future, I would imagine we might be able to connect a Bits constant to a Bitstruct using the pack/unpack facility. We might also want to connect a struct const to a struct signal.