### PR TITLE
Add --recursive to autoflake

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -47,7 +47,7 @@ install:
 #------------------------------------------------------------------------
 
 script:
- - autoflake --in-place --remove-duplicate-keys .
+ - autoflake --recursive --in-place --remove-duplicate-keys .
  - pyupgrade --py3-only --keep-percent-format $(find . -name '*.py')
  - isort --apply --recursive ./pymtl3
  - flake8 --select=F --ignore=F401,F405,F403,F811,F821,F841

--- a/examples/ex03_proc/proc-sim
+++ b/examples/ex03_proc/proc-sim
@@ -19,8 +19,6 @@
 
 import argparse
 import os
-import re
-import struct
 import sys
 
 from pymtl3 import *

--- a/examples/ex04_xcel/proc-xcel-sim
+++ b/examples/ex04_xcel/proc-xcel-sim
@@ -19,7 +19,6 @@
 
 import argparse
 import os
-import re
 import struct
 import sys
 


### PR DESCRIPTION
The original autoflake command line options were missing the `--recursive` option.