### PR TITLE
Fix reset-related problems

### DIFF
--- a/pymtl3/dsl/Component.py
+++ b/pymtl3/dsl/Component.py
@@ -428,7 +428,8 @@ class Component( ComponentLevel7 ):
     s._check_called_at_elaborate_top( "sim_reset" )
 
     s.reset = Bits1( 1 )
-    s.tick() # This tick propagates the reset signal
+    s.tick() # Tick twice to propagate the reset signal
+    s.tick()
     s.reset = Bits1( 0 )
 
   def check( s ):

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRGenL1Pass.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRGenL1Pass.py
@@ -210,6 +210,23 @@ class BehavioralRTLIRGeneratorL1( ast.NodeVisitor ):
       ret.ast = node
       return ret
 
+    # reduce methods
+    # elif obj is reduce_and or obj is reduce_or or obj is reduce_xor:
+      # if obj is reduce_and:
+        # op = bir.BitAnd()
+      # elif obj is reduce_or:
+        # op = bir.BitOr()
+      # elif obj is reduce_xor:
+        # op = bir.BitXor()
+      # if len( node.args ) != 1:
+        # raise PyMTLSyntaxError( s.blk, node,
+          # 'exactly two arguments should be given to reduce {} methods!'. \
+              # format( op ) )
+      # value = s.visit( node.args[0] )
+      # ret = bir.Reduce( op, value )
+      # ret.ast = node
+      # return ret
+
     else:
       # Only Bits class instantiation is supported at L1
       raise PyMTLSyntaxError( s.blk, node,

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRTypeCheckL1Pass.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRTypeCheckL1Pass.py
@@ -50,6 +50,9 @@ class BehavioralRTLIRTypeCheckVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
     s.type_expect[ 'SignExt' ] = {
       'value':( rt.Signal, 'extension only applies to signals!' )
     }
+    s.type_expect[ 'Reduce' ] = {
+      'value':( rt.Signal, 'reduce only applies on a signal!' )
+    }
     s.type_expect[ 'SizeCast' ] = {
       'value':( rt.Signal, 'size casting only applies to signals/consts!' )
     }
@@ -209,6 +212,11 @@ class BehavioralRTLIRTypeCheckVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
         '{} is not greater than {}!'.format(new_nbits, old_nbits) )
     node.Type = copy.copy( child_type )
     node.Type.dtype = rdt.Vector( new_nbits )
+
+  def visit_Reduce( s, node ):
+    child_type = node.value.Type
+    node.Type = copy.copy( child_type )
+    node.Type.dtype = rdt.Vector( 1 )
 
   def visit_SizeCast( s, node ):
     nbits = node.nbits

--- a/pymtl3/passes/rtlir/rtype/RTLIRType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRType.py
@@ -558,14 +558,16 @@ def _handle_Interface( i_id, obj ):
         properties[ _id ] = _obj_type
         if isinstance( _obj_type, Array ):
           _add_packed_instances( _id, _obj_type, properties )
-    else:
-      if not inspect.ismethod(_obj):
-        err_msg = \
-"""\
- - Note: {} attribute {} of {} was dropped during conversion to RTLIR because it is
-         not an interface, a port, or a list of them. \
-"""
-        print( err_msg.format( _id, _obj, i_id ) )
+    # TODO: Figure out a way to inform user of dropped attributes without
+    # flooding STDOUT
+    # else:
+      # if not inspect.ismethod(_obj):
+        # err_msg = \
+# """\
+ # - Note: {} attribute {} of {} was dropped during conversion to RTLIR because it is
+         # not an interface, a port, or a list of them. \
+# """
+        # print( err_msg.format( _id, _obj, i_id ) )
   return InterfaceView( obj.__class__.__name__, properties, obj )
 
 def _handle_Component( c_id, obj ):
@@ -579,15 +581,17 @@ def _handle_Component( c_id, obj ):
         properties[ _id ] = _obj_type
         if isinstance( _obj_type, Array ):
           _add_packed_instances( _id, _obj_type, properties )
