### PR TITLE
Add default argument Bits1 to Signal (Wire,InPort,OutPort)

### DIFF
--- a/pymtl3/dsl/Connectable.py
+++ b/pymtl3/dsl/Connectable.py
@@ -10,7 +10,7 @@ Date   : Apr 16, 2018
 import types
 from collections import deque
 
-from pymtl3.datatypes import Bits, mk_bits
+from pymtl3.datatypes import Bits, Bits1, mk_bits
 
 from .errors import InvalidConnectionError
 from .NamedObject import DSLMetadata, NamedObject
@@ -141,7 +141,7 @@ class Const( Connectable ):
 
 class Signal( NamedObject, Connectable ):
 
-  def __init__( s, Type ):
+  def __init__( s, Type=Bits1 ):
     assert isinstance( Type, type ), "Use actual type instead of instance!"
     s._dsl.Type = Type
     s._dsl.type_instance = None

--- a/pymtl3/dsl/test/ComponentLevel2_test.py
+++ b/pymtl3/dsl/test/ComponentLevel2_test.py
@@ -8,7 +8,7 @@ Date   : Nov 3, 2018
 """
 from collections import deque
 
-from pymtl3.datatypes import Bits32, bitstruct, mk_bits
+from pymtl3.datatypes import Bits1, Bits32, bitstruct, mk_bits
 from pymtl3.dsl.ComponentLevel2 import ComponentLevel2
 from pymtl3.dsl.Connectable import InPort, OutPort, Wire
 from pymtl3.dsl.ConstraintTypes import RD, WR, U
@@ -702,3 +702,18 @@ def test_var_written_in_both_ff_and_up():
     print("{} is thrown\n{}".format( e.__class__.__name__, e ))
     return
   raise Exception("Should've thrown MultiWriterError.")
+
+def test_signal_default_Bits1():
+
+  class Top(ComponentLevel2):
+
+    def construct( s ):
+      s.x0 = Wire()
+      s.x1 = InPort()
+      s.x2 = OutPort()
+      assert s.x0._dsl.Type == Bits1
+      assert s.x1._dsl.Type == Bits1
+      assert s.x2._dsl.Type == Bits1
+
+  A = Top()
+  A.elaborate()


### PR DESCRIPTION
As per @cbatten suggested, this can be a really nice syntactic sugar when people model net-list-level stuff.

This test shows an example https://github.com/cornell-brg/pymtl3/commit/b7d58e7b1ca4045e9e9306dca8b836523a94b9cc#diff-93f90fe9147a2c1bc54ad23e9e2732fdR710