### PR TITLE
[WIP] Prep for release on PyPI

### DIFF
--- a/README.md
+++ b/README.md
@@ -8,8 +8,30 @@ PyMTL 3 (Mamba) is the latest version of PyMTL, an open-source
 Python-based hardware generation, simulation, and verification framework with
 multi-level hardware modeling support. The original PyMTL was introduced
 at MICRO-47 in December, 2014. Please note that PyMTL 3 is currently
-**alpha** software that is under active development and documentation is
+**beta** software that is under active development and documentation is
 currently quite sparse.
+
+In June 2019, [Keeping Computer Hardware Fast and Furious: "PyMTL is a fantastic example of what we need to jump-start the open-source hardware ecosystem…It’s a key missing link."](https://research.cornell.edu/news-features/keeping-computer-hardware-fast-and-furious "Link to the article") was featured on Cornell Research.
+
+Tutorial
+--------
+We recently hold a very high quality PyMTL 3 tutorial at FCRC 2019 with 40+
+researchers attended.
+The code for tutorial is here https://github.com/cornell-brg/pymtl-tutorial-isca2019.
+The website with all slides and link to VM is here https://www.csl.cornell.edu/pymtl2019/.
+This 32-bit CentOS 7 virtualbox image includes pymtl3 and all the
+open-source EDA toolchains required to complete the tutorial. 
+
+
+Related publications
+--------------------------------------------------------------------------
+
+- Shunning Jiang, Christopher Torng, and Christopher Batten. _"An Open-Source Python-Based Hardware Generation, Simulation, and Verification Framework."_ First Workshop on Open-Source EDA Technology (WOSET'18) held in conjunction with ICCAD-37, Nov. 2018.
+
+- Shunning Jiang, Berkin Ilbeyi, and Christopher Batten. _"Mamba: Closing the Performance Gap in Productive Hardware Development Frameworks."_ 55th ACM/IEEE Design Automation Conf. (DAC-55), June 2018. 
+
+- Derek Lockhart, Gary Zibrat, and Christopher Batten. _"PyMTL: A Unified Framework for Vertically Integrated Computer Architecture Research."_ 47th ACM/IEEE Int'l Symp. on Microarchitecture (MICRO-47), Dec. 2014.
+
 
 License
 --------------------------------------------------------------------------

--- a/pymtl3/__init__.py
+++ b/pymtl3/__init__.py
@@ -19,6 +19,8 @@ from .dsl.Connectable import (
 from .dsl.ConstraintTypes import RD, WR, M, U
 from .passes.PassGroups import DynamicSim, SimpleSim, SimulationPass
 
+__version__ = "0.1.0"
+
 __all__ = [
   'U','M','RD','WR',
   'Wire', 'InPort', 'OutPort', 'Interface', 'CallerPort', 'CalleePort',

--- a/setup.py
+++ b/setup.py
@@ -17,20 +17,13 @@ from setuptools import find_packages, setup
 #-------------------------------------------------------------------------
 # get_version
 #-------------------------------------------------------------------------
-# We use the output of git describe to create a version number. Note that
-# this will fail without a release tag because git describe will fail.
-# Eventually when we actually have tarball releases we will need to
-# also support using a separate RELEASE-VERSION file, but for now we
-# always install using pip git+https from GitHub so this shoud work fine.
 
 def get_version():
-  cmd = "git describe --dirty"
-  try:
-    result = check_output( cmd.split(),  ).strip()
-    if not isinstance(result, str):
-      result = result.decode()
-  except:
-    result = "?"
+  result = "?"
+  with open("pymtl3/__init__.py") as f:
+    for line in f:
+      if line.startswith("__version__"):
+        _, result, _ = line.split('"')
   return result
 
 #-------------------------------------------------------------------------
@@ -68,11 +61,12 @@ setup(
 
   # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
   classifiers=[
-    'Development Status :: 3 - Alpha',
+    'Development Status :: 4 - Beta',
     'License :: OSI Approved :: BSD License',
     'Programming Language :: Python :: 2.7',
     'Operating System :: MacOS :: MacOS X',
     'Operating System :: POSIX :: Linux',
+    'Topic :: Scientific/Engineering :: Electronic Design Automation (EDA)',
   ],
 
   packages = find_packages(

--- a/setup.py
+++ b/setup.py
@@ -52,6 +52,7 @@ setup(
   version          = get_version(),
   description      = 'PyMTL 3 (Mamba): Python-based hardware generation, simulation, and verification framework',
   long_description = get_long_description(),
+  long_description_content_type="text/markdown",
   url              = 'https://github.com/cornell-brg/pymtl3',
   author           = 'Batten Research Group',
   author_email     = 'brg-pymtl@csl.cornell.edu',
@@ -62,8 +63,10 @@ setup(
 
   license='BSD',
 
-  # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
+  # Pip will block installation on unsupported versions of Python
+  python_requires=">=2.7",
 
+  # See https://pypi.python.org/pypi?%3Aaction=list_classifiers
   classifiers=[
     'Development Status :: 3 - Alpha',
     'License :: OSI Approved :: BSD License',


### PR DESCRIPTION
```
pip install --user --upgrade setuptools wheel twine
rm -r ./dist/
python setup.py sdist bdist_wheel
# Note: check version number first; upload to testpypi to confirm install works
twine upload --skip-existing dist/*
```

See [this page](https://packaging.python.org/tutorials/packaging-projects/#uploading-the-distribution-archives) for details; you'll need to create an account on PyPI and I'd recommend running against testpypi first.

Finally, we'll need to change over to explicitly writing out the version number, so that installation from the source distribution (which is not a git repo) from PyPI still works.  I'd suggest copying the implementation [that I use in hypothesis-jsonschema](https://github.com/Zac-HD/hypothesis-jsonschema/blob/master/setup.py).