-    else:
-      if not inspect.ismethod(_obj):
-        err_msg = \
-"""\
- - Note: {} attribute {} of {} was dropped during conversion to RTLIR because it is
-         not a port, a, wire, an interface, a component, a constantor, or a
-         list of them. \
-"""
-        print( err_msg.format( _id, _obj, c_id ) )
+    # TODO: Figure out a way to inform user of dropped attributes without
+    # flooding STDOUT
+    # else:
+      # if not inspect.ismethod(_obj):
+        # err_msg = \
+# """\
+ # - Note: {} attribute {} of {} was dropped during conversion to RTLIR because it is
+         # not a port, a, wire, an interface, a component, a constantor, or a
+         # list of them. \
+# """
+        # print( err_msg.format( _id, _obj, c_id ) )
   return Component( obj, properties )
 
 def _is_of_type( obj, Type ):

--- a/pymtl3/passes/rtlir/rtype/RTLIRType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRType.py
@@ -559,12 +559,13 @@ def _handle_Interface( i_id, obj ):
         if isinstance( _obj_type, Array ):
           _add_packed_instances( _id, _obj_type, properties )
     else:
-      err_msg = \
+      if not inspect.ismethod(_obj):
+        err_msg = \
 """\
  - Note: {} attribute {} of {} was dropped during conversion to RTLIR because it is
          not an interface, a port, or a list of them. \
 """
-      print( err_msg.format( _id, _obj, i_id ) )
+        print( err_msg.format( _id, _obj, i_id ) )
   return InterfaceView( obj.__class__.__name__, properties, obj )
 
 def _handle_Component( c_id, obj ):
@@ -579,13 +580,14 @@ def _handle_Component( c_id, obj ):
         if isinstance( _obj_type, Array ):
           _add_packed_instances( _id, _obj_type, properties )
     else:
-      err_msg = \
+      if not inspect.ismethod(_obj):
+        err_msg = \
 """\
  - Note: {} attribute {} of {} was dropped during conversion to RTLIR because it is
          not a port, a, wire, an interface, a component, a constantor, or a
          list of them. \
 """
-      print( err_msg.format( _id, _obj, c_id ) )
+        print( err_msg.format( _id, _obj, c_id ) )
   return Component( obj, properties )
 
 def _is_of_type( obj, Type ):

--- a/pymtl3/passes/sverilog/import_/ImportPass.py
+++ b/pymtl3/passes/sverilog/import_/ImportPass.py
@@ -890,7 +890,7 @@ m->{name}{sub} = {deference}model->{name}{sub};
       return ret
 
   def gen_constraints( s, packed_ports ):
-    ret = []
+    ret = ["U( seq_upblk ) > WR( s.mangled__reset ),"]
     for py_name, rtype in packed_ports:
       if s._get_direction( rtype ) == 'OutPort':
         if isinstance( rtype, rt.Array ):

--- a/pymtl3/passes/sverilog/import_/ImportPass.py
+++ b/pymtl3/passes/sverilog/import_/ImportPass.py
@@ -890,7 +890,7 @@ m->{name}{sub} = {deference}model->{name}{sub};
       return ret
 
   def gen_constraints( s, packed_ports ):
-    ret = ["U( seq_upblk ) > WR( s.mangled__reset ),"]
+    ret = []
     for py_name, rtype in packed_ports:
       if s._get_direction( rtype ) == 'OutPort':
         if isinstance( rtype, rt.Array ):

--- a/pymtl3/passes/sverilog/import_/verilator_wrapper.c.template
+++ b/pymtl3/passes/sverilog/import_/verilator_wrapper.c.template
@@ -120,7 +120,7 @@ void destroy_model( V{component_name}_t * m ) {{
 
   #if DUMP_VCD
   if ( m->_vcd_en ) {{
-    printf("DESTROYING %d\n", m->trace_time);
+    // printf("DESTROYING %d\n", m->trace_time);
     VerilatedVcdC * tfp = (VerilatedVcdC *) m->tfp;
     tfp->close();
   }}
@@ -153,12 +153,13 @@ void eval( V{component_name}_t * m ) {{
       g_main_time += 50;
     }}
     m->prev_clk = model->clk;
-  }}
 
-  // dump current signal values
-  VerilatedVcdC * tfp = (VerilatedVcdC *) m->tfp;
-  tfp->dump( m->trace_time );
-  tfp->flush();
+    // dump current signal values
+    VerilatedVcdC * tfp = (VerilatedVcdC *) m->tfp;
+    tfp->dump( m->trace_time );
+    tfp->flush();
+
+  }}
   #endif
 
 }}

