### PR TITLE
Fix byte/str concatenation issue

### DIFF
--- a/pymtl3/passes/sverilog/import_/ImportConfigs.py
+++ b/pymtl3/passes/sverilog/import_/ImportConfigs.py
@@ -406,6 +406,7 @@ class ImportConfigs( BasePassConfigs ):
       try:
         vl_include_dir = \
             subprocess.check_output(get_dir_cmd, stderr = subprocess.STDOUT).strip()
+        vl_include_dir = vl_include_dir.decode('ascii')
       except OSError as e:
         vl_include_dir_msg = \
 """\
@@ -415,7 +416,6 @@ $PYMTL_VERILATOR_INCLUDE_DIR is set or `pkg-config` has been configured properly
         raise OSError(fill(vl_include_dir_msg)) from e
 
     # Add verilator include path
-    vl_include_dir = vl_include_dir.decode('ascii')
     s.vl_include_dir = vl_include_dir
     includes += [vl_include_dir, vl_include_dir + "/vltstd"]
 

--- a/pymtl3/passes/sverilog/import_/ImportConfigs.py
+++ b/pymtl3/passes/sverilog/import_/ImportConfigs.py
@@ -415,6 +415,7 @@ $PYMTL_VERILATOR_INCLUDE_DIR is set or `pkg-config` has been configured properly
         raise OSError(fill(vl_include_dir_msg)) from e
 
     # Add verilator include path
+    vl_include_dir = vl_include_dir.decode('ascii')
     s.vl_include_dir = vl_include_dir
     includes += [vl_include_dir, vl_include_dir + "/vltstd"]
 


### PR DESCRIPTION
In Python3 subprocess.check_output returns bytes instead of string. An explicit
decode is necessary.

Fix issue #91 