### PR TITLE
Use short names for translation

### DIFF
--- a/conftest.py
+++ b/conftest.py
@@ -1,4 +1,3 @@
-
 import pytest
 
 

--- a/pymtl3/__init__.py
+++ b/pymtl3/__init__.py
@@ -1,4 +1,3 @@
-
 from .datatypes import *
 from .datatypes import _bitwidths
 from .dsl.Component import Component

--- a/pymtl3/datatypes/__init__.py
+++ b/pymtl3/datatypes/__init__.py
@@ -1,4 +1,3 @@
-
 from .bits_import import *
 from .bits_import import _bitwidths
 from .BitStruct import BitStruct, mk_bit_struct

--- a/pymtl3/passes/PassGroups.py
+++ b/pymtl3/passes/PassGroups.py
@@ -1,4 +1,3 @@
-
 from pymtl3.dsl import Component
 
 from .CLLineTracePass import CLLineTracePass

--- a/pymtl3/passes/__init__.py
+++ b/pymtl3/passes/__init__.py
@@ -1,2 +1,1 @@
-
 from .PassGroups import *

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRGenL1Pass.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRGenL1Pass.py
@@ -66,9 +66,9 @@ class BehavioralRTLIRGeneratorL1( ast.NodeVisitor ):
     return ret
 
   def get_call_obj( s, node ):
-    if getattr(node, "starargs", False):
+    if hasattr(node, "starargs") and node.starargs:
       raise PyMTLSyntaxError( s.blk, node, 'star argument is not supported!')
-    if getattr(node, "kwargs", False):
+    if hasattr(node, "kwargs") and node.kwargs:
       raise PyMTLSyntaxError( s.blk, node,
         'double-star argument is not supported!')
     if node.keywords:

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRTypeCheckL1Pass.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRTypeCheckL1Pass.py
@@ -246,7 +246,7 @@ class BehavioralRTLIRTypeCheckVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
     node.Type = node.value.Type.get_property( node.attr )
 
   def visit_Index( s, node ):
-    idx = getattr( node.idx, '_value', None )
+    idx = None if not hasattr(node.idx, "_value") else node.idx._value
     if isinstance( node.value.Type, rt.Array ):
       if idx is not None and not (0 <= idx < node.value.Type.get_dim_sizes()[0]):
         raise PyMTLTypeError( s.blk, node.ast, 'array index out of range!' )
@@ -280,8 +280,8 @@ class BehavioralRTLIRTypeCheckVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
         'cannot perform index on {}!'.format(node.value.Type))
 
   def visit_Slice( s, node ):
-    lower_val = getattr( node.lower, '_value', None )
-    upper_val  = getattr( node.upper, '_value', None )
+    lower_val = None if not hasattr(node.lower, "_value") else node.lower._value
+    upper_val = None if not hasattr(node.upper, "_value") else node.upper._value
     dtype = node.value.Type.get_dtype()
 
     if not isinstance( dtype, rdt.Vector ):

--- a/pymtl3/passes/rtlir/rtype/RTLIRType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRType.py
@@ -310,11 +310,11 @@ class Component( BaseRTLIRType ):
     # _dsl.args: all unnamed arguments supplied to construct()
     # _dsl.kwargs: all named arguments supplied to construct()
     try:
-      argspec = inspect.getfullargspec( getattr( obj, 'construct' ) )
+      argspec = inspect.getfullargspec( obj.construct )
       assert not argspec.varkw, "keyword args are not allowed for construct!"
       assert not argspec.kwonlyargs, "keyword args are not allowed for construct!"
     except AttributeError:
-      argspec = inspect.getargspec( getattr( obj, 'construct' ) )
+      argspec = inspect.getargspec( obj.construct )
       assert not argspec.keywords, "keyword args are not allowed for construct!"
     assert not argspec.varargs, "varargs are not allowed for construct!"
     arg_names = argspec.args[1:]

--- a/pymtl3/passes/rtlir/util/utility.py
+++ b/pymtl3/passes/rtlir/util/utility.py
@@ -21,3 +21,18 @@ def collect_objs( m, Type ):
       if _is_of_type( obj, Type ):
         ret.append( ( name, obj ) )
   return ret
