### PR TITLE
Make constant-sized slicings translatable

### DIFF
--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIR.asdl
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIR.asdl
@@ -30,7 +30,10 @@ module BehavioralRTLIR
        -- an assignment
        | Attribute( expr value, identifier attr )
        | Index( expr value, expr idx )
-       | Slice( expr value, expr lower, expr upper )
+       -- Slice nodes might have `slice_size` and `slice_base` attributes
+       -- annotated by the type checking pass. These fields indicate this
+       -- slice object is a constant size slicing (i.e. [base +: size]).
+       | Slice( expr value, expr lower, expr upper, expr? base, int? size )
        | Base( object base )
        | LoopVar( string name )
        | FreeVar( string name, object obj )

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIR.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIR.py
@@ -211,13 +211,15 @@ class Index( BaseBehavioralRTLIR ):
     return isinstance(other, Index) and s.value == other.value and s.idx == other.idx
 
 class Slice( BaseBehavioralRTLIR ):
-  def __init__( s, value, lower, upper ):
+  def __init__( s, value, lower, upper, base = None, size = None ):
     s.value = value
     s.lower = lower
     s.upper = upper
+    s.base = base
+    s.size = size
 
   def __eq__( s, other ):
-    return isinstance(other, Slice) and s.value == other.value and s.lower == other.lower and s.upper == other.upper
+    return isinstance(other, Slice) and s.value == other.value and s.lower == other.lower and s.upper == other.upper and s.base == other.base and s.size == other.size
 
 class Base( BaseBehavioralRTLIR ):
   def __init__( s, base ):

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRTypeCheckL1Pass.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRTypeCheckL1Pass.py
@@ -304,10 +304,11 @@ class BehavioralRTLIRTypeCheckVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
         assert isinstance( node.upper, bir.BinOp )
         assert isinstance( node.upper.op, bir.Add )
         nbits = node.upper.right
+        slice_size = nbits._value
         assert s.is_same( node.lower, node.upper.left )
-        node.Type = rt.NetWire( rdt.Vector( nbits.value ) )
+        node.Type = rt.NetWire( rdt.Vector( slice_size ) )
         # Add new fields that might help translation
-        node.size = nbits.value
+        node.size = slice_size
         node.base = node.lower
       except Exception:
         raise PyMTLTypeError( s.blk, node.ast, 'slice bounds must be constant!' )

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRTypeCheckL1Pass.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRTypeCheckL1Pass.py
@@ -305,6 +305,9 @@ class BehavioralRTLIRTypeCheckVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
         assert isinstance( node.upper.op, bir.Add )
         nbits = node.upper.right
         assert s.is_same( node.lower, node.upper.left )
-        node.Type = rt.NetWire( rdt.Vector( nbits ) )
+        node.Type = rt.NetWire( rdt.Vector( nbits.value ) )
+        # Add new fields that might help translation
+        node.size = nbits.value
+        node.base = node.lower
       except Exception:
         raise PyMTLTypeError( s.blk, node.ast, 'slice bounds must be constant!' )

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRVisualizationPass.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRVisualizationPass.py
@@ -14,7 +14,6 @@ from pymtl3.passes.rtlir.rtype.RTLIRType import BaseRTLIRType
 
 from .BehavioralRTLIR import BehavioralRTLIRNodeVisitor
 
-
 class BehavioralRTLIRVisualizationPass( BasePass ):
   def __call__( s, model ):
     visitor = BehavioralRTLIRVisualizationVisitor()
@@ -293,9 +292,9 @@ class BehavioralRTLIRVisualizationVisitor( BehavioralRTLIRNodeVisitor ):
   def visit_Slice( s, node ):
     s.cur += 1
     local_cur = s.cur
-    table_body = '<TR><TD COLSPAN="2">Slice</TD></TR>'
+    table_body = '<TR><TD COLSPAN="2">Slice</TD></TR> <TR><TD>size</TD><TD>{size}</TD></TR>'
     table_opt = s.gen_table_opt( node )
-    label = (s.table_header + table_body + table_opt + s.table_trail)
+    label = (s.table_header + table_body + table_opt + s.table_trail).format(size=s.get_str(node.size))
     s.g.node( str( s.cur ), label = label )
     s.g.edge( str(local_cur), str(s.cur+1), label = 'value' )
     s.visit( node.value )
@@ -303,6 +302,9 @@ class BehavioralRTLIRVisualizationVisitor( BehavioralRTLIRNodeVisitor ):
     s.visit( node.lower )
     s.g.edge( str(local_cur), str(s.cur+1), label = 'upper' )
     s.visit( node.upper )
+    if node.base is not None:
+      s.g.edge( str(local_cur), str(s.cur+1), label = 'base' )
+      s.visit( node.base )
 
   def visit_Base( s, node ):
     s.cur += 1

--- a/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRVisualizationPass.py
+++ b/pymtl3/passes/rtlir/behavioral/BehavioralRTLIRVisualizationPass.py
@@ -14,6 +14,7 @@ from pymtl3.passes.rtlir.rtype.RTLIRType import BaseRTLIRType
 
 from .BehavioralRTLIR import BehavioralRTLIRNodeVisitor
 
