### PR TITLE
Fix reset-related issues

### DIFF
--- a/pymtl3/dsl/Component.py
+++ b/pymtl3/dsl/Component.py
@@ -428,7 +428,8 @@ class Component( ComponentLevel7 ):
     s._check_called_at_elaborate_top( "sim_reset" )
 
     s.reset = Bits1( 1 )
-    s.tick() # This tick propagates the reset signal
+    s.tick() # Tick twice to propagate the reset signal
+    s.tick()
     s.reset = Bits1( 0 )
 
   def check( s ):

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRTypeCheckL1Pass.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRTypeCheckL1Pass.py
@@ -50,6 +50,9 @@ class BehavioralRTLIRTypeCheckVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
     s.type_expect[ 'SignExt' ] = {
       'value':( rt.Signal, 'extension only applies to signals!' )
     }
+    s.type_expect[ 'Reduce' ] = {
+      'value':( rt.Signal, 'reduce only applies on a signal!' )
+    }
     s.type_expect[ 'SizeCast' ] = {
       'value':( rt.Signal, 'size casting only applies to signals/consts!' )
     }
@@ -209,6 +212,11 @@ class BehavioralRTLIRTypeCheckVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
         '{} is not greater than {}!'.format(new_nbits, old_nbits) )
     node.Type = copy.copy( child_type )
     node.Type.dtype = rdt.Vector( new_nbits )
+
+  def visit_Reduce( s, node ):
+    child_type = node.value.Type
+    node.Type = copy.copy( child_type )
+    node.Type.dtype = rdt.Vector( 1 )
 
   def visit_SizeCast( s, node ):
     nbits = node.nbits

--- a/pymtl3/passes/rtlir/rtype/RTLIRType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRType.py
@@ -558,13 +558,15 @@ def _handle_Interface( i_id, obj ):
         properties[ _id ] = _obj_type
         if isinstance( _obj_type, Array ):
           _add_packed_instances( _id, _obj_type, properties )
-    else:
-      err_msg = \
-"""\
- - Note: {} attribute {} of {} was dropped during conversion to RTLIR because it is
-         not an interface, a port, or a list of them. \
-"""
-      print( err_msg.format( _id, _obj, i_id ) )
+    # TODO: Figure out a way to inform user of dropped attributes without
+    # flooding STDOUT
+    # else:
+      # err_msg = \
+# """\
+ # - Note: {} attribute {} of {} was dropped during conversion to RTLIR because it is
+         # not an interface, a port, or a list of them. \
+# """
+      # print( err_msg.format( _id, _obj, i_id ) )
   return InterfaceView( obj.__class__.__name__, properties, obj )
 
 def _handle_Component( c_id, obj ):
@@ -578,14 +580,16 @@ def _handle_Component( c_id, obj ):
         properties[ _id ] = _obj_type
         if isinstance( _obj_type, Array ):
           _add_packed_instances( _id, _obj_type, properties )
-    else:
-      err_msg = \
-"""\
- - Note: {} attribute {} of {} was dropped during conversion to RTLIR because it is
-         not a port, a, wire, an interface, a component, a constantor, or a
-         list of them. \
-"""
-      print( err_msg.format( _id, _obj, c_id ) )
+    # TODO: Figure out a way to inform user of dropped attributes without
+    # flooding STDOUT
+    # else:
+      # err_msg = \
+# """\
+ # - Note: {} attribute {} of {} was dropped during conversion to RTLIR because it is
+         # not a port, a, wire, an interface, a component, a constantor, or a
+         # list of them. \
+# """
+      # print( err_msg.format( _id, _obj, c_id ) )
   return Component( obj, properties )
 
 def _is_of_type( obj, Type ):

--- a/pymtl3/passes/sverilog/import_/ImportPass.py
+++ b/pymtl3/passes/sverilog/import_/ImportPass.py
@@ -206,12 +206,15 @@ Fail to verilate model {} in file {}
     port_inits = '\n'.join( port_inits )
 
     # Fill in the C wrapper template
-    if not cached:
-      with open( template_name, 'r' ) as template:
-        with open( wrapper_name, 'w' ) as output:
-          c_wrapper = template.read()
-          c_wrapper = c_wrapper.format( **locals() )
-          output.write( c_wrapper )
+    # Since we may run import with or without dump_vcd enabled, we need
+    # to dump C wrapper regardless of whether the verilated model is
+    # cached or not.
+    # if not cached:
+    with open( template_name, 'r' ) as template:
+      with open( wrapper_name, 'w' ) as output:
+        c_wrapper = template.read()
+        c_wrapper = c_wrapper.format( **locals() )
+        output.write( c_wrapper )
 
     return wrapper_name, port_cdefs
 
@@ -223,7 +226,13 @@ Fail to verilate model {} in file {}
     """Return the name of compiled shared lib."""
     lib_name = 'lib{}_v.so'.format( full_name )
 
