### PR TITLE
Improve annotations in translated files

### DIFF
--- a/examples/ex02_cksum/cksum-translate
+++ b/examples/ex02_cksum/cksum-translate
@@ -95,9 +95,9 @@ def main():
   finally:
     if success:
       path = os.getcwd() + \
-             "/{}.sv".format(cksum._translator._top_module_full_name)
+             "/{}.sv".format(cksum.translated_top_module_name)
       print("\nTranslation finished successfully!")
-      print("You can find the generated SystemVerilog file at {}.".format(path))
+      print(f"You can find the generated SystemVerilog file at {path}.")
     else:
       print()
       print("\nTranslation failed!")

--- a/examples/ex03_proc/proc-translate
+++ b/examples/ex03_proc/proc-translate
@@ -97,9 +97,9 @@ def main():
   finally:
     if success:
       path = os.getcwd() + \
-             "/{}.sv".format(proc._translator._top_module_full_name)
+             "/{}.sv".format(proc.translated_top_module_name)
       print("\nTranslation finished successfully!")
-      print("You can find the generated SystemVerilog file at {}.".format(path))
+      print(f"You can find the generated SystemVerilog file at {path}.")
     else:
       print()
       print("\nTranslation failed!")

--- a/examples/ex04_xcel/proc-xcel-translate
+++ b/examples/ex04_xcel/proc-xcel-translate
@@ -118,7 +118,7 @@ A valid output directory should be alloy-asic/designs/<design_name>/rtl
   finally:
     if success:
       path = os.getcwd() + \
-             "/{}.sv".format(proc_xcel._translator._top_module_full_name)
+             "/{}.sv".format(proc_xcel.translated_top_module_name)
 
       if opts.output_dir:
         # Upon success, symlink the file to outputs/design.v which is the
@@ -132,7 +132,7 @@ A valid output directory should be alloy-asic/designs/<design_name>/rtl
         os.symlink( path, design_v )
 
       print("\nTranslation finished successfully!")
-      print("You can find the generated SystemVerilog file at {}.".format(path))
+      print(f"You can find the generated SystemVerilog file at {path}.")
     else:
       print()
       print("\nTranslation failed!")

--- a/pymtl3/passes/rtlir/rtype/RTLIRDataType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRDataType.py
@@ -63,7 +63,7 @@ class Struct( BaseRTLIRDataType ):
       try:
         file_name = inspect.getsourcefile( cls )
         line_no = inspect.getsourcelines( cls )[1]
-        s.file_info = f"File: {file_name}, Line: {line_no}"
+        s.file_info = f"{file_name}:{line_no}"
       except OSError:
         s.file_info = f"Dynamically generated class {cls.__name__}"
     else:

--- a/pymtl3/passes/rtlir/rtype/RTLIRType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRType.py
@@ -300,7 +300,7 @@ class Component( BaseRTLIRType ):
     try:
       file_name = inspect.getsourcefile( cls )
       line_no = inspect.getsourcelines( cls )[1]
-      s.file_info = f"File: {file_name}, Line: {line_no}"
+      s.file_info = f"{file_name}:{line_no}"
     except OSError:
       s.file_info = f"Dynamically generated component {cls.__name__}"
 

--- a/pymtl3/passes/sverilog/translation/SVTranslator.py
+++ b/pymtl3/passes/sverilog/translation/SVTranslator.py
@@ -85,8 +85,8 @@ def mk_SVTranslator( _RTLIRTranslator, _STranslator, _BTranslator ):
       for struct_dtype, tplt in hierarchy.decl_type_struct:
         template = \
 """\
-// Definition of PyMTL BitStruct {dtype_name}
-// {file_info}
+// PyMTL BitStruct {dtype_name} Definition
+// At {file_info}
 {struct_def}\
 """
         dtype_name = struct_dtype.get_name()