+
 class BehavioralRTLIRVisualizationPass( BasePass ):
   def __call__( s, model ):
     visitor = BehavioralRTLIRVisualizationVisitor()

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
@@ -425,6 +425,15 @@ def test_ff_upblk( do_test ):
         Assign( Attribute( Base( a ), 'out0' ), BinOp( Attribute( Base( a ), 'in0' ), Add(), Attribute( Base( a ), 'in1' ) ), False ),
         ] )
   }
+  a._test_vector = [
+                'in0                in1              *out',
+    [         Bits32,            Bits32,            Bits32 ],
+
+    [     Bits32(-1),       Bits32(0xff),     Bits32(0xfe) ],
+    [     Bits32(1),        Bits32(0x11),     Bits32(0x12) ],
+    [     Bits32(7),        Bits32(0x77),     Bits32(0x7d) ],
+  ]
+
   do_test( a )
 
 def test_fixed_size_slice( do_test ):
@@ -451,4 +460,16 @@ def test_fixed_size_slice( do_test ):
         )
       ])
   }
+  a._test_vector = [
+                'in_              *out[0]          *out[1]',
+    [         Bits16,               Bits8,            Bits8 ],
+
+    [     Bits16(-1),         Bits8(0xff),      Bits8(0xff) ],
+    [      Bits16(1),         Bits8(0x01),      Bits8(0x00) ],
+    [      Bits16(7),         Bits8(0x07),      Bits8(0x00) ],
+    [ Bits16(0xff00),         Bits8(0x00),      Bits8(0xff) ],
+    [ Bits16(0x3412),         Bits8(0x12),      Bits8(0x34) ],
+    [ Bits16(0x9876),         Bits8(0x76),      Bits8(0x98) ],
+  ]
+
   do_test( a )

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
@@ -426,3 +426,29 @@ def test_ff_upblk( do_test ):
         ] )
   }
   do_test( a )
+
+def test_fixed_size_slice( do_test ):
+  class A( Component ):
+    def construct( s ):
+      s.in_ = InPort( Bits16 )
+      s.out = [ OutPort( Bits8 ) for _ in range(2) ]
+      @s.update
+      def upblk():
+        for i in range(2):
+          s.out[i] = s.in_[i*8 : i*8 + 8]
+  a = A()
+  a._rtlir_test_ref = {
+      'upblk' : CombUpblk( 'upblk', [
+        For( LoopVarDecl('i'), Number(0), Number(2), Number(1), [
+          Assign(
+            Index(Attribute(Base(a), 'out'), LoopVar('i')),
+            Slice(Attribute(Base(a), 'in_'),
+                  BinOp(LoopVar('i'), Mult(), Number(8)),
+                  BinOp(BinOp(LoopVar('i'), Mult(), Number(8)), Add(), Number(8)),
+                  BinOp(LoopVar('i'), Mult(), Number(8)),
+                  8,
+            ), True)]
+        )
+      ])
+  }
+  do_test( a )

--- a/pymtl3/passes/sverilog/test/TranslationImport_adhoc_test.py
+++ b/pymtl3/passes/sverilog/test/TranslationImport_adhoc_test.py
@@ -23,6 +23,7 @@ from ..translation.behavioral.test.SVBehavioralTranslatorL1_test import (
     test_zext,
 )
 from ..translation.behavioral.test.SVBehavioralTranslatorL2_test import (
+    test_fixed_size_slice,
     test_for_range_lower_upper,
     test_for_range_lower_upper_step,
     test_for_range_upper,

--- a/pymtl3/passes/sverilog/translation/behavioral/SVBehavioralTranslatorL1.py
+++ b/pymtl3/passes/sverilog/translation/behavioral/SVBehavioralTranslatorL1.py
@@ -457,7 +457,7 @@ class BehavioralRTLIRToSVVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
     value = s.visit( node.value )
 
     # Check for +: syntax
-    if hasattr( node, 'base' ) and hasattr( node, 'size' ):
+    if node.base and node.size:
       size = int( node.size )
       base = s.visit( node.base )
 

--- a/pymtl3/passes/sverilog/translation/behavioral/SVBehavioralTranslatorL1.py
+++ b/pymtl3/passes/sverilog/translation/behavioral/SVBehavioralTranslatorL1.py
@@ -456,12 +456,21 @@ class BehavioralRTLIRToSVVisitorL1( bir.BehavioralRTLIRNodeVisitor ):
     lower = s.visit( node.lower )
     value = s.visit( node.value )
 
-    if hasattr( node.upper, '_value' ):
-      upper = str( int( node.upper._value - Bits32(1) ) )
-    else:
-      upper = s.visit( node.upper ) + '-1'
+    # Check for +: syntax
+    if hasattr( node, 'base' ) and hasattr( node, 'size' ):
+      size = int( node.size )
+      base = s.visit( node.base )
 
-    return f'{value}[{upper}:{lower}]'
+      return f'{value}[{base} +: {size}]'
+
+    # Reguarl [ lower : upper ] syntax
+    else:
+      if hasattr( node.upper, '_value' ):
+        upper = str( int( node.upper._value - Bits32(1) ) )
+      else:
+        upper = s.visit( node.upper ) + '-1'
+
+      return f'{value}[{upper}:{lower}]'
 
   #-----------------------------------------------------------------------
   # visit_Base


### PR DESCRIPTION
Constant-sized slicings (e.g. `s.out[v*8 : v*8 + 8]` where `v` could be a loop index) can be nicely translated to Verilog (using `+:`). This PR supports translating slices whose upper bound is larger (i.e. adding a constant) than its lower bound by a constant.