### PR TITLE
stdlib cleanup

### DIFF
--- a/pymtl3/stdlib/cl/DelayPipeCL_test.py
+++ b/pymtl3/stdlib/cl/DelayPipeCL_test.py
@@ -20,15 +20,15 @@ from .DelayPipeCL import DelayPipeDeqCL, DelayPipeSendCL
 
 class TestHarness( Component ):
 
-  def construct( s, dut_class, src_msgs, sink_msgs, stall_prob, latency, src_lat, sink_lat ):
+  def construct( s, dut_class, src_msgs, sink_msgs, latency, src_lat, sink_lat ):
 
     # Messge type
 
     # Instantiate models
 
-    s.src  = TestSrcCL( src_msgs, 0, src_lat )
+    s.src  = TestSrcCL( None, src_msgs, 0, src_lat )
     s.dut  = dut_class( latency )
-    s.sink = TestSinkCL( sink_msgs, 0, sink_lat )
+    s.sink = TestSinkCL( None, sink_msgs, 0, sink_lat )
 
     # Connect
 
@@ -116,7 +116,7 @@ def basic_msgs():
 def test_delay_pipe_deq( test_params, dump_vcd ):
   msgs = test_params.msg_func()
   run_cl_sim( TestHarness( DelayPipeDeqCL, msgs[::2], msgs[1::2],
-                           0, test_params.lat,
+                           test_params.lat,
                            test_params.src_lat, test_params.sink_lat ) )
 
 @pytest.mark.parametrize( **mk_test_case_table([
@@ -135,5 +135,5 @@ def test_delay_pipe_deq( test_params, dump_vcd ):
 def test_delay_pipe_send( test_params, dump_vcd ):
   msgs = test_params.msg_func()
   run_cl_sim( TestHarness( DelayPipeSendCL, msgs[::2], msgs[1::2],
-                           0, test_params.lat,
+                           test_params.lat,
                            test_params.src_lat, test_params.sink_lat ) )

--- a/pymtl3/stdlib/cl/MemoryCL.py
+++ b/pymtl3/stdlib/cl/MemoryCL.py
@@ -110,6 +110,7 @@ class MemoryCL( Component ):
   #-----------------------------------------------------------------------
   # line_trace
   #-----------------------------------------------------------------------
+  # TODO: better line trace.
 
   def line_trace( s ):
     return "|".join( [ x[0].line_trace() + x[1].line_trace() for x in zip(s.req_qs, s.resp_qs) ] )

--- a/pymtl3/stdlib/cl/MemoryCL_test.py
+++ b/pymtl3/stdlib/cl/MemoryCL_test.py
@@ -28,11 +28,11 @@ class TestHarness( Component ):
                  stall_prob, mem_latency,
                  src_initial,  src_interval, sink_initial, sink_interval,
                  arrival_time=None ):
-
-    s.srcs = [ TestSrcCL( src_msgs[i], src_initial, src_interval )
+    ReqType, RespType = mk_mem_msg(8,32,32)
+    s.srcs = [ TestSrcCL( ReqType, src_msgs[i], src_initial, src_interval )
                 for i in xrange(nports) ]
-    s.mem  = cls( nports, [mk_mem_msg(8,32,32)]*nports, mem_latency )
-    s.sinks = [ TestSinkCL( sink_msgs[i], sink_initial, sink_interval,
+    s.mem  = cls( nports, [(ReqType, RespType)]*nports, mem_latency )
+    s.sinks = [ TestSinkCL( RespType, sink_msgs[i], sink_initial, sink_interval,
                             arrival_time ) for i in xrange(nports) ]
 
     # Connections
@@ -346,11 +346,11 @@ def run_sim( th, max_cycles=1000 ):
 
   print("")
   ncycles = 0
-  print("{}:{}".format( ncycles, th.line_trace() ))
+  print("{:3}:{}".format( ncycles, th.line_trace() ))
   while not th.done() and ncycles < max_cycles:
     th.tick()
     ncycles += 1
-    print("{}:{}".format( ncycles, th.line_trace() ))
+    print("{:3}:{}".format( ncycles, th.line_trace() ))
 
   # Check timeout
 

--- a/pymtl3/stdlib/cl/queues.py
+++ b/pymtl3/stdlib/cl/queues.py
@@ -21,8 +21,8 @@ from pymtl3.stdlib.ifcs.SendRecvIfc import enrdy_to_str
 
 class PipeQueueCL( Component ):
 
-  def construct( s, size ):
-    s.queue = deque( maxlen=size )
+  def construct( s, num_entries=1 ):
+    s.queue = deque( maxlen=num_entries )
 
     s.add_constraints(
       M( s.peek   ) < M( s.enq  ),
@@ -55,8 +55,8 @@ class PipeQueueCL( Component ):
 
 class BypassQueueCL( Component ):
 
-  def construct( s, size ):
-    s.queue = deque( maxlen=size )
+  def construct( s, num_entries=1 ):
+    s.queue = deque( maxlen=num_entries )
 
     s.add_constraints(
       M( s.enq    ) < M( s.peek    ),
@@ -84,8 +84,8 @@ class BypassQueueCL( Component ):
 
 class NormalQueueCL( Component ):
 
-  def construct( s, size ):
-    s.queue = deque( maxlen=size )
+  def construct( s, num_entries=1 ):
+    s.queue = deque( maxlen=num_entries )
     s.enq_rdy = False
     s.deq_rdy = False
 

--- a/pymtl3/stdlib/ifcs/SendRecvIfc.py
+++ b/pymtl3/stdlib/ifcs/SendRecvIfc.py
@@ -24,11 +24,16 @@ class RecvIfcRTL( Interface ):
     s.msg =  InPort( Type )
     s.en  =  InPort( int if Type is int else Bits1 )
     s.rdy = OutPort( int if Type is int else Bits1 )
-
+    
+    # Some metadata.
     s.MsgType = Type
+    try:
+      s.trace_len = len( "{}".format( Type() ) )
+    except:
+      s.trace_len = 16
 
   def line_trace( s ):
-    return enrdy_to_str( s.msg, s.en, s.rdy )
+    return enrdy_to_str( s.msg, s.en, s.rdy, s.trace_len )
 
   def __str__( s ):
     return s.line_trace()
@@ -69,11 +74,16 @@ class SendIfcRTL( Interface ):
     s.msg = OutPort( Type )
     s.en  = OutPort( int if Type is int else Bits1 )
     s.rdy =  InPort( int if Type is int else Bits1 )
-
+    
+    # Some metadata.
     s.MsgType = Type
+    try:
+      s.trace_len = len( "{}".format( Type() ) )
+    except:
+      s.trace_len = 16
 
   def line_trace( s ):
-    return enrdy_to_str( s.msg, s.en, s.rdy )
+    return enrdy_to_str( s.msg, s.en, s.rdy, s.trace_len )
 
   def __str__( s ):
     return s.line_trace()

--- a/pymtl3/stdlib/ifcs/SendRecvIfc.py
+++ b/pymtl3/stdlib/ifcs/SendRecvIfc.py
@@ -24,16 +24,17 @@ class RecvIfcRTL( Interface ):
     s.msg =  InPort( Type )
     s.en  =  InPort( int if Type is int else Bits1 )
     s.rdy = OutPort( int if Type is int else Bits1 )
-    
-    # Some metadata.
+
     s.MsgType = Type
-    try:
-      s.trace_len = len( "{}".format( Type() ) )
-    except:
-      s.trace_len = 16
 
   def line_trace( s ):
-    return enrdy_to_str( s.msg, s.en, s.rdy, s.trace_len )
+    try:
+      trace_len = s.trace_len
+    except AttributeError:
+      s.trace_len = len( "{}".format( s.MsgType() ) )
+      trace_len = s.trace_len
+
+    return enrdy_to_str( s.msg, s.en, s.rdy, trace_len )
 
   def __str__( s ):
     return s.line_trace()
@@ -74,16 +75,17 @@ class SendIfcRTL( Interface ):
     s.msg = OutPort( Type )
     s.en  = OutPort( int if Type is int else Bits1 )
     s.rdy =  InPort( int if Type is int else Bits1 )
-    
-    # Some metadata.
+
     s.MsgType = Type
-    try:
-      s.trace_len = len( "{}".format( Type() ) )
-    except:
-      s.trace_len = 16
 
   def line_trace( s ):
-    return enrdy_to_str( s.msg, s.en, s.rdy, s.trace_len )
+    try:
+      trace_len = s.trace_len
+    except AttributeError:
+      s.trace_len = len( "{}".format( s.MsgType() ) )
+      trace_len = s.trace_len
+
+    return enrdy_to_str( s.msg, s.en, s.rdy, trace_len )
 
   def __str__( s ):
     return s.line_trace()

--- a/pymtl3/stdlib/rtl/enrdy_queues_test.py
+++ b/pymtl3/stdlib/rtl/enrdy_queues_test.py
@@ -21,14 +21,13 @@ from .enrdy_queues import *
 
 class TestHarness( Component ):
 
-  def construct( s, Type, q, src_msgs, sink_msgs, src_stall_prob=0,
-                                                  sink_stall_prob=0 ):
+  def construct( s, Type, q, src_msgs, sink_msgs ):
 
     # Instantiate models
 
-    s.src  = TestSrcCL( src_msgs )
+    s.src  = TestSrcCL( Type, src_msgs )
     s.q    = q
-    s.sink = TestSinkCL( sink_msgs )
+    s.sink = TestSinkCL( Type, sink_msgs )
 
     # Connect
 
@@ -67,16 +66,16 @@ def test_normal_queue():
   run_sim( TestHarness( Bits32, NormalQueue1RTL(Bits32), req, resp) )
 
 def test_normal_queue_stall():
-  run_sim( TestHarness( Bits32, NormalQueue1RTL(Bits32), req, resp,  0.5, 0.25) )
+  run_sim( TestHarness( Bits32, NormalQueue1RTL(Bits32), req, resp ) )
 
 def test_pipe_queue():
   run_sim( TestHarness( Bits32, PipeQueue1RTL(Bits32), req, resp) )
 
 def test_pipe_queue_stall():
-  run_sim( TestHarness( Bits32, PipeQueue1RTL(Bits32), req, resp,  0.5, 0.25) )
+  run_sim( TestHarness( Bits32, PipeQueue1RTL(Bits32), req, resp ) )
 
 def test_bypass_queue():
-  run_sim( TestHarness( Bits32, BypassQueue1RTL(Bits32), req, resp) )
+  run_sim( TestHarness( Bits32, BypassQueue1RTL(Bits32), req, resp ) )
 
 def test_bypass_queue_stall():
-  run_sim( TestHarness( Bits32, BypassQueue1RTL(Bits32), req, resp,  0.5, 0.25) )
+  run_sim( TestHarness( Bits32, BypassQueue1RTL(Bits32), req, resp ) )

--- a/pymtl3/stdlib/rtl/queues_test.py
+++ b/pymtl3/stdlib/rtl/queues_test.py
@@ -68,7 +68,7 @@ class TestHarness( Component ):
                  src_interval, sink_initial, sink_interval,
                  arrival_time=None ):
 
-    s.src  = TestSrcCL  ( src_msgs,  src_initial,  src_interval )
+    s.src  = TestSrcCL ( MsgType, src_msgs,  src_initial,  src_interval )
     s.dut  = NormalQueueRTL( MsgType, qsize )
     s.sink = TestSinkRTL( MsgType, sink_msgs, sink_initial, sink_interval,
                           arrival_time )
@@ -90,8 +90,7 @@ class TestHarness( Component ):
 def run_sim( th, max_cycles=100 ):
 
   # Create a simulator
-  # th.elaborate()
-  # th.apply( simple_sim_pass )
+
   th.apply( SimpleSim )
   th.sim_reset()
 

--- a/pymtl3/stdlib/test/test_sinks.py
+++ b/pymtl3/stdlib/test/test_sinks.py
@@ -19,8 +19,10 @@ from pymtl3.stdlib.ifcs import RecvIfcRTL, RecvRTL2SendCL, enrdy_to_str
 
 class TestSinkCL( Component ):
 
-  def construct( s, msgs, initial_delay=0, interval_delay=0,
+  def construct( s, Type, msgs, initial_delay=0, interval_delay=0,
                  arrival_time=None ):
+    
+    s.recv.Type = Type
 
     # [msgs] and [arrival_time] must have the same length.
     if arrival_time is not None:
@@ -102,18 +104,18 @@ Received at    : {}""".format(
 
 class TestSinkRTL( Component ):
 
-  def construct( s, MsgType, msgs, initial_delay=0, interval_delay=0,
+  def construct( s, Type, msgs, initial_delay=0, interval_delay=0,
                  arrival_time=None ):
 
     # Interface
 
-    s.recv = RecvIfcRTL( MsgType )
+    s.recv = RecvIfcRTL( Type )
 
     # Components
 
-    s.sink    = TestSinkCL( msgs, initial_delay, interval_delay,
+    s.sink    = TestSinkCL( Type, msgs, initial_delay, interval_delay,
                             arrival_time )
-    s.adapter = RecvRTL2SendCL( MsgType )
+    s.adapter = RecvRTL2SendCL( Type )
 
     s.connect( s.recv,         s.adapter.recv )
     s.connect( s.adapter.send, s.sink.recv    )

--- a/pymtl3/stdlib/test/test_srcs.py
+++ b/pymtl3/stdlib/test/test_srcs.py
@@ -23,7 +23,6 @@ class TestSrcCL( Component ):
   def construct( s, Type, msgs, initial_delay=0, interval_delay=0 ):
 
     s.send = NonBlockingCallerIfc( Type )
-    print( "HEREH", msgs )
     s.msgs = deque( msgs )
 
     s.count  = initial_delay

--- a/pymtl3/stdlib/test/test_srcs.py
+++ b/pymtl3/stdlib/test/test_srcs.py
@@ -7,7 +7,6 @@ Test sources with CL or RTL interfaces.
 Author : Yanghui Ou
   Date : Mar 11, 2019
 """
-
 from __future__ import absolute_import, division, print_function
 
 from collections import deque
@@ -21,10 +20,10 @@ from pymtl3.stdlib.ifcs import RecvCL2SendRTL, SendIfcRTL
 
 class TestSrcCL( Component ):
 
-  def construct( s, msgs, initial_delay=0, interval_delay=0 ):
+  def construct( s, Type, msgs, initial_delay=0, interval_delay=0 ):
 
-    s.send = NonBlockingCallerIfc()
-
+    s.send = NonBlockingCallerIfc( Type )
+    print( "HEREH", msgs )
     s.msgs = deque( msgs )
 
     s.count  = initial_delay
@@ -50,19 +49,20 @@ class TestSrcCL( Component ):
 #-------------------------------------------------------------------------
 # TestSrcRTL
 #-------------------------------------------------------------------------
+# TODO: deprecating TestSrcRTL.
 
 class TestSrcRTL( Component ):
 
-  def construct( s, MsgType, msgs, initial_delay=0, interval_delay=0 ):
+  def construct( s, Type, msgs, initial_delay=0, interval_delay=0 ):
 
     # Interface
 
-    s.send = SendIfcRTL( MsgType )
+    s.send = SendIfcRTL( Type )
 
     # Components
 
-    s.src     = TestSrcCL( msgs, initial_delay, interval_delay )
-    s.adapter = RecvCL2SendRTL( MsgType )
+    s.src     = TestSrcCL( Type, msgs, initial_delay, interval_delay )
+    s.adapter = RecvCL2SendRTL( Type )
 
     s.connect( s.src.send,     s.adapter.recv )
     s.connect( s.adapter.send, s.send         )


### PR DESCRIPTION
In this PR I added Type as constructor for CL test src/sink in order to provide better line trace. I also use Type to infer the line trace width for send/recv interfaces.