+
+def get_component_full_name( c_rtype ):
+
+  def get_string( obj ):
+    """Return the string that identifies `obj`"""
+    if isinstance(obj, type): return obj.__name__
+    return str( obj )
+
+  comp_name = c_rtype.get_name()
+  comp_params = c_rtype.get_params()
+  assert comp_name
+  for arg_name, arg_value in comp_params:
+    assert arg_name != ''
+    comp_name += '__' + arg_name + '_' + get_string(arg_value)
+  return comp_name

--- a/pymtl3/passes/sverilog/__init__.py
+++ b/pymtl3/passes/sverilog/__init__.py
@@ -1,4 +1,3 @@
-
 from .import_.ImportConfigs import ImportConfigs
 from .import_.ImportPass import ImportPass
 from .translation.TranslationPass import TranslationPass

--- a/pymtl3/passes/sverilog/translation/SVTranslator.py
+++ b/pymtl3/passes/sverilog/translation/SVTranslator.py
@@ -113,11 +113,11 @@ module {module_name}
 {body}
 endmodule
 """
-      component_name = getattr( structural, "component_name" )
-      file_info = getattr( structural, "component_file_info" )
+      component_name = structural.component_name
+      file_info = structural.component_file_info
       ports_template = "{port_decls}{ifc_decls}"
-      full_name = getattr( structural, "component_full_name" )
-      module_name = getattr( structural, "component_unique_name" )
+      full_name = structural.component_full_name
+      module_name = structural.component_unique_name
 
       if full_name != module_name:
         optional_full_name = "\n// Full name: {}".format(full_name)
@@ -145,7 +145,7 @@ endmodule
         connections = '\n' + connections
       body += connections
 
-      s._top_module_name = getattr( structural, "component_name", module_name )
+      s._top_module_name = structural.component_name
       s._top_module_full_name = module_name
       return template.format( **locals() )
 

--- a/pymtl3/passes/sverilog/translation/SVTranslator.py
+++ b/pymtl3/passes/sverilog/translation/SVTranslator.py
@@ -107,6 +107,7 @@ def mk_SVTranslator( _RTLIRTranslator, _STranslator, _BTranslator ):
 """\
 // Definition of PyMTL Component {component_name}
 // {file_info}
+// Full name: {full_name}
 module {module_name}
 (
 {ports});
@@ -116,6 +117,7 @@ endmodule
       component_name = getattr( structural, "component_name" )
       file_info = getattr( structural, "component_file_info" )
       ports_template = "{port_decls}{ifc_decls}"
+      full_name = getattr( structural, "component_full_name" )
       module_name = getattr( structural, "component_unique_name" )
 
       port_decls = s.get_pretty(structural, 'decl_ports', False)

--- a/pymtl3/passes/sverilog/translation/SVTranslator.py
+++ b/pymtl3/passes/sverilog/translation/SVTranslator.py
@@ -106,8 +106,7 @@ def mk_SVTranslator( _RTLIRTranslator, _STranslator, _BTranslator ):
       template =\
 """\
 // Definition of PyMTL Component {component_name}
-// {file_info}
-// Full name: {full_name}
+// {file_info}{optional_full_name}
 module {module_name}
 (
 {ports});
@@ -119,6 +118,11 @@ endmodule
       ports_template = "{port_decls}{ifc_decls}"
       full_name = getattr( structural, "component_full_name" )
       module_name = getattr( structural, "component_unique_name" )
+
+      if full_name != module_name:
+        optional_full_name = "\n// Full name: {}".format(full_name)
+      else:
+        optional_full_name = ""
 
       port_decls = s.get_pretty(structural, 'decl_ports', False)
       ifc_decls = s.get_pretty(structural, 'decl_ifcs', False)

--- a/pymtl3/passes/sverilog/translation/behavioral/__init__.py
+++ b/pymtl3/passes/sverilog/translation/behavioral/__init__.py
@@ -1,2 +1,1 @@
-
 from .SVBehavioralTranslatorL5 import SVBehavioralTranslatorL5 as SVBehavioralTranslator

--- a/pymtl3/passes/sverilog/translation/structural/__init__.py
+++ b/pymtl3/passes/sverilog/translation/structural/__init__.py
@@ -1,2 +1,1 @@
-
 from .SVStructuralTranslatorL4 import SVStructuralTranslatorL4 as SVStructuralTranslator

--- a/pymtl3/passes/sverilog/translation/test/SVTranslator_L2_cases_test.py
+++ b/pymtl3/passes/sverilog/translation/test/SVTranslator_L2_cases_test.py
@@ -1388,3 +1388,35 @@ module A
 endmodule
 """
   do_test( a )