-    if not cached:
+    # Since we may run import with or without dump_vcd enabled, we need
+    # to compile C wrapper regardless of whether the verilated model is
+    # cached or not.
+    # TODO: A better caching strategy is to attch some metadata
+    # to the C wrapper so that we know the wrapper was generated with or
+    # without dump_vcd enabled.
+    if dump_vcd or not cached:
       # Find out the include directory of Verilator
       # First look at $PYMTL_VERILATOR_INCLUDE_DIR environment variable
       verilator_include_dir = os.environ.get( 'PYMTL_VERILATOR_INCLUDE_DIR' )
@@ -831,7 +840,7 @@ m->{name}{sub} = {deference}model->{name}{sub};
     ret = []
     for py_name, rtype in packed_ports:
       p_n_dim, p_rtype = s._get_rtype( rtype )
-      if s._get_direction( p_rtype ) == 'InPort':
+      if s._get_direction( p_rtype ) == 'InPort' and py_name != 'clk':
         dtype = p_rtype.get_dtype()
         v_name = s._verilator_name( py_name )
         lhs = "_ffi_m."+v_name

--- a/pymtl3/passes/sverilog/import_/ImportPass.py
+++ b/pymtl3/passes/sverilog/import_/ImportPass.py
@@ -206,10 +206,12 @@ Fail to verilate model {} in file {}
     port_inits = '\n'.join( port_inits )
 
     # Fill in the C wrapper template
+
     # Since we may run import with or without dump_vcd enabled, we need
     # to dump C wrapper regardless of whether the verilated model is
     # cached or not.
-    # if not cached:
+    # TODO: we can avoid dumping C wrapper if we attach some metadata to
+    # tell if the wrapper was generated with or without `dump_vcd` enabled.
     with open( template_name, 'r' ) as template:
       with open( wrapper_name, 'w' ) as output:
         c_wrapper = template.read()
@@ -229,7 +231,7 @@ Fail to verilate model {} in file {}
     # Since we may run import with or without dump_vcd enabled, we need
     # to compile C wrapper regardless of whether the verilated model is
     # cached or not.
-    # TODO: A better caching strategy is to attch some metadata
+    # TODO: A better caching strategy is to attach some metadata
     # to the C wrapper so that we know the wrapper was generated with or
     # without dump_vcd enabled.
     if dump_vcd or not cached:
@@ -838,6 +840,10 @@ m->{name}{sub} = {deference}model->{name}{sub};
 
   def gen_comb_input( s, packed_ports ):
     ret = []
+    # Read all input ports ( except for 'clk' ) from component ports into
+    # the verilated model. We do NOT want `clk` signal to be read into
+    # the verilated model because only the sequential update block of
+    # the imported component should manipulate it.
     for py_name, rtype in packed_ports:
       p_n_dim, p_rtype = s._get_rtype( rtype )
       if s._get_direction( p_rtype ) == 'InPort' and py_name != 'clk':

--- a/pymtl3/passes/sverilog/import_/verilator_wrapper.c.template
+++ b/pymtl3/passes/sverilog/import_/verilator_wrapper.c.template
@@ -120,7 +120,7 @@ void destroy_model( V{component_name}_t * m ) {{
 
   #if DUMP_VCD
   if ( m->_vcd_en ) {{
-    printf("DESTROYING %d\n", m->trace_time);
+    // printf("DESTROYING %d\n", m->trace_time);
     VerilatedVcdC * tfp = (VerilatedVcdC *) m->tfp;
     tfp->close();
   }}
@@ -153,13 +153,13 @@ void eval( V{component_name}_t * m ) {{
       g_main_time += 50;
     }}
     m->prev_clk = model->clk;
-  }}
 
-  // dump current signal values
-  VerilatedVcdC * tfp = (VerilatedVcdC *) m->tfp;
-  tfp->dump( m->trace_time );
-  tfp->flush();
+    // dump current signal values
+    VerilatedVcdC * tfp = (VerilatedVcdC *) m->tfp;
+    tfp->dump( m->trace_time );
+    tfp->flush();
+
+  }}
   #endif
 
 }}
-

--- a/pymtl3/passes/sverilog/import_/verilator_wrapper.py.template
+++ b/pymtl3/passes/sverilog/import_/verilator_wrapper.py.template
@@ -142,10 +142,11 @@ class {component_name}( Component ):
 
     @s.update_on_edge
     def seq_upblk():
+      _ffi_m.reset[0] = int(s.mangled__reset)
       # Advance the clock
-      _ffi_m.clk[0] = 1
-      _ffi_inst.eval( _ffi_m )
       _ffi_m.clk[0] = 0
+      _ffi_inst.eval( _ffi_m )
+      _ffi_m.clk[0] = 1
       _ffi_inst.eval( _ffi_m )
       set_output()
 