--- a/pymtl3/passes/sverilog/import_/verilator_wrapper.py.template
+++ b/pymtl3/passes/sverilog/import_/verilator_wrapper.py.template
@@ -143,9 +143,9 @@ class {component_name}( Component ):
     @s.update_on_edge
     def seq_upblk():
       # Advance the clock
-      _ffi_m.clk[0] = 1
-      _ffi_inst.eval( _ffi_m )
       _ffi_m.clk[0] = 0
+      _ffi_inst.eval( _ffi_m )
+      _ffi_m.clk[0] = 1
       _ffi_inst.eval( _ffi_m )
       set_output()
 

--- a/pymtl3/passes/sverilog/import_/verilator_wrapper.py.template
+++ b/pymtl3/passes/sverilog/import_/verilator_wrapper.py.template
@@ -142,6 +142,7 @@ class {component_name}( Component ):
 
     @s.update_on_edge
     def seq_upblk():
+      _ffi_m.reset[0] = int(s.mangled__reset)
       # Advance the clock
       _ffi_m.clk[0] = 0
       _ffi_inst.eval( _ffi_m )

--- a/pymtl3/passes/sverilog/test/TranslationImport_closed_loop_dircted_test.py
+++ b/pymtl3/passes/sverilog/test/TranslationImport_closed_loop_dircted_test.py
@@ -40,6 +40,7 @@ def run_sim( _th ):
 
     print()
     cycle = 0
+    th.sim_reset()
     while not th.done() and cycle < 1000:
       th.tick()
       print(th.line_trace())

--- a/pymtl3/passes/sverilog/translation/behavioral/SVBehavioralTranslatorL1.py
+++ b/pymtl3/passes/sverilog/translation/behavioral/SVBehavioralTranslatorL1.py
@@ -316,7 +316,7 @@ class BehavioralRTLIRToSVVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
           "unrecognized operator {} for reduce method!".format(op_t) )
     value = s.visit( node.value )
     op = reduce_ops[ op_t ]
-    return "({op}{value})".format( **locals() )
+    return "({op} {value})".format( **locals() )
 
   #-----------------------------------------------------------------------
   # visit_SizeCast

--- a/pymtl3/passes/yosys/test/TranslationImport_closed_loop_dircted_test.py
+++ b/pymtl3/passes/yosys/test/TranslationImport_closed_loop_dircted_test.py
@@ -43,6 +43,7 @@ def run_sim( _th ):
 
     print()
     cycle = 0
+    th.sim_reset()
     while not th.done() and cycle < 1000:
       th.tick()
       print(th.line_trace())

--- a/pymtl3/stdlib/rtl/enrdy_queues.py
+++ b/pymtl3/stdlib/rtl/enrdy_queues.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, division, print_function
 
 from pymtl3 import *
 from pymtl3.stdlib.ifcs.SendRecvIfc import RecvIfcRTL, SendIfcRTL
-from pymtl3.stdlib.rtl import Mux, Reg, RegEn
+from pymtl3.stdlib.rtl import Mux, Reg, RegEn, RegRst
 
 
 class PipeQueue1RTL( Component ):
@@ -44,7 +44,7 @@ class BypassQueue1RTL( Component ):
 
     s.buffer  = RegEn( Type )( in_ = s.enq.msg )
 
-    s.full = Reg( Bits1 )
+    s.full = RegRst( Bits1, reset_value = Bits1(0) )
 
     s.byp_mux = Mux( Type, 2 )(
       out = s.deq.msg,

--- a/pymtl3/stdlib/rtl/enrdy_queues_test.py
+++ b/pymtl3/stdlib/rtl/enrdy_queues_test.py
@@ -45,6 +45,7 @@ def run_sim( model ):
 
   print()
   cycle = 0
+  model.sim_reset()
   while not model.done() and cycle < 1000:
     model.tick()
     print( "{:3}: {}".format( cycle, model.line_trace() ) )


### PR DESCRIPTION
1. `sim_reset` now asserts reset signal for two cycles to ensure every component gets reset correctly.
2. Bypass queue now uses `RegRst` for `full` signal so the queue is always ready after reset.
3. `dump_vcd` tag will now generates clean VCD from Verilator.
4. Tests and translation support for `reduce_and/or/xor`.