### PR TITLE
Run flake8 in CI

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -50,12 +50,10 @@ install:
 
 script:
  - futurize --write --stage1 ./pymtl3 &> /dev/null
- # - futurize --write --stage2 .
- - autoflake --in-place --remove-duplicate-keys $(find ./pymtl3 -name '*.py')
- - pyupgrade --keep-percent-format $(find ./pymtl3 -name '*.py')
+ - autoflake --in-place --remove-duplicate-keys .
+ - pyupgrade --keep-percent-format $(find . -name '*.py')
  - isort --apply --recursive ./pymtl3
- # - black .
- # - flake8 .
+ - flake8 --select=F --ignore=F401,F405,F403,F811,F821,F841
  - git diff --exit-code
  - python --version | grep "Python 3" && futurize --write --stage2 ./pymtl3 &> /dev/null || true
  - mkdir -p build

--- a/pymtl3/dsl/NamedObject.py
+++ b/pymtl3/dsl/NamedObject.py
@@ -359,13 +359,13 @@ class NamedObject(object):
   #-----------------------------------------------------------------------
 
   def is_component( s ):
-    raise NotImplemented
+    raise NotImplementedError
 
   def is_signal( s ):
-    raise NotImplemented
+    raise NotImplementedError
 
   def is_interface( s ):
-    raise NotImplemented
+    raise NotImplementedError
 
   # These two APIs are reused across Connectable and Component
 

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRL1Pass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRL1Pass_test.py
@@ -504,7 +504,7 @@ def test_L1_call_double_star_arg( do_test ):
 def test_L1_call_keyword_arg( do_test ):
   class A( Component ):
     def construct( s ):
-      x = 42
+      xx = 42
       @s.update
       def upblk():
         x = x(x=x)

--- a/requirements.txt
+++ b/requirements.txt
@@ -8,6 +8,7 @@ graphviz
 
 # CI dependencies
 autoflake
+flake8
 future
 isort
 pytest-cov


### PR DESCRIPTION
`flake8` is great for finding shallow bugs!  In this config we select only "fatal" errors, then ignore several of them too - but the remaining issues are real, and it'll defend against a variety of possible future issues.

[Here's the list of `flake8` error codes](http://flake8.pycqa.org/en/latest/user/error-codes.html).