--- a/pymtl3/passes/sverilog/import_/verilator_wrapper.py.template
+++ b/pymtl3/passes/sverilog/import_/verilator_wrapper.py.template
@@ -142,7 +142,6 @@ class {component_name}( Component ):
 
     @s.update_on_edge
     def seq_upblk():
-      _ffi_m.reset[0] = int(s.mangled__reset)
       # Advance the clock
       _ffi_m.clk[0] = 0
       _ffi_inst.eval( _ffi_m )

--- a/pymtl3/passes/sverilog/test/TranslationImport_adhoc_test.py
+++ b/pymtl3/passes/sverilog/test/TranslationImport_adhoc_test.py
@@ -8,8 +8,7 @@
 from __future__ import absolute_import, division, print_function
 
 from pymtl3.passes.rtlir.util.test_utility import do_test
-from pymtl3.passes.sverilog import TranslationPass
-from pymtl3.passes.sverilog.import_.ImportPass import ImportPass
+from pymtl3.passes.sverilog import ImportPass, TranslationPass
 from pymtl3.stdlib.test import TestVectorSimulator
 
 from ..translation.behavioral.test.SVBehavioralTranslatorL1_test import (
@@ -37,6 +36,7 @@ from ..translation.behavioral.test.SVBehavioralTranslatorL2_test import (
     test_if_exp_for,
     test_if_exp_unary_op,
     test_nested_if,
+    test_reduce,
     test_tmpvar,
 )
 from ..translation.behavioral.test.SVBehavioralTranslatorL3_test import (

--- a/pymtl3/passes/sverilog/translation/behavioral/SVBehavioralTranslatorL1.py
+++ b/pymtl3/passes/sverilog/translation/behavioral/SVBehavioralTranslatorL1.py
@@ -316,7 +316,7 @@ class BehavioralRTLIRToSVVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
           "unrecognized operator {} for reduce method!".format(op_t) )
     value = s.visit( node.value )
     op = reduce_ops[ op_t ]
-    return "({op}{value})".format( **locals() )
+    return "( {op} {value} )".format( **locals() )
 
   #-----------------------------------------------------------------------
   # visit_SizeCast

--- a/pymtl3/passes/yosys/test/TranslationImport_adhoc_test.py
+++ b/pymtl3/passes/yosys/test/TranslationImport_adhoc_test.py
@@ -45,6 +45,7 @@ from pymtl3.passes.sverilog.test.TranslationImport_adhoc_test import (
     test_port_part_selection,
     test_port_wire,
     test_port_wire_array_index,
+    test_reduce,
     test_seq_assign,
     test_sext,
     test_struct,

--- a/pymtl3/passes/yosys/translation/behavioral/test/YosysBehavioralTranslatorL2_test.py
+++ b/pymtl3/passes/yosys/translation/behavioral/test/YosysBehavioralTranslatorL2_test.py
@@ -24,6 +24,7 @@ from pymtl3.passes.sverilog.translation.behavioral.test.SVBehavioralTranslatorL2
     test_if_exp_for,
     test_if_exp_unary_op,
     test_nested_if,
+    test_reduce,
     test_tmpvar,
 )
 

--- a/pymtl3/stdlib/rtl/enrdy_queues.py
+++ b/pymtl3/stdlib/rtl/enrdy_queues.py
@@ -12,7 +12,7 @@ from __future__ import absolute_import, division, print_function
 
 from pymtl3 import *
 from pymtl3.stdlib.ifcs.SendRecvIfc import RecvIfcRTL, SendIfcRTL
-from pymtl3.stdlib.rtl import Mux, Reg, RegEn
+from pymtl3.stdlib.rtl import Mux, Reg, RegEn, RegRst
 
 
 class PipeQueue1RTL( Component ):
@@ -44,7 +44,7 @@ class BypassQueue1RTL( Component ):
 
     s.buffer  = RegEn( Type )( in_ = s.enq.msg )
 
-    s.full = Reg( Bits1 )
+    s.full = RegRst( Bits1, reset_value = Bits1(0) )
 
     s.byp_mux = Mux( Type, 2 )(
       out = s.deq.msg,

--- a/pymtl3/stdlib/rtl/enrdy_queues.py
+++ b/pymtl3/stdlib/rtl/enrdy_queues.py
@@ -44,7 +44,7 @@ class BypassQueue1RTL( Component ):
 
     s.buffer  = RegEn( Type )( in_ = s.enq.msg )
 
-    s.full = RegRst( Bits1, reset_value = Bits1(0) )
+    s.full = RegRst( Bits1, reset_value = 0 )
 
     s.byp_mux = Mux( Type, 2 )(
       out = s.deq.msg,


### PR DESCRIPTION
1. The sequential block in import wrapper now reads in `reset` value
2. Use `RegRst` for `full` signal of bypass queue
3. Add translation support and tests for `reduce_and/or/xor`