### PR TITLE
Add vcd cycle time import config

### DIFF
--- a/pymtl3/passes/sverilog/import_/ImportConfigs.py
+++ b/pymtl3/passes/sverilog/import_/ImportConfigs.py
@@ -66,6 +66,10 @@ class ImportConfigs( BasePassConfigs ):
                   all(c.isdigit() for c in v[:-2]),
         "expects a timescale string")
     s.set_checker(
+        "vl_trace_cycle_time",
+        lambda v: isinstance(v, int) and (v % 2) == 0,
+        "expects an integer `n` such that `n`*`vl_trace_timescale` is the cycle time")
+    s.set_checker(
         "vl_mk_dir",
         lambda v: isinstance(v, str),
         "expects a path to directory")
@@ -179,6 +183,11 @@ class ImportConfigs( BasePassConfigs ):
 
       # Passed to verilator tracing function
       "vl_trace_timescale" : "10ps",
+
+      # `vl_trace_cycle_time`*`vl_trace_timescale` is the cycle time of the
+      # PyMTL clock that appears in the generated VCD
+      # With the default options, the frequency of PyMTL clock is 1GHz
+      "vl_trace_cycle_time" : 100,
 
       # C-compilation options
       # These options will be passed to the C compiler to create a shared lib.
@@ -334,6 +343,9 @@ class ImportConfigs( BasePassConfigs ):
 
   def get_vl_trace_timescale( s ):
     return s.get_option( "vl_trace_timescale" )
+
+  def get_vl_trace_half_cycle_time( s ):
+    return s.get_option( "vl_trace_cycle_time" ) // 2
 
   def get_module_to_parametrize( s ):
     return s.wrapped_module

--- a/pymtl3/passes/sverilog/import_/ImportPass.py
+++ b/pymtl3/passes/sverilog/import_/ImportPass.py
@@ -210,6 +210,7 @@ class ImportPass( BasePass ):
     component_name = config.get_top_module()
     dump_vcd = int(config.is_vl_trace_enabled())
     vcd_timescale = config.get_vl_trace_timescale()
+    half_cycle_time = config.get_vl_trace_half_cycle_time()
     wrapper_name = config.get_c_wrapper_path()
     config.vprint("\n=====Generate C wrapper=====")
 

--- a/pymtl3/passes/sverilog/import_/verilator_wrapper.c.template
+++ b/pymtl3/passes/sverilog/import_/verilator_wrapper.c.template
@@ -150,8 +150,8 @@ void eval( V{component_name}_t * m ) {{
 
     // update simulation time only on clock toggle
     if (m->prev_clk != model->clk) {{
-      m->trace_time += 50;
-      g_main_time += 50;
+      m->trace_time += {half_cycle_time};
+      g_main_time += {half_cycle_time};
     }}
     m->prev_clk = model->clk;
 


### PR DESCRIPTION
This PR introduces a new import pass configuration option `vl_trace_cycle_time`. This option, together with the option `vl_timescale`, provides fine grain control over the possible clock frequencies in the VCD dump.