### PR TITLE
Connect const struct to a signal

### DIFF
--- a/pymtl3/datatypes/PythonBits.py
+++ b/pymtl3/datatypes/PythonBits.py
@@ -176,7 +176,7 @@ class Bits:
   # Print
 
   def __repr__(self):
-    return "Bits{}( {} )".format( self.nbits, self.hex() )
+    return "Bits{}({})".format( self.nbits, int(self.value) )
 
   def __str__(self):
     str = "{:x}".format(int(self.value)).zfill(((self.nbits-1)>>2)+1)

--- a/pymtl3/datatypes/__init__.py
+++ b/pymtl3/datatypes/__init__.py
@@ -4,6 +4,7 @@ from .bitstructs import bitstruct, is_bitstruct_class, is_bitstruct_inst, mk_bit
 from .helpers import (
     clog2,
     concat,
+    get_bitstruct_inst_all_classes,
     get_nbits,
     reduce_and,
     reduce_or,

--- a/pymtl3/datatypes/bitstructs.py
+++ b/pymtl3/datatypes/bitstructs.py
@@ -214,14 +214,14 @@ def _mk_str_fn( fields ):
 # function that looks like the following:
 #
 # def __repr__( self ):
-#  return self.__class__.qualname__ + f'(x={self.x!r}, y={self.y!r})'
+#  return self.__class__.__name__ + f'(x={self.x!r}, y={self.y!r})'
 
 def _mk_repr_fn( fields ):
   return _create_fn(
     '__repr__',
     [ 'self' ],
-    [ 'return self.__class__.__qualname__ + f"(' +
-      ', '.join([ f'{name}={{self.{name}!r}}' for name in fields ]) +
+    [ 'return self.__class__.__name__ + f"(' +
+      ','.join([ f'{{self.{name}!r}}' for name in fields ]) +
       ')"']
   )
 

--- a/pymtl3/datatypes/helpers.py
+++ b/pymtl3/datatypes/helpers.py
@@ -85,15 +85,15 @@ def to_bits( obj ):
   assert is_bitstruct_inst( obj ), f"{obj} is not a valid PyMTL Bitstruct!"
   return concat( *[ to_bits(getattr(obj, v)) for v in obj.__bitstruct_fields__.keys() ] )
 
-def _get_bitstruct_inst_all_classes( obj ):
+def get_bitstruct_inst_all_classes( obj ):
   # list: put all types together
   if isinstance( obj, list ):
-    return functools.reduce( operator.or_, [ _get_bitstruct_inst_all_classes(x) for x in obj ] )
+    return functools.reduce( operator.or_, [ get_bitstruct_inst_all_classes(x) for x in obj ] )
   ret = { obj.__class__ }
   # BitsN or int
   if isinstance( obj, (Bits, int) ):
     return ret
   # BitStruct
   assert is_bitstruct_inst( obj ), f"{obj} is not a valid PyMTL Bitstruct!"
-  return ret | functools.reduce( operator.or_, [ _get_bitstruct_inst_all_classes(getattr(obj, v))
+  return ret | functools.reduce( operator.or_, [ get_bitstruct_inst_all_classes(getattr(obj, v))
                                                 for v in obj.__bitstruct_fields__.keys() ] )

--- a/pymtl3/datatypes/helpers.py
+++ b/pymtl3/datatypes/helpers.py
@@ -89,10 +89,9 @@ def _get_bitstruct_inst_all_classes( obj ):
   # list: put all types together
   if isinstance( obj, list ):
     return functools.reduce( operator.or_, [ _get_bitstruct_inst_all_classes(x) for x in obj ] )
-
   ret = { obj.__class__ }
-  # BitsN
-  if isinstance( obj, Bits ):
+  # BitsN or int
+  if isinstance( obj, (Bits, int) ):
     return ret
   # BitStruct
   assert is_bitstruct_inst( obj ), f"{obj} is not a valid PyMTL Bitstruct!"

--- a/pymtl3/datatypes/test/helpers_test.py
+++ b/pymtl3/datatypes/test/helpers_test.py
@@ -1,0 +1,81 @@
+"""
+==========================================================================
+helpers_test.py
+==========================================================================
+Test cases for helper functions
+
+Author : Shunning Jiang
+  Date : Nov 30, 2019
+"""
+
+from pymtl3.datatypes import *
+from pymtl3.datatypes.helpers import _get_bitstruct_inst_all_classes
+
+def test_concat():
+  x = concat( Bits128(0x1234567890abcdef1234567890abcdef),
+              Bits252(0xffffffffff22222222222222222444441234567890abcdef1234567890abcdef) )
+  assert x.nbits == 380
+  assert x == mk_bits(380)(0x1234567890abcdef1234567890abcdeffffffffff22222222222222222444441234567890abcdef1234567890abcdef)
+
+def test_zext():
+  assert zext( Bits8(0xe), 24 ) == Bits24(0xe)
+
+def test_sext():
+  assert zext( Bits8(0xe), 24 ) == Bits24(0xe)
+
+def test_clog2():
+  assert clog2(7) == 3
+  assert clog2(8) == 3
+  assert clog2(9) == 4
+
+def test_reduce_and():
+  for i in range(255):
+    assert not reduce_and( b8(i) )
+  assert reduce_and( b8(255) )
+  assert reduce_and( b512((2**512)-1) )
+
+def test_reduce_or():
+  for i in range(1, 256):
+    assert reduce_or(i)
+  assert not reduce_or( b8(0) )
+  assert reduce_or( b512((2**512)-1) )
+
+def test_reduce_xor():
+  assert reduce_xor( b8(0b10101011) ) == 1
+  assert reduce_xor( b8(0b10101010) ) == 0
+
+def test_get_nbits():
+
+  @bitstruct
+  class SomeMsg:
+    c: [ Bits3, Bits3 ]
+    d: [ Bits5, Bits5 ]
+
+  assert get_nbits( SomeMsg ) == 16
+
+def test_to_bits():
+
+  @bitstruct
+  class SomeMsg:
+    c: [ Bits4, Bits4 ]
+    d: [ Bits8, Bits8 ]
+
+  assert to_bits( SomeMsg([b4(0x2),b4(0x3)],[b8(0x45), b8(0x67)]) ) == b24(0x234567)
+
+def test_get_bitstruct_inst_all_classes():
+
+  @bitstruct
+  class SomeMsg1:
+    a: [ Bits4, Bits4 ]
+    b: Bits8
+
+  @bitstruct
+  class SomeMsg2:
+    c: [ SomeMsg1, SomeMsg1 ]
+    d: [ Bits6, Bits6 ]
+
+  a = SomeMsg2()
+  print()
+  print(_get_bitstruct_inst_all_classes( a ))
+  print({Bits4, Bits8, SomeMsg1, Bits6, SomeMsg2})
+  assert _get_bitstruct_inst_all_classes( a ) == {Bits4, Bits8, SomeMsg1, Bits6, SomeMsg2}

--- a/pymtl3/datatypes/test/helpers_test.py
+++ b/pymtl3/datatypes/test/helpers_test.py
@@ -9,7 +9,7 @@ Author : Shunning Jiang
 """
 
 from pymtl3.datatypes import *
-from pymtl3.datatypes.helpers import _get_bitstruct_inst_all_classes
+from pymtl3.datatypes.helpers import get_bitstruct_inst_all_classes
 
 
 def test_concat():
@@ -77,6 +77,6 @@ def test_get_bitstruct_inst_all_classes():
 
   a = SomeMsg2()
   print()
-  print(_get_bitstruct_inst_all_classes( a ))
+  print(get_bitstruct_inst_all_classes( a ))
   print({Bits4, Bits8, SomeMsg1, Bits6, SomeMsg2})
-  assert _get_bitstruct_inst_all_classes( a ) == {Bits4, Bits8, SomeMsg1, Bits6, SomeMsg2}
+  assert get_bitstruct_inst_all_classes( a ) == {Bits4, Bits8, SomeMsg1, Bits6, SomeMsg2}

--- a/pymtl3/datatypes/test/helpers_test.py
+++ b/pymtl3/datatypes/test/helpers_test.py
@@ -11,6 +11,7 @@ Author : Shunning Jiang
 from pymtl3.datatypes import *
 from pymtl3.datatypes.helpers import _get_bitstruct_inst_all_classes
 
+
 def test_concat():
   x = concat( Bits128(0x1234567890abcdef1234567890abcdef),
               Bits252(0xffffffffff22222222222222222444441234567890abcdef1234567890abcdef) )

--- a/pymtl3/datatypes/test/strategies_test.py
+++ b/pymtl3/datatypes/test/strategies_test.py
@@ -16,7 +16,7 @@ from pymtl3.datatypes.bits_import import *
 
 
 @pytest.mark.parametrize( 'nbits', [1, 3, 4, 8, 16, 32] )
-def test_unsiged( nbits ):
+def test_unsigned( nbits ):
   print("")
   @hypothesis.given(
     bits = pst.bits(nbits)

--- a/pymtl3/dsl/ComponentLevel3.py
+++ b/pymtl3/dsl/ComponentLevel3.py
@@ -17,7 +17,7 @@ import inspect
 import linecache
 from collections import defaultdict
 
-from pymtl3.datatypes import Bits
+from pymtl3.datatypes import Bits, is_bitstruct_inst
 
 from .ComponentLevel1 import ComponentLevel1
 from .ComponentLevel2 import ComponentLevel2, compiled_re
@@ -245,6 +245,12 @@ class ComponentLevel3( ComponentLevel2 ):
       if Type is not Type2:
         raise InvalidConnectionError( f"Bitwidth mismatch when connecting a {Type2} constant "
                                       f"to signal {o1} with type {Type}." )
+      o2 = Const( Type, o2, s )
+    elif is_bitstruct_inst( o2 ):
+      Type2 = type(o2)
+      if Type is not Type2:
+        raise InvalidConnectionError( f"We don't support connecting a {Type2} constant bitstruct"
+                                      f"to non-bitstruct type {Type}" )
       o2 = Const( Type, o2, s )
     else:
       raise InvalidConnectionError(f"\n>>> {o2} of type {type(o2)} is not a const! \n"

--- a/pymtl3/dsl/Connectable.py
+++ b/pymtl3/dsl/Connectable.py
@@ -127,9 +127,6 @@ class Const( Connectable ):
     except AttributeError:
       raise NotElaboratedError()
 
-  def get_sibling_slices( s ):
-    return []
-
   def is_component( s ):
     return False
 

--- a/pymtl3/dsl/test/ComponentLevel3_test.py
+++ b/pymtl3/dsl/test/ComponentLevel3_test.py
@@ -727,6 +727,9 @@ def test_const_connect_Bits_signal_to_int():
   print(x._dsl.consts)
   assert len(x._dsl.consts) == 1
 
+  simple_sim_pass(x)
+  x.tick()
+
 def test_const_connect_int_signal_to_int():
 
   class Top( ComponentLevel3 ):
@@ -739,6 +742,9 @@ def test_const_connect_int_signal_to_int():
   print(x._dsl.consts)
   assert len(x._dsl.consts) == 1
 
+  simple_sim_pass(x)
+  x.tick()
+
 def test_const_connect_Bits_signal_to_Bits():
 
   class Top( ComponentLevel3 ):
@@ -750,6 +756,9 @@ def test_const_connect_Bits_signal_to_Bits():
   x.elaborate()
   print(x._dsl.consts)
   assert len(x._dsl.consts) == 1
+
+  simple_sim_pass(x)
+  x.tick()
 
 def test_const_connect_Bits_signal_to_mismatch_Bits():
 
@@ -765,6 +774,51 @@ def test_const_connect_Bits_signal_to_mismatch_Bits():
     print("{} is thrown\n{}".format( e.__class__.__name__, e ))
     return
   raise Exception("Should've thrown InvalidConnectionError.")
+
+def test_const_connect_struct_signal_to_struct():
+
+  @bitstruct
+  class SomeMsg1:
+    a: Bits8
+    b: Bits32
+
+  class Top( ComponentLevel3 ):
+    def construct( s ):
+      s.out = OutPort(SomeMsg1)
+      connect( s.out, SomeMsg1(1,3) )
+
+  x = Top()
+  x.elaborate()
+  simple_sim_pass(x)
+  x.tick()
+  assert x.out == SomeMsg1(1,3)
+
+def test_const_connect_diffrent_structs_same_name():
+
+  class A:
+    @bitstruct
+    class SomeMsg1:
+      a: Bits8
+      b: Bits32
+  class B:
+    @bitstruct
+    class SomeMsg1:
+      c: Bits8
+
+  class Top( ComponentLevel3 ):
+    def construct( s ):
+      s.out = OutPort(A.SomeMsg1)
+      connect( s.out, A.SomeMsg1(1,3) )
+
+      s.out2 = OutPort(B.SomeMsg1)
+      connect( s.out2, B.SomeMsg1(4) )
+
+  x = Top()
+  x.elaborate()
+  simple_sim_pass(x)
+  x.tick()
+  assert x.out == A.SomeMsg1(1,3)
+  assert x.out2 == B.SomeMsg1(4)
 
 def test_invalid_connect_outside_hierarchy():
 

--- a/pymtl3/dsl/test/ComponentLevel3_test.py
+++ b/pymtl3/dsl/test/ComponentLevel3_test.py
@@ -850,7 +850,6 @@ def test_const_connect_cannot_handle_same_name_nested_struct():
     return
   raise Exception("Should've thrown AssertionError")
 
-
 def test_const_connect_diffrent_structs_same_name():
 
   class A:

--- a/pymtl3/dsl/test/sim_utils.py
+++ b/pymtl3/dsl/test/sim_utils.py
@@ -12,7 +12,7 @@ from collections import defaultdict
 
 import py.code
 
-from pymtl3.datatypes.helpers import _get_bitstruct_inst_all_classes
+from pymtl3.datatypes.helpers import get_bitstruct_inst_all_classes
 from pymtl3.dsl.ComponentLevel1 import ComponentLevel1
 from pymtl3.dsl.ComponentLevel2 import ComponentLevel2
 from pymtl3.dsl.ComponentLevel3 import ComponentLevel3
@@ -77,7 +77,7 @@ def simple_sim_pass( s, seed=0xdeadbeef ):
         _globals = { 's': s }
 
         if isinstance( writer, Const ) and type(writer._dsl.const) is not int:
-          types = _get_bitstruct_inst_all_classes( writer._dsl.const )
+          types = get_bitstruct_inst_all_classes( writer._dsl.const )
 
           for t in types:
             if t.__name__ in _globals:

--- a/pymtl3/passes/GenDAGPass.py
+++ b/pymtl3/passes/GenDAGPass.py
@@ -12,7 +12,7 @@ from collections import defaultdict, deque
 from linecache import cache as line_cache
 
 from pymtl3.datatypes import *
-from pymtl3.datatypes.helpers import _get_bitstruct_inst_all_classes
+from pymtl3.datatypes.helpers import get_bitstruct_inst_all_classes
 from pymtl3.dsl import *
 from pymtl3.dsl.errors import LeftoverPlaceholderError
 
@@ -102,7 +102,7 @@ class GenDAGPass( BasePass ):
       _globals = {'s': wr_lca }
 
       if isinstance( writer, Const ) and type(writer._dsl.const) is not int:
-        types = _get_bitstruct_inst_all_classes( writer._dsl.const )
+        types = get_bitstruct_inst_all_classes( writer._dsl.const )
 
         for t in types:
           if t.__name__ in _globals:

--- a/pymtl3/passes/GenDAGPass.py
+++ b/pymtl3/passes/GenDAGPass.py
@@ -48,6 +48,10 @@ class GenDAGPass( BasePass ):
     # top._dag.genblk_src     = {}
 
     # Fall back to compiling one block at a time
+    # This is currently because there might be different structs with
+    # the same name but essentially different type. It requires name
+    # disambiguation to let them co-exist in closure. With block-by-block
+    # compilation, we minimize the effect.
 
     # TODO see if directly compiling AST instead of source can be faster
     def compile_net_blk( _globals, src ):

--- a/pymtl3/passes/GenDAGPass.py
+++ b/pymtl3/passes/GenDAGPass.py
@@ -12,6 +12,7 @@ from collections import defaultdict, deque
 from linecache import cache as line_cache
 
 from pymtl3.datatypes import *
+from pymtl3.datatypes.helpers import _get_bitstruct_inst_all_classes
 from pymtl3.dsl import *
 from pymtl3.dsl.errors import LeftoverPlaceholderError
 
@@ -46,19 +47,15 @@ class GenDAGPass( BasePass ):
     top._dag.genblk_writes  = {}
     # top._dag.genblk_src     = {}
 
-    # To reduce the time to compile update blocks, I first group the list
-    # of update blocks that have the same host object together and fire
-    # them in a single compile command.
+    # Fall back to compiling one block at a time
 
-    # Note that it introduced problems with multiple update blocks having
-    # the same const writer at the same hostobj. As a result, I add a
-    # suffix to each block like Bits1_xxx_no_12, Bits1_xxx_no_13 to
-    # disambiguate the blocks
-
-    hostobj_allsrc = defaultdict(str)
-    hostobj_bits   = defaultdict(set)
-    blkname_meta   = {}
-    blkname_suffix = {}
+    # TODO see if directly compiling AST instead of source can be faster
+    def compile_net_blk( _globals, src ):
+      _locals = {}
+      fname = f"Net at {_globals['s']!r}"
+      exec( compile( src, filename=fname, mode="exec"), _globals, _locals )
+      line_cache[ fname ] = (len(src), None, src.splitlines(), fname )
+      return list(_locals.values())[0]
 
     for writer, signals in top.get_all_value_nets():
       if len(signals) == 1:
@@ -102,13 +99,17 @@ class GenDAGPass( BasePass ):
           rd_lcas[i] = rd_lcas[i].get_parent_object()
 
       lca_len = len( repr(wr_lca) )
+      _globals = {'s': wr_lca }
 
-      # hostobj_bits is used to only keep useful Bits in the
-      # closure instead of getting all those garbage in "globals()"
+      if isinstance( writer, Const ) and type(writer._dsl.const) is not int:
+        types = _get_bitstruct_inst_all_classes( writer._dsl.const )
 
-      if isinstance( writer, Const ):
+        for t in types:
+          if t.__name__ in _globals:
+            assert t is _globals[ t.__name__ ], "Cannot handle two subfields with the same struct name but different structs"
+          _globals[ t.__name__ ] = t
         wstr = repr(writer)
-        hostobj_bits[ wr_lca ].add( writer._dsl.Type.__name__ )
+
       else:
         wstr = f"s.{repr(writer)[lca_len+1:]}"
 
@@ -116,54 +117,19 @@ class GenDAGPass( BasePass ):
       upblk_name = f"{writer!r}__{fanout}".replace( " ", "" ) \
                       .replace( ".", "_" ).replace( ":", "_" ) \
                       .replace( "[", "_" ).replace( "]", "_" ) \
-                      .replace( "(", "_" ).replace( ")", "_" )
-
-      # NAME DISAMBIGUATION
-      # There are cases where the same const drives multiple nets. We
-      # basically add a suffix to name each of them differently.
-
-      if upblk_name in blkname_meta:
-        if upblk_name in blkname_suffix:
-          current = blkname_suffix[ upblk_name ]
-        else:
-          current = 1
-        blkname_suffix[ upblk_name ] = current + 1
-        upblk_name += f"_no_{current}"
+                      .replace( "(", "_" ).replace( ")", "_" ) \
+                      .replace( ",", "_" )
 
       gen_src = """
-  def {}():
-    {} = {}""".format( upblk_name, " = ".join( rstrs ), wstr )
-      hostobj_allsrc[ wr_lca ] += gen_src
-      blkname_meta[ upblk_name ] = (writer, readers)
+def {}():
+  {} = {}""".format( upblk_name, " = ".join( rstrs ), wstr )
 
-    # TODO see if directly compiling AST instead of source can be faster
+      blk = compile_net_blk( _globals, gen_src )
 
-    for hostobj, allsrc in hostobj_allsrc.items():
-      if hostobj in hostobj_bits:
-        bits_import_src = f"from pymtl3.datatypes import {','.join( hostobj_bits[hostobj] )}"
-      else:
-        bits_import_src = ""
-      src = """
-{}
-def compile_upblks( s ):
-  {}
-  return locals()
-""".format( bits_import_src, allsrc )
-
-      fname = f"Generated net at {hostobj!r}"
-      l = {}
-      exec( compile( src, filename=fname, mode="exec"), l )
-      line_cache[ fname ] = (len(src), None, src.splitlines(), fname )
-
-      ret = l[f'compile_upblks']( hostobj )
-
-      for name, blk in ret.items():
-        if name != 's':
-          top._dag.genblks.add( blk )
-          writer, readers = blkname_meta[ name ]
-          if writer.is_signal():
-            top._dag.genblk_reads[ blk ] = [ writer ]
-          top._dag.genblk_writes[ blk ] = readers
+      top._dag.genblks.add( blk )
+      if writer.is_signal():
+        top._dag.genblk_reads[ blk ] = [ writer ]
+      top._dag.genblk_writes[ blk ] = readers
 
     # Get the final list of update blocks
     top._dag.final_upblks = top.get_all_update_blocks() | top._dag.genblks

--- a/pymtl3/passes/test/DynamicSchedulePass_test.py
+++ b/pymtl3/passes/test/DynamicSchedulePass_test.py
@@ -5,7 +5,7 @@
 # Author : Shunning Jiang
 # Date   : Apr 19, 2019
 
-from pymtl3.datatypes import Bits32, bitstruct, Bits8
+from pymtl3.datatypes import Bits8, Bits32, bitstruct
 from pymtl3.dsl import *
 from pymtl3.dsl.errors import UpblkCyclicError
 from pymtl3.passes.DynamicSchedulePass import DynamicSchedulePass

--- a/pymtl3/passes/yosys/translation/structural/YosysStructuralTranslatorL1.py
+++ b/pymtl3/passes/yosys/translation/structural/YosysStructuralTranslatorL1.py
@@ -253,7 +253,8 @@ class YosysStructuralTranslatorL1( SVStructuralTranslatorL1 ):
     s.deq.append( {'attr':[], 'index':[], 's_attr':"", 's_index':""} )
     return ''
 
-  def rtlir_tr_literal_number( s, nbits, value ):
+  def rtlir_tr_literal_number( s, nbits, value, first_called = True ):
     num_str = s._literal_number( nbits, value )
-    s.deq.append( {'attr':[], 'index':[], 's_attr':num_str, 's_index':""} )
+    if first_called:
+      s.deq.append( {'attr':[], 'index':[], 's_attr':num_str, 's_index':""} )
     return num_str

--- a/pymtl3/passes/yosys/translation/test/YosysTranslator_L2_cases_test.py
+++ b/pymtl3/passes/yosys/translation/test/YosysTranslator_L2_cases_test.py
@@ -31,6 +31,7 @@ from pymtl3.passes.sverilog.translation.test.SVTranslator_L2_cases_test import (
     test_struct,
     test_struct_packed_array,
     test_struct_port,
+    test_struct_uniqueness,
     test_tmpvar,
 )
 from pymtl3.passes.yosys.translation.YosysTranslator import YosysTranslator

--- a/pymtl3/passes/yosys/translation/test/YosysTranslator_L2_cases_test.py
+++ b/pymtl3/passes/yosys/translation/test/YosysTranslator_L2_cases_test.py
@@ -10,6 +10,7 @@ from pymtl3.passes.sverilog.translation.structural.test.SVStructuralTranslatorL1
     check_eq,
 )
 from pymtl3.passes.sverilog.translation.test.SVTranslator_L2_cases_test import (
+    test_const_struct,
     test_for_range_lower_upper,
     test_for_range_lower_upper_step,
     test_for_range_upper,
@@ -21,6 +22,7 @@ from pymtl3.passes.sverilog.translation.test.SVTranslator_L2_cases_test import (
     test_if_exp_for,
     test_if_exp_unary_op,
     test_lambda_connect,
+    test_long_component_name,
     test_nested_if,
     test_nested_struct,
     test_nested_struct_port,


### PR DESCRIPTION
This PR implements connecting a signal to a constant bitstruct. Basically I use repr(x) as the writer when generating connection block. Note that repr(x) cannot disambiguate A.X and B.X because they all look like X(Bits4(2)). I throw an error for this case. Otherwise it's good to go.

I also added tests for pymtl3.datatypes.helpers

@ptpan can you also add some translation tests based on the added tests in ComponentLevel_test.py