@@ -105,8 +105,8 @@ def mk_SVTranslator( _RTLIRTranslator, _STranslator, _BTranslator ):
 
       template =\
 """\
-// Definition of PyMTL Component {component_name}
-// {file_info}{optional_full_name}
+// PyMTL Component {component_name} Definition
+// {optional_full_name}At {file_info}
 module {module_name}
 (
 {ports});
@@ -120,7 +120,7 @@ endmodule
       module_name = structural.component_unique_name
 
       if full_name != module_name:
-        optional_full_name = f"\n// Full name: {full_name}"
+        optional_full_name = f"Full name: {full_name}\n// "
       else:
         optional_full_name = ""
 

--- a/pymtl3/passes/sverilog/translation/TranslationPass.py
+++ b/pymtl3/passes/sverilog/translation/TranslationPass.py
@@ -53,6 +53,8 @@ def mk_TranslationPass( _SVTranslator ):
         # Rename the temporary file to the output file
         os.rename( temporary_file, output_file )
 
+        # Expose some attributes about the translation process
+        m.translated_top_module_name = module_name
         m._translator = s.translator
         m._pass_sverilog_translation.translated = True
 

--- a/pymtl3/passes/sverilog/translation/behavioral/SVBehavioralTranslatorL1.py
+++ b/pymtl3/passes/sverilog/translation/behavioral/SVBehavioralTranslatorL1.py
@@ -72,17 +72,17 @@ class SVBehavioralTranslatorL1( SVBehavioralTranslatorL0, BehavioralTranslatorL1
       upblk_py_src = upblk_py_src[:-1]
 
     # Add comments to the generated block
-    py_src = [ "PYMTL SOURCE:", "" ]
+    py_src = []
 
     if is_lambda:
       py_src += [
-        f"This upblk was generated from a lambda function defined in file {filename}, line {lino}:",
-        f"{src}",
+        "PyMTL Lambda Block Source",
+        "{src}",
       ]
     else:
-      py_src += [
-        f"This upblk was generated from an upblk defined in file {filename}, line {lino}",
-      ]
+      py_src += [ "PyMTL Update Block Source" ]
+
+    py_src += [ f"At {filename}:{lino}" ]
 
     py_src += upblk_py_src
 

--- a/pymtl3/passes/sverilog/translation/test/SVTranslator_L1_cases_test.py
+++ b/pymtl3/passes/sverilog/translation/test/SVTranslator_L1_cases_test.py
@@ -41,8 +41,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = s.in_
@@ -75,8 +73,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update_ff
   // def upblk():
   //   s.out <<= s.in_
@@ -111,8 +107,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( s.in_1, s.in_2 )
@@ -143,8 +137,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( Bits32(42), Bits32(0) )
@@ -177,8 +169,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( s.in_, Bits32(0) )
@@ -211,8 +201,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = sext( s.in_, 64 )
@@ -245,8 +233,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = zext( s.in_, 64 )
@@ -281,8 +267,6 @@ module A
 );
   localparam [31:0] __const__STATE_IDLE = 32'd42;
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( s.in_, STATE_IDLE )
@@ -303,8 +287,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( s.in_, STATE_IDLE )
@@ -336,8 +318,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( s.in_[0], s.in_[1] )
@@ -360,8 +340,6 @@ module A
 );
   logic [31:0] in_ [0:1];
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( s.in_[0], s.in_[1] )
@@ -396,8 +374,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = s.in_[1]
@@ -430,8 +406,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = s.in_[4:36]
@@ -544,8 +518,6 @@ module A
 );
   localparam [31:0] STATE_IDLE = 32'd42;
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out_2 = s.STATE_IDLE
@@ -568,8 +540,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out_2 = s.STATE_IDLE
@@ -607,8 +577,6 @@ module A
 );
   localparam [31:0] STATES [0:4] = '{ 32'd1, 32'd2, 32'd3, 32'd4, 32'd5 };
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.tmp = s.STATES[0]
@@ -640,8 +608,6 @@ module A
 );
   logic [31:0] out [0:4];
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.tmp = s.STATES[0]

--- a/pymtl3/passes/sverilog/translation/test/SVTranslator_L2_cases_test.py
+++ b/pymtl3/passes/sverilog/translation/test/SVTranslator_L2_cases_test.py
@@ -46,8 +46,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   if Bits1(1):
@@ -93,8 +91,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   if Bits1(1):
@@ -143,8 +139,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   if Bits1(1):
@@ -196,8 +190,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   if Bits1(1):
@@ -260,8 +252,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   if Bits1(1):
@@ -327,8 +317,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(2):
@@ -355,8 +343,6 @@ module A
   logic [31:0] in_ [0:1];
   logic [31:0] out [0:1];
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(2):
@@ -399,8 +385,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(1, 2):
@@ -429,8 +413,6 @@ module A
   logic [31:0] in_ [0:1];
   logic [31:0] out [0:1];
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(1, 2):
@@ -476,8 +458,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(0, 5, 2):
@@ -514,8 +494,6 @@ module A
   logic [31:0] in_ [0:4];
   logic [31:0] out [0:4];
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(0, 5, 2):
@@ -567,8 +545,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(5):
@@ -601,8 +577,6 @@ module A
   logic [31:0] in_ [0:4];
   logic [31:0] out [0:4];
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(5):
@@ -650,8 +624,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(5):
@@ -684,8 +656,6 @@ module A
   logic [31:0] in_ [0:4];
   logic [31:0] out [0:4];
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(5):
@@ -736,8 +706,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(5):
@@ -777,8 +745,6 @@ module A
   logic [31:0] in_ [0:4];
   logic [31:0] out [0:4];
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(5):
@@ -838,8 +804,6 @@ module A
 );
   logic [31:0] __tmpvar__upblk_tmpvar;
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(5):
@@ -883,8 +847,6 @@ module A
   logic [31:0] out [0:4];
   logic [31:0] __tmpvar__upblk_tmpvar;
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   for i in range(5):
@@ -948,8 +910,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = s.in_.foo
@@ -971,8 +931,6 @@ module A
 );
   logic [31:0] in_;
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = s.in_.foo
@@ -1015,8 +973,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( s.in_.bar[0], s.in_.bar[1], s.in_.foo )
@@ -1041,8 +997,6 @@ module A
   logic [31:0] in___bar [0:1];
   logic [95:0] in_;
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( s.in_.bar[0], s.in_.bar[1], s.in_.foo )
@@ -1098,8 +1052,6 @@ module A
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( s.in_.bar[0], s.in_.c.woof, s.in_.foo )
@@ -1126,8 +1078,6 @@ module A
   logic [31:0] in___c;
   logic [127:0] in_;
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = concat( s.in_.bar[0], s.in_.c.woof, s.in_.foo )
@@ -1164,12 +1114,6 @@ module A
   output logic [31:0] out,
   input logic [0:0] reset
 );
-
-  // PYMTL SOURCE:
-  //
-  // This upblk was generated from a lambda function defined in file \
-  //    .../pymtl3/passes/sverilog/translation/test/SVTranslator_L2_cases_test.py, line 1157:
-  //       s.out //= lambda: s.in_ + Bits32(42)
 
   // def _lambda__s_out(): s.out = s.in_ + Bits32(42)
 

--- a/pymtl3/passes/sverilog/translation/test/SVTranslator_L3_cases_test.py
+++ b/pymtl3/passes/sverilog/translation/test/SVTranslator_L3_cases_test.py
@@ -57,8 +57,6 @@ module A
   output logic [0:0] out__val
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out.val = s.in_.val
@@ -99,8 +97,6 @@ module A
   output logic [31:0] in___1__foo
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = s.in_[1].foo
@@ -123,8 +119,6 @@ module A
 );
   logic [31:0] in___foo [0:1];
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = s.in_[1].foo

--- a/pymtl3/passes/sverilog/translation/test/SVTranslator_L4_cases_test.py
+++ b/pymtl3/passes/sverilog/translation/test/SVTranslator_L4_cases_test.py
@@ -42,8 +42,6 @@ module B
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.foo = Bits32(42)
@@ -72,8 +70,6 @@ module A
     .reset( b__reset )
   );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = s.b.foo
@@ -114,8 +110,6 @@ module B
   input logic [0:0] reset
 );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out_b = Bits32(0)
@@ -144,8 +138,6 @@ module A
     .reset( b__reset )
   );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = zext( s.b.out_b, 64 )
@@ -214,8 +206,6 @@ module A
     .reset( comp__1__reset )
   );
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = s.comp[1].out
@@ -280,8 +270,6 @@ module A
   assign comp__0__reset = comp__reset[0];
   assign comp__1__reset = comp__reset[1];
 
-  // PYMTL SOURCE:
-  //
   // @s.update
   // def upblk():
   //   s.out = s.comp[1].out

--- a/pymtl3/passes/yosys/translation/TranslationPass.py
+++ b/pymtl3/passes/yosys/translation/TranslationPass.py
@@ -51,6 +51,8 @@ class TranslationPass( BasePass ):
       # Rename the temporary file to the output file
       os.rename( temporary_file, output_file )
 
+      # Expose some attributes about the translation process
+      m.translated_top_module_name = module_name
       m._translator = s.translator
       m._pass_yosys_translation.translated = True
 

--- a/pymtl3/passes/yosys/translation/YosysTranslator.py
+++ b/pymtl3/passes/yosys/translation/YosysTranslator.py
@@ -38,8 +38,8 @@ class YosysTranslator( SVTranslator ):
 
     template =\
 """\
-// Definition of PyMTL Component {component_name}
-// {file_info}{optional_full_name}
+// PyMTL Component {component_name} Definition
+// {optional_full_name}At {file_info}
 module {module_name}
 (
 {ports});
@@ -53,7 +53,7 @@ endmodule
     module_name = structural.component_unique_name
 
     if full_name != module_name:
-      optional_full_name = f"\n// Full name: {full_name}"
+      optional_full_name = f"Full name: {full_name}\n// "
     else:
       optional_full_name = ""
 


### PR DESCRIPTION
In this PR we use the following annotations in comments of the translated file
Update blocks: `PyMTL Update Block`
Lambda blocks: `PyMTL Lambda Block`
Component definitions: `PyMTL Component <component-name> Definition`
BitStruct definitions: `PyMTL BitStruct <bitstruct-name> Definition`
And the above annotations are followed by a file name and line number. 