+
+def test_long_component_name( do_test ):
+  class ThisIsABitStructWithSuperLongName( BitStruct ):
+    def __init__( s, bar=1 ):
+      s.bar = Bits32(bar)
+  class A( Component ):
+    def construct( s, T1, T2, T3, T4, T5, T6, T7 ):
+      s.in_ = InPort( Bits32 )
+      s.wire_ = Wire( Bits32 )
+      s.out = OutPort( Bits32 )
+      connect( s.in_, s.wire_ )
+      connect( s.wire_, s.out )
+  args = [ThisIsABitStructWithSuperLongName]*7
+  a = A(*args)
+  a._ref_src = \
+"""
+module A__a840bd1c84c05ea2
+(
+  input logic [0:0] clk,
+  input logic [31:0] in_,
+  output logic [31:0] out,
+  input logic [0:0] reset
+);
+  logic [31:0] wire_;
+
+  assign wire_ = in_;
+  assign out = wire_;
+
+endmodule
+"""
+  a._ref_src_yosys = a._ref_src
+  do_test( a )

--- a/pymtl3/passes/sverilog/util/utility.py
+++ b/pymtl3/passes/sverilog/util/utility.py
@@ -8,6 +8,9 @@
 import os
 import shutil
 import textwrap
+from hashlib import blake2b
+
+from pymtl3.passes.rtlir.util.utility import get_component_full_name
 
 
 def make_indent( src, nindent ):
@@ -17,19 +20,21 @@ def make_indent( src, nindent ):
     src[ idx ] = nindent * indent + s
 
 def get_component_unique_name( c_rtype ):
+  full_name = get_component_full_name( c_rtype )
+
+  if len( full_name ) < 64:
+    return full_name
+
+  comp_name = c_rtype.get_name()
+  param_hash = blake2b(digest_size = 8)
+  param_hash.update(full_name[len(comp_name):].encode('ascii'))
+  param_name = param_hash.hexdigest()
+  return comp_name + "__" + param_name
 
   def get_string( obj ):
     """Return the string that identifies `obj`"""
     if isinstance(obj, type): return obj.__name__
     return str( obj )
-
-  comp_name = c_rtype.get_name()
-  comp_params = c_rtype.get_params()
-  assert comp_name
-  for arg_name, arg_value in comp_params:
-    assert arg_name != ''
-    comp_name += '__' + arg_name + '_' + get_string(arg_value)
-  return comp_name
 
 def wrap( s ):
   col = shutil.get_terminal_size().columns

--- a/pymtl3/passes/translator/RTLIRTranslator.py
+++ b/pymtl3/passes/translator/RTLIRTranslator.py
@@ -48,7 +48,7 @@ def mk_RTLIRTranslator( _StructuralTranslator, _BehavioralTranslator ):
           components.append(
             s.rtlir_tr_component(
               get_component_nspace( s.behavioral, m ),
-              get_component_nspace( s.structural, m )
+              get_component_nspace( s.structural, m ),
           ) )
           translated.append( s.structural.component_unique_name[m] )
         s.gen_hierarchy_metadata( 'decl_type_vector', 'decl_type_vector' )

--- a/pymtl3/passes/translator/__init__.py
+++ b/pymtl3/passes/translator/__init__.py
@@ -1,2 +1,1 @@
-
 from .RTLIRTranslator import RTLIRTranslator

--- a/pymtl3/passes/translator/behavioral/__init__.py
+++ b/pymtl3/passes/translator/behavioral/__init__.py
@@ -1,2 +1,1 @@
-
 from .BehavioralTranslatorL5 import BehavioralTranslatorL5 as BehavioralTranslator

--- a/pymtl3/passes/translator/structural/StructuralTranslatorL1.py
+++ b/pymtl3/passes/translator/structural/StructuralTranslatorL1.py
@@ -13,6 +13,7 @@ from pymtl3.passes.rtlir import StructuralRTLIRSignalExpr as sexp
 from pymtl3.passes.rtlir.structural.StructuralRTLIRGenL1Pass import (
     StructuralRTLIRGenL1Pass,
 )
+from pymtl3.passes.rtlir.util.utility import get_component_full_name
 
 from ..BaseRTLIRTranslator import BaseRTLIRTranslator, TranslatorMetadata
 
@@ -118,6 +119,7 @@ class StructuralTranslatorL1( BaseRTLIRTranslator ):
     # Component metadata
     s.structural.component_name = {}
     s.structural.component_file_info = {}
+    s.structural.component_full_name = {}
     s.structural.component_unique_name = {}
 
     # Declarations
@@ -142,6 +144,7 @@ class StructuralTranslatorL1( BaseRTLIRTranslator ):
     m_rtype = m._pass_structural_rtlir_gen.rtlir_type
     s.structural.component_file_info[m] = m_rtype.get_file_info()
     s.structural.component_name[m] = m_rtype.get_name()
+    s.structural.component_full_name[m] = get_component_full_name(m_rtype)
     s.structural.component_unique_name[m] = \
         s.rtlir_tr_component_unique_name(m_rtype)
 

--- a/pymtl3/passes/translator/structural/__init__.py
+++ b/pymtl3/passes/translator/structural/__init__.py
@@ -1,2 +1,1 @@
-
 from .StructuralTranslatorL4 import StructuralTranslatorL4 as StructuralTranslator

--- a/pymtl3/passes/translator/test/TestRTLIRTranslator.py
+++ b/pymtl3/passes/translator/test/TestRTLIRTranslator.py
@@ -45,9 +45,7 @@ component {component_name}
 endcomponent
 """
     ports_template = "{port_decls}{ifc_decls}"
-    component_name = \
-      "" if not hasattr(structural, "component_unique_name") else \
-      structural.component_unique_name
+    component_name = structural.component_unique_name
 
     port_decls = get_pretty(structural, "decl_ports", False)
     ifc_decls = get_pretty(structural, "decl_ifcs", False)

--- a/pymtl3/passes/translator/test/TestRTLIRTranslator.py
+++ b/pymtl3/passes/translator/test/TestRTLIRTranslator.py
@@ -45,7 +45,9 @@ component {component_name}
 endcomponent
 """
     ports_template = "{port_decls}{ifc_decls}"
-    component_name = getattr(structural, "component_unique_name", "")
+    component_name = \
+      "" if not hasattr(structural, "component_unique_name") else \
+      structural.component_unique_name
 
     port_decls = get_pretty(structural, "decl_ports", False)
     ifc_decls = get_pretty(structural, "decl_ifcs", False)

--- a/pymtl3/passes/yosys/__init__.py
+++ b/pymtl3/passes/yosys/__init__.py
@@ -1,4 +1,3 @@
-
 from pymtl3.passes.sverilog import ImportConfigs
 
 from .import_.ImportPass import ImportPass

--- a/pymtl3/passes/yosys/translation/YosysTranslator.py
+++ b/pymtl3/passes/yosys/translation/YosysTranslator.py
@@ -46,28 +46,28 @@ module {module_name}
 {body}
 endmodule
 """
-    component_name = getattr( structural, "component_name" )
-    file_info = getattr( structural, "component_file_info" )
+    component_name = structural.component_name
+    file_info = structural.component_file_info
     ports_template = "{port_decls}{ifc_decls}"
-    full_name = getattr( structural, "component_full_name" )
-    module_name = getattr( structural, "component_unique_name" )
+    full_name = structural.component_full_name
+    module_name = structural.component_unique_name
 
     if full_name != module_name:
       optional_full_name = "\n// Full name: {}".format(full_name)
     else:
       optional_full_name = ""
 
-    port_dct = getattr( structural, "decl_ports" )
+    port_dct = structural.decl_ports
     structural.p_port_decls = port_dct["port_decls"]
     structural.p_wire_decls = port_dct["wire_decls"]
     structural.p_connections = port_dct["connections"]
 
-    ifc_dct = getattr( structural, "decl_ifcs" )
+    ifc_dct = structural.decl_ifcs
     structural.i_port_decls = ifc_dct["port_decls"]
     structural.i_wire_decls = ifc_dct["wire_decls"]
     structural.i_connections = ifc_dct["connections"]
 
-    subcomp_dct = getattr( structural, "decl_subcomps" )
+    subcomp_dct = structural.decl_subcomps
     structural.c_port_decls = subcomp_dct["port_decls"]
     structural.c_wire_decls = subcomp_dct["wire_decls"]
     structural.c_connections = subcomp_dct["connections"]
@@ -163,7 +163,7 @@ endmodule
       connections = '\n' + connections
     body += connections
 
-    s._top_module_name = getattr( structural, "component_name", module_name )
+    s._top_module_name = structural.component_name
     s._top_module_full_name = module_name
 
     # Fill in the template and return

--- a/pymtl3/passes/yosys/translation/YosysTranslator.py
+++ b/pymtl3/passes/yosys/translation/YosysTranslator.py
@@ -39,8 +39,7 @@ class YosysTranslator( SVTranslator ):
     template =\
 """\
 // Definition of PyMTL Component {component_name}
-// {file_info}
-// Full name: {full_name}
+// {file_info}{optional_full_name}
 module {module_name}
 (
 {ports});
@@ -52,6 +51,11 @@ endmodule
     ports_template = "{port_decls}{ifc_decls}"
     full_name = getattr( structural, "component_full_name" )
     module_name = getattr( structural, "component_unique_name" )
+
+    if full_name != module_name:
+      optional_full_name = "\n// Full name: {}".format(full_name)
+    else:
+      optional_full_name = ""
 
     port_dct = getattr( structural, "decl_ports" )
     structural.p_port_decls = port_dct["port_decls"]

--- a/pymtl3/passes/yosys/translation/YosysTranslator.py
+++ b/pymtl3/passes/yosys/translation/YosysTranslator.py
@@ -40,6 +40,7 @@ class YosysTranslator( SVTranslator ):
 """\
 // Definition of PyMTL Component {component_name}
 // {file_info}
+// Full name: {full_name}
 module {module_name}
 (
 {ports});
@@ -49,6 +50,7 @@ endmodule
     component_name = getattr( structural, "component_name" )
     file_info = getattr( structural, "component_file_info" )
     ports_template = "{port_decls}{ifc_decls}"
+    full_name = getattr( structural, "component_full_name" )
     module_name = getattr( structural, "component_unique_name" )
 
     port_dct = getattr( structural, "decl_ports" )

--- a/pymtl3/passes/yosys/translation/behavioral/YosysBehavioralTranslatorL1.py
+++ b/pymtl3/passes/yosys/translation/behavioral/YosysBehavioralTranslatorL1.py
@@ -126,7 +126,7 @@ class YosysBehavioralRTLIRToSVVisitorL1( BehavioralRTLIRToSVVisitorL1 ):
 
   def visit_SizeCast( s, node ):
     nbits = node.nbits
-    value = getattr( node.value, "_value", None )
+    value = None if not hasattr(node.value, "_value") else node.value._value
 
     if value is None:
       value_str = s.visit( node.value )

--- a/pymtl3/passes/yosys/translation/behavioral/__init__.py
+++ b/pymtl3/passes/yosys/translation/behavioral/__init__.py
@@ -1,4 +1,3 @@
-
 from .YosysBehavioralTranslatorL5 import (
     YosysBehavioralTranslatorL5 as YosysBehavioralTranslator,
 )

--- a/pymtl3/passes/yosys/translation/structural/__init__.py
+++ b/pymtl3/passes/yosys/translation/structural/__init__.py
@@ -1,4 +1,3 @@
-
 from .YosysStructuralTranslatorL4 import (
     YosysStructuralTranslatorL4 as YosysStructuralTranslator,
 )

--- a/pymtl3/stdlib/cl/MemoryCL_test.py
+++ b/pymtl3/stdlib/cl/MemoryCL_test.py
@@ -4,7 +4,6 @@
 
 import random
 import struct
-from functools import reduce
 
 import pytest
 

--- a/pymtl3/stdlib/cl/__init__.py
+++ b/pymtl3/stdlib/cl/__init__.py
@@ -1,2 +1,1 @@
-
 from .queues import PipeQueueCL

--- a/pymtl3/stdlib/fl/MemoryFL.py
+++ b/pymtl3/stdlib/fl/MemoryFL.py
@@ -1,4 +1,3 @@
-
 from pymtl3 import *
 from pymtl3.stdlib.ifcs import MemMsgType
 from pymtl3.stdlib.ifcs.mem_ifcs import MemMinionIfcFL

--- a/pymtl3/stdlib/fl/__init__.py
+++ b/pymtl3/stdlib/fl/__init__.py
@@ -1,2 +1,1 @@
-
 from .MemoryFL import MemoryFL

--- a/pymtl3/stdlib/ifcs/__init__.py
+++ b/pymtl3/stdlib/ifcs/__init__.py
@@ -1,4 +1,3 @@
-
 from .EnqDeqIfc import DeqIfcRTL, EnqIfcRTL
 from .GetGiveIfc import GetIfcRTL, GiveIfcRTL
 from .ifcs_utils import enrdy_to_str, valrdy_to_str

--- a/pymtl3/stdlib/rtl/RegisterFile.py
+++ b/pymtl3/stdlib/rtl/RegisterFile.py
@@ -1,4 +1,3 @@
-
 from copy import deepcopy
 
 from pymtl3 import *

--- a/pymtl3/stdlib/rtl/__init__.py
+++ b/pymtl3/stdlib/rtl/__init__.py
@@ -1,4 +1,3 @@
-
 from .arbiters import RoundRobinArbiter, RoundRobinArbiterEn
 from .arithmetics import (
     Adder,

--- a/pymtl3/stdlib/rtl/arithmetics.py
+++ b/pymtl3/stdlib/rtl/arithmetics.py
@@ -1,4 +1,3 @@
-
 from pymtl3 import *
 
 # N-input Mux

--- a/pymtl3/stdlib/rtl/registers.py
+++ b/pymtl3/stdlib/rtl/registers.py
@@ -1,4 +1,3 @@
-
 from copy import deepcopy
 
 from pymtl3 import *

--- a/pymtl3/stdlib/rtl/valrdy_queues.py
+++ b/pymtl3/stdlib/rtl/valrdy_queues.py
@@ -1,4 +1,3 @@
-
 from pymtl3 import *
 from pymtl3.stdlib.ifcs import InValRdyIfc, OutValRdyIfc
 from pymtl3.stdlib.rtl import Mux, Reg, RegEn, RegisterFile

--- a/pymtl3/stdlib/rtl/valrdy_queues_test.py
+++ b/pymtl3/stdlib/rtl/valrdy_queues_test.py
@@ -1,4 +1,3 @@
-
 from pymtl3 import *
 from pymtl3.stdlib.ifcs import InValRdyIfc, OutValRdyIfc
 from pymtl3.stdlib.test import TestVectorSimulator

--- a/pymtl3/stdlib/test/__init__.py
+++ b/pymtl3/stdlib/test/__init__.py
@@ -1,4 +1,3 @@
-
 from .test_sinks import TestSinkCL
 from .test_srcs import TestSrcCL
 from .test_utils import TestVectorSimulator, mk_test_case_table

--- a/pymtl3/stdlib/test/test_utils.py
+++ b/pymtl3/stdlib/test/test_utils.py
@@ -1,4 +1,3 @@
-
 import collections
 
 from pymtl3 import *

--- a/setup.py
+++ b/setup.py
@@ -6,10 +6,8 @@ setup.py inspired by the PyPA sample project:
 https://github.com/pypa/sampleproject/blob/master/setup.py
 """
 
-from __future__ import absolute_import, division, print_function
 
 from os import path
-from subprocess import check_output
 
 from setuptools import find_packages, setup
 


### PR DESCRIPTION
This pull requests addresses various problems related to super long (>100 characters) translated component names as mentioned in #75. It does so by replacing parameter list of names longer than 64 characters with a hash value using `blake2b` hash function from `hashlib`.