### PR TITLE
eval comb and schedule pass refactoring

### DIFF
--- a/examples/ex01_basics/IncrMethodModular_test.py
+++ b/examples/ex01_basics/IncrMethodModular_test.py
@@ -114,7 +114,7 @@ def test_method_modular():
 
   # Print out the update block schedule.
   print( "\n==== Schedule ====" )
-  for blk in tb._sched.schedule:
+  for blk in tb._sched.update_schedule:
     if not blk.__name__.startswith('s'):
       print( blk.__name__ )
 

--- a/examples/ex01_basics/IncrMethodPorts_test.py
+++ b/examples/ex01_basics/IncrMethodPorts_test.py
@@ -97,7 +97,7 @@ def test_method_ports():
 
   # Print out the update block schedule.
   print( "\n==== Schedule ====" )
-  for blk in incr._sched.schedule:
+  for blk in incr._sched.update_schedule:
     if not blk.__name__.startswith('s'):
       print( blk.__name__ )
 

--- a/examples/ex01_basics/IncrPyObjs_test.py
+++ b/examples/ex01_basics/IncrPyObjs_test.py
@@ -96,7 +96,7 @@ def test_py_objs():
 
   # Print out the update block schedule.
   print( "\n==== Schedule ====" )
-  for blk in incr._sched.schedule:
+  for blk in incr._sched.update_schedule:
     if not blk.__name__.startswith('s'):
       print( blk.__name__ )
 

--- a/examples/ex01_basics/IncrPyVars_test.py
+++ b/examples/ex01_basics/IncrPyVars_test.py
@@ -79,7 +79,7 @@ def test_py_vars():
 
   # Print out the update block schedule.
   print( "\n==== Schedule ====" )
-  for blk in incr._sched.schedule:
+  for blk in incr._sched.update_schedule:
     if not blk.__name__.startswith('s'):
       print( blk.__name__ )
 

--- a/examples/ex01_basics/IncrValueModular_test.py
+++ b/examples/ex01_basics/IncrValueModular_test.py
@@ -91,7 +91,7 @@ def test_value_modular():
 
   # Print out the update block schedule.
   print( "\n==== Schedule ====" )
-  for blk in tb._sched.schedule:
+  for blk in tb._sched.update_schedule:
     if not blk.__name__.startswith('s'):
       print( blk.__name__ )
 

--- a/examples/ex01_basics/IncrWires_test.py
+++ b/examples/ex01_basics/IncrWires_test.py
@@ -68,7 +68,7 @@ def test_wires():
 
   # Print out the update block schedule.
   print( "\n==== Schedule ====" )
-  for blk in incr._sched.schedule:
+  for blk in incr._sched.update_schedule:
     if not blk.__name__.startswith('s'):
       print( blk.__name__ )
 

--- a/examples/ex02_cksum/test/ChecksumRTL_test.py
+++ b/examples/ex02_cksum/test/ChecksumRTL_test.py
@@ -54,16 +54,19 @@ def checksum_rtl( words ):
   dut.send.rdy = b1(1)
   while not dut.recv.rdy:
     dut.recv.en = b1(0)
+    dut.eval_combinational()
     dut.tick()
 
   # Feed in the input
   dut.recv.en = b1(1)
   dut.recv.msg = bits_in
+  dut.eval_combinational()
   dut.tick()
 
   # Wait until the checksum unit is about to send the message
   while not dut.send.en:
     dut.recv.en = b1(0)
+    dut.eval_combinational()
     dut.tick()
 
   # Return the result

--- a/pymtl3/datatypes/helpers.py
+++ b/pymtl3/datatypes/helpers.py
@@ -81,6 +81,8 @@ def to_bits( obj ):
   # BitsN
   if isinstance( obj, Bits ):
     return obj
+
+  assert not isinstance( obj, int ), f"{obj} is an integer, not Bits or Bitstruct."
   # BitStruct
   assert is_bitstruct_inst( obj ), f"{obj} is not a valid PyMTL Bitstruct!"
   return concat( *[ to_bits(getattr(obj, v)) for v in obj.__bitstruct_fields__.keys() ] )

--- a/pymtl3/passes/PassGroups.py
+++ b/pymtl3/passes/PassGroups.py
@@ -50,7 +50,5 @@ class AutoTickSimPass( BasePass ):
     top.elaborate()
     GenDAGPass(),
     WrapGreenletPass()( top )
-    CLLineTracePass()( top )
-    VcdGenerationPass()( top )
     OpenLoopCLPass(), # Inject this pass to build infrastructure
     top.lock_in_simulation()

--- a/pymtl3/passes/autotick/OpenLoopCLPass.py
+++ b/pymtl3/passes/autotick/OpenLoopCLPass.py
@@ -10,10 +10,13 @@
 """
 from pymtl3.dsl import CalleePort, NonBlockingCalleeIfc
 from pymtl3.dsl.errors import UpblkCyclicError
-from pymtl3.passes.BasePass import BasePass, PassMetadata
-from pymtl3.passes.errors import PassOrderError
-from pymtl3.passes.sim.SimpleSchedulePass import SimpleSchedulePass
-from pymtl3.passes.tracing.CLLineTracePass import CLLineTracePass
+from ..BasePass import BasePass, PassMetadata
+from ..errors import PassOrderError
+from ..sim.SimpleSchedulePass import SimpleSchedulePass
+from ..tracing.CLLineTracePass import CLLineTracePass
+from ..tracing.CollectSignalPass import CollectSignalPass
+from ..tracing.PrintWavePass import PrintWavePass
+from ..tracing.VcdGenerationPass import VcdGenerationPass
 
 
 class OpenLoopCLPass( BasePass ):

--- a/pymtl3/passes/autotick/OpenLoopCLPass.py
+++ b/pymtl3/passes/autotick/OpenLoopCLPass.py
@@ -12,7 +12,7 @@ from pymtl3.dsl import CalleePort, NonBlockingCalleeIfc
 from pymtl3.dsl.errors import UpblkCyclicError
 from pymtl3.passes.BasePass import BasePass, PassMetadata
 from pymtl3.passes.errors import PassOrderError
-from pymtl3.passes.sim.SimpleSchedulePass import make_double_buffer_func
+from pymtl3.passes.sim.SimpleSchedulePass import SimpleSchedulePass
 from pymtl3.passes.tracing.CLLineTracePass import CLLineTracePass
 
 
@@ -117,15 +117,29 @@ class OpenLoopCLPass( BasePass ):
         if not InD[v]:
           Q.append( v )
 
-    # Shunning: we call CL line trace pass here.
-    cl_trace = CLLineTracePass()
-    schedule.insert( 0, cl_trace.process_component( top ) )
+    # Shunning: we call line trace related pass here.
+    CLLineTracePass()( top )
+    CollectSignalPass()( top )
+    VcdGenerationPass()( top )
+    PrintWavePass()( top )
+    # Shunning: we reuse ff and posedge schedules from SimpleSchedulePass
+    simple = SimpleSchedulePass()
+    simple.schedule_ff( top )
+    simple.schedule_posedge_flip( top )
 
-    # Sequential blocks and double buffering
-    schedule.extend( list(top._dsl.all_update_ff) )
-    func = make_double_buffer_func( top )
-    if func is not None:
-      schedule.append( func )
+    # clear trace before any update block
+    schedule.insert( 0, top._tracing.clear_cl_trace )
+
+    # call ff blocks after normal schedule
+    schedule.extend( top._sched.schedule_ff )
+
+    # work on tracing
+    if hasattr( top._tracing, "vcd_func" ):
+      schedule.append( top._tracing.vcd_func )
+    if hasattr( top._tracing, "collect_text_sigs" ):
+      schedule.append( top._tracing.collect_text_sigs )
+
+    schedule.extend( top._sched.schedule_posedge_flip )
 
     top._sched.new_schedule_index  = 0
     top._sched.orig_schedule_index = 0

--- a/pymtl3/passes/autotick/OpenLoopCLPass.py
+++ b/pymtl3/passes/autotick/OpenLoopCLPass.py
@@ -10,6 +10,7 @@
 """
 from pymtl3.dsl import CalleePort, NonBlockingCalleeIfc
 from pymtl3.dsl.errors import UpblkCyclicError
+
 from ..BasePass import BasePass, PassMetadata
 from ..errors import PassOrderError
 from ..sim.SimpleSchedulePass import SimpleSchedulePass

--- a/pymtl3/passes/autotick/test/OpenLoopCLPass_test.py
+++ b/pymtl3/passes/autotick/test/OpenLoopCLPass_test.py
@@ -10,11 +10,12 @@ from pymtl3.datatypes import Bits32
 from pymtl3.dsl import *
 from pymtl3.dsl.errors import UpblkCyclicError
 from pymtl3.passes.sim.GenDAGPass import GenDAGPass
+from pymtl3.passes import TracingConfigs
 
 from ..OpenLoopCLPass import OpenLoopCLPass
 
 
-def test_top_level_method():
+def test_top_level_method_tracing():
 
   class Top(Component):
 
@@ -40,7 +41,7 @@ def test_top_level_method():
           s.value = s.amp + s.element
           s.element = None
         else:
-          s.value = -1
+          s.value = Bits32( -1 )
 
       s.add_constraints(
         M( s.push ) < U( up_compose_in ),
@@ -64,6 +65,10 @@ def test_top_level_method():
 
   A = Top()
   A.elaborate()
+
+  # Turn on textwave
+  A.config_tracing = TracingConfigs( tracing='text_fancy' )
+
   A.apply( GenDAGPass() )
   A.apply( OpenLoopCLPass() )
   A.lock_in_simulation()
@@ -84,6 +89,7 @@ def test_top_level_method():
   print(A.pull())
 
   print("num_cycles_executed: ", A.num_cycles_executed)
+  A.print_textwave()
 
 class TestModuleNonBlockingIfc(Component):
 

--- a/pymtl3/passes/autotick/test/OpenLoopCLPass_test.py
+++ b/pymtl3/passes/autotick/test/OpenLoopCLPass_test.py
@@ -9,8 +9,8 @@
 from pymtl3.datatypes import Bits32
 from pymtl3.dsl import *
 from pymtl3.dsl.errors import UpblkCyclicError
-from pymtl3.passes.sim.GenDAGPass import GenDAGPass
 from pymtl3.passes import TracingConfigs
+from pymtl3.passes.sim.GenDAGPass import GenDAGPass
 
 from ..OpenLoopCLPass import OpenLoopCLPass
 

--- a/pymtl3/passes/mamba/HeuristicTopoPass.py
+++ b/pymtl3/passes/mamba/HeuristicTopoPass.py
@@ -12,8 +12,9 @@ from queue import PriorityQueue
 
 from ..BasePass import BasePass, PassMetadata
 from ..errors import PassOrderError
-from ..sim.SimpleSchedulePass import check_schedule
+from ..sim.SimpleSchedulePass import SimpleSchedulePass, check_schedule
 
+# FIXME also apply branchiness to all update_ff blocks
 
 class CountBranches( ast.NodeVisitor ):
 
@@ -56,20 +57,27 @@ class HeuristicTopoPass( BasePass ):
 
     top._sched = PassMetadata()
 
-    top._sched.schedule = self.schedule( top )
+    self.schedule_intra_cycle( top )
 
-  def schedule( self, top ):
+    # Reuse simple's ff and flip schedule
+    simple = SimpleSchedulePass()
+    simple.schedule_ff( top )
+    simple.schedule_posedge_flip( top )
 
-    # Construct the graph
+  def schedule_intra_cycle( self, top ):
 
-    V   = top._dag.final_upblks
-    E   = top._dag.all_constraints
+    # Construct the intra-cycle graph based on normal update blocks
+
+    V   = top._dag.final_upblks - top.get_all_update_ff()
+    E   = set()
     Es  = { v: [] for v in V }
     InD = { v: 0  for v in V }
 
-    for (u, v) in E: # u -> v
-      InD[v] += 1
-      Es [u].append( v )
+    for (u, v) in top._dag.all_constraints: # u -> v
+      if u in V and v in V:
+        InD[v] += 1
+        Es[u].append( v )
+        E.add( (u, v) )
 
     # Extract branchiness
 
@@ -85,7 +93,7 @@ class HeuristicTopoPass( BasePass ):
     # Note that here we use a priority queue to get the blocks with small
     # branchiness as early as possible
 
-    schedule = []
+    top._sched.update_schedule = update_schedule = []
 
     # Python3 doesn't have hash for functions
     id_v = { id(v): v for v in V}
@@ -97,12 +105,10 @@ class HeuristicTopoPass( BasePass ):
 
     while not Q.empty():
       br, u = Q.get()
-      schedule.append( id_v[u] )
+      update_schedule.append( id_v[u] )
       for v in Es[id_v[u]]:
         InD[v] -= 1
         if not InD[v]:
           Q.put( (branchiness[ v ], id(v)) )
 
-    check_schedule( top, schedule, V, E, InD )
-
-    return schedule
+    check_schedule( top, update_schedule, V, E, InD )

--- a/pymtl3/passes/mamba/UnrollTickPass.py
+++ b/pymtl3/passes/mamba/UnrollTickPass.py
@@ -12,6 +12,7 @@ import py
 
 from pymtl3.passes.BasePass import BasePass
 from pymtl3.passes.errors import PassOrderError
+from pymtl3.passes.sim.SimpleTickPass import SimpleTickPass
 
 
 class UnrollTickPass( BasePass ):
@@ -40,13 +41,31 @@ class UnrollTickPass( BasePass ):
     return l['compile_unroll']( schedule )
 
   def __call__( self, top ):
-    if not hasattr( top._sched, "schedule" ):
-      raise PassOrderError( "schedule" )
+    if not hasattr( top, "_sched" ):
+      raise PassOrderError( "_sched" )
+    if not hasattr( top._sched, "update_schedule" ):
+      raise PassOrderError( "update_schedule" )
+    if not hasattr( top._sched, "schedule_ff" ):
+      raise PassOrderError( "schedule_ff" )
+    if not hasattr( top._sched, "schedule_posedge_flip" ):
+      raise PassOrderError( "schedule_posedge_flip" )
 
-    if hasattr( top, "_cl_trace" ):
-      schedule = top._cl_trace.schedule
-    else:
-      schedule = top._sched.schedule
+    # We assemble the final schedule from multiple sources of required
+    # work to generate a tick function for simulation
 
+    # Currently the tick order is:
+    # [ ff, tracing, posedge, clear_cl_trace, update ]
 
-    top.tick = UnrollTickPass.gen_tick_function( schedule )
+    final_schedule = []
+    # call ff blocks first
+    final_schedule.extend( top._sched.schedule_ff )
+
+    # no tracing
+
+    # posedge flip
+    final_schedule.extend( top._sched.schedule_posedge_flip )
+
+    # execute all update blocks
+    final_schedule.extend( top._sched.update_schedule )
+
+    top.tick = UnrollTickPass.gen_tick_function( final_schedule )

--- a/pymtl3/passes/mamba/test/TraceBreakingSim_test.py
+++ b/pymtl3/passes/mamba/test/TraceBreakingSim_test.py
@@ -1,3 +1,4 @@
+from pymtl3.datatypes import Bits32
 from pymtl3.dsl import *
 
 from ..PassGroups import TraceBreakingSim
@@ -7,8 +8,8 @@ def test_very_deep_dag():
 
   class Inner(Component):
     def construct( s ):
-      s.in_ = InPort(int)
-      s.out = OutPort(int)
+      s.in_ = InPort(Bits32)
+      s.out = OutPort(Bits32)
 
       @s.update
       def up():
@@ -26,10 +27,19 @@ def test_very_deep_dag():
       for i in range(N-1):
         s.inners[i].out //= s.inners[i+1].in_
 
-    def line_trace( s ):
-      return str(s.inners[-1].out)
+      s.out = OutPort(Bits32)
+      @s.update_ff
+      def ff():
+        if s.reset:
+          s.out <<= 0
+        else:
+          s.out <<= s.out + s.inners[N-1].out
 
-  A = Top()
+    def line_trace( s ):
+      return str(s.inners[-1].out) + " " + str(s.out)
+
+  N = 2000
+  A = Top( N )
 
   A.apply( TraceBreakingSim() )
 
@@ -37,5 +47,6 @@ def test_very_deep_dag():
   while T < 5:
     A.tick()
     print(A.line_trace())
+    assert A.out == T * N
     T += 1
   return A

--- a/pymtl3/passes/mamba/test/UnrollSim_test.py
+++ b/pymtl3/passes/mamba/test/UnrollSim_test.py
@@ -1,3 +1,4 @@
+from pymtl3.datatypes import Bits32
 from pymtl3.dsl import *
 
 from ..PassGroups import UnrollSim
@@ -7,8 +8,8 @@ def test_very_deep_dag():
 
   class Inner(Component):
     def construct( s ):
-      s.in_ = InPort(int)
-      s.out = OutPort(int)
+      s.in_ = InPort(Bits32)
+      s.out = OutPort(Bits32)
 
       @s.update
       def up():
@@ -26,10 +27,19 @@ def test_very_deep_dag():
       for i in range(N-1):
         s.inners[i].out //= s.inners[i+1].in_
 
-    def line_trace( s ):
-      return str(s.inners[-1].out)
+      s.out = OutPort(Bits32)
+      @s.update_ff
+      def ff():
+        if s.reset:
+          s.out <<= 0
+        else:
+          s.out <<= s.out + s.inners[N-1].out
 
-  A = Top()
+    def line_trace( s ):
+      return str(s.inners[-1].out) + " " + str(s.out)
+
+  N = 2000
+  A = Top( N )
 
   A.apply( UnrollSim() )
 
@@ -37,5 +47,6 @@ def test_very_deep_dag():
   while T < 5:
     A.tick()
     print(A.line_trace())
+    assert A.out == T * N
     T += 1
   return A

--- a/pymtl3/passes/sim/DynamicSchedulePass.py
+++ b/pymtl3/passes/sim/DynamicSchedulePass.py
@@ -14,7 +14,7 @@ import py
 from pymtl3.passes.BasePass import BasePass, PassMetadata
 from pymtl3.passes.errors import PassOrderError
 
-from .SimpleSchedulePass import dump_dag, make_double_buffer_func
+from .SimpleSchedulePass import dump_dag, SimpleSchedulePass
 from .SimpleTickPass import SimpleTickPass
 
 
@@ -23,25 +23,36 @@ class DynamicSchedulePass( BasePass ):
     if not hasattr( top._dag, "all_constraints" ):
       raise PassOrderError( "all_constraints" )
 
+    if hasattr( top, "_sched" ):
+      raise Exception("Some schedule pass has already been applied!")
+
     top._sched = PassMetadata()
 
-    top._sched.schedule = self.schedule( top )
+    self.schedule_intra_cycle( top )
 
-  def schedule( self, top ):
+    # Reuse simple's ff and flip schedule
+    simple = SimpleSchedulePass()
+    simple.schedule_ff( top )
+    simple.schedule_posedge_flip( top )
 
-    # Construct the graph
+  def schedule_intra_cycle( self, top ):
+
+    # Construct the intra-cycle graph based on normal update blocks
 
     V   = top._dag.final_upblks - top.get_all_update_ff()
-    E   = top._dag.all_constraints
+
     G   = { v: [] for v in V }
     G_T = { v: [] for v in V } # transpose graph
 
+    E = set()
+    for (u, v) in top._dag.all_constraints: # u -> v
+      if u in V and v in V:
+        G  [u].append( v )
+        G_T[v].append( u )
+        E.add( (u, v) )
+
     if 'MAMBA_DAG' in os.environ:
       dump_dag( top, V, E )
-
-    for (u, v) in E: # u -> v
-      G  [u].append( v )
-      G_T[v].append( u )
 
     #---------------------------------------------------------------------
     # Run Kosaraju's algorithm to shrink all strongly connected components
@@ -162,10 +173,8 @@ class DynamicSchedulePass( BasePass ):
 
     constraint_objs = top._dag.constraint_objs
 
-    # From now on, we put the schedule in the order of
-    # [ flip, normal upblks, update_ffs ]
-
-    schedule = [ make_double_buffer_func( top ) ]
+    # Put the graph schedule to _sched
+    top._sched.update_schedule = schedule = []
 
     scc_id = 0
     for i in scc_schedule:
@@ -271,7 +280,3 @@ class DynamicSchedulePass( BasePass ):
                                          ", ".join( [ x.__name__ for x in scc] ) )
                                          # "; ".join( print_srcs ) )
         schedule.append( gen_wrapped_SCCblk( top, tmp_schedule, scc_block_src ) )
-
-    schedule.extend( list(top._dsl.all_update_ff) )
-
-    return schedule

--- a/pymtl3/passes/sim/DynamicSchedulePass.py
+++ b/pymtl3/passes/sim/DynamicSchedulePass.py
@@ -14,7 +14,7 @@ import py
 from pymtl3.passes.BasePass import BasePass, PassMetadata
 from pymtl3.passes.errors import PassOrderError
 
-from .SimpleSchedulePass import dump_dag, SimpleSchedulePass
+from .SimpleSchedulePass import SimpleSchedulePass, dump_dag
 from .SimpleTickPass import SimpleTickPass
 
 

--- a/pymtl3/passes/sim/GenDAGPass.py
+++ b/pymtl3/passes/sim/GenDAGPass.py
@@ -239,9 +239,9 @@ def {}():
           if wr_blk not in update_ff:
             for rd_blk in rd_blks:
               if wr_blk != rd_blk:
-                if rd_blk not in update_ff:
-                  impl_constraints.add( (wr_blk, rd_blk) ) # wr < rd default
-                  constraint_objs[ (wr_blk, rd_blk) ].add( obj )
+                # if rd_blk not in update_ff:
+                impl_constraints.add( (wr_blk, rd_blk) ) # wr < rd default
+                constraint_objs[ (wr_blk, rd_blk) ].add( obj )
 
     # Collect all objs that read the variable whose id is "write"
     # 1) WR A.b.b.b, A.b.b, A.b, A (detect 2-writer conflict)
@@ -266,9 +266,9 @@ def {}():
           for reader in readers:
               for rd_blk in read_upblks[ reader ]:
                 if wr_blk != rd_blk:
-                  if rd_blk not in update_ff:
-                    impl_constraints.add( (wr_blk, rd_blk) ) # wr < rd default
-                    constraint_objs[ (wr_blk, rd_blk) ].add( obj )
+                  # if rd_blk not in update_ff:
+                  impl_constraints.add( (wr_blk, rd_blk) ) # wr < rd default
+                  constraint_objs[ (wr_blk, rd_blk) ].add( obj )
 
     top._dag.constraint_objs = constraint_objs
     top._dag.all_constraints = { *U_U }

--- a/pymtl3/passes/sim/SimpleSchedulePass.py
+++ b/pymtl3/passes/sim/SimpleSchedulePass.py
@@ -16,71 +16,6 @@ from pymtl3.passes.BasePass import BasePass, PassMetadata
 from pymtl3.passes.errors import PassOrderError
 
 
-def make_double_buffer_func( s ):
-
-  # To reduce the time to compile the code and the amount of bytecode, I
-  # use a heuristic to group signals that belong to
-  #   s.x.y.z._flip()
-  #   s.x.y.zz._flip()
-  # becomes
-  #   x = s.x.y
-  #   x.z._flip()
-  #   x.zz._flip()
-
-  hostobj_signals = defaultdict(list)
-  for x in reversed(sorted( s._dsl.all_signals, \
-      key=lambda x: x.get_host_component().get_component_level() )):
-    if x._dsl.needs_double_buffer:
-      hostobj_signals[ x.get_host_component() ].append( x )
-
-  done = False
-  while not done:
-    next_hostobj_signals = defaultdict(list)
-    done = True
-
-    for x, y in hostobj_signals.items():
-      if len(y) > 1:
-        next_hostobj_signals[x].extend( y )
-      elif x is s:
-        next_hostobj_signals[x].extend( y )
-      else:
-        x = x.get_parent_object()
-        next_hostobj_signals[x].append( y[0] )
-        done = False
-    hostobj_signals = next_hostobj_signals
-
-  strs = []
-  for x,y in hostobj_signals.items():
-    if len(y) == 1:
-      strs.append( f"{repr(y[0])}._flip()" )
-    elif x is s:
-      for z in sorted(y, key=repr):
-        strs.append(f"{repr(z)}._flip()")
-    else:
-      pos = len(repr(x)) + 1
-      strs.append( f"x = {repr(x)}" )
-
-      for z in sorted(y, key=repr):
-        strs.append(f"x.{repr(z)[pos:]}._flip()")
-
-  if not strs:
-    def no_double_buffer():
-      pass
-    return no_double_buffer
-
-  src = """
-  def compile_double_buffer( s ):
-    def double_buffer():
-      {}
-    return double_buffer
-  """.format( "\n      ".join(strs) )
-
-  import py
-  # print(src)
-  l = locals()
-  exec(py.code.Source( src ).compile(), l)
-  return l['compile_double_buffer']( s )
-
 class SimpleSchedulePass( BasePass ):
   def __call__( self, top ):
     if not hasattr( top._dag, "all_constraints" ):
@@ -88,13 +23,18 @@ class SimpleSchedulePass( BasePass ):
 
     top._sched = PassMetadata()
 
-    top._sched.schedule = self.schedule( top )
+    self.schedule_intra_cycle( top )
+    self.schedule_ff( top )
+    self.schedule_posedge_flip( top )
 
-  def schedule( self, top ):
+  def schedule_intra_cycle( self, top ):
+
+    if not hasattr( top, "_sched" ):
+      raise Exception( "Please create top._sched pass metadata namespace first!" )
 
     # Construct the graph
 
-    V   = top._dag.final_upblks - top.get_all_update_ff()
+    V   = top._dag.final_upblks - top._dag.all_update_ff
     E   = top._dag.all_constraints
     Es  = { v: [] for v in V }
     InD = { v: 0  for v in V }
@@ -109,7 +49,7 @@ class SimpleSchedulePass( BasePass ):
 
     # Perform topological sort for a serial schedule.
 
-    update_schedule = []
+    top._sched.update_schedule = update_schedule = []
 
     Q = [ v for v in V if not InD[v] ]
 
@@ -125,14 +65,80 @@ class SimpleSchedulePass( BasePass ):
 
     check_schedule( top, update_schedule, V, E, InD )
 
-    # From now on, we put the schedule in the order of
-    # [ flip, normal upblks, update_ffs ]
+  def schedule_ff( self, top ):
 
-    schedule = [ make_double_buffer_func( top ) ]
-    schedule.extend( update_schedule )
-    schedule.extend( top._dsl.all_update_ff )
+    if not hasattr( top, "_sched" ):
+      raise Exception( "Please create top._sched pass metadata namespace first!" )
+    top._sched.schedule_ff = top.get_all_update_ff().copy()
 
-    return schedule
+  def schedule_posedge_flip( self, top ):
+
+    if not hasattr( top, "_sched" ):
+      raise Exception( "Please create top._sched pass metadata namespace first!" )
+
+    # To reduce the time to compile the code and the amount of bytecode, I
+    # use a heuristic to group signals that belong to
+    #   s.x.y.z._flip()
+    #   s.x.y.zz._flip()
+    # becomes
+    #   x = s.x.y
+    #   x.z._flip()
+    #   x.zz._flip()
+
+    hostobj_signals = defaultdict(list)
+    for x in reversed(sorted( top._dsl.all_signals, \
+        key=lambda x: x.get_host_component().get_component_level() )):
+      if x._dsl.needs_double_buffer:
+        hostobj_signals[ x.get_host_component() ].append( x )
+
+    done = False
+    while not done:
+      next_hostobj_signals = defaultdict(list)
+      done = True
+
+      for x, y in hostobj_signals.items():
+        if len(y) > 1:
+          next_hostobj_signals[x].extend( y )
+        elif x is top:
+          next_hostobj_signals[x].extend( y )
+        else:
+          x = x.get_parent_object()
+          next_hostobj_signals[x].append( y[0] )
+          done = False
+      hostobj_signals = next_hostobj_signals
+
+    strs = []
+    for x,y in hostobj_signals.items():
+      if len(y) == 1:
+        strs.append( f"{repr(y[0])}._flip()" )
+      elif x is top:
+        for z in sorted(y, key=repr):
+          strs.append(f"{repr(z)}._flip()")
+      else:
+        pos = len(repr(x)) + 1
+        strs.append( f"x = {repr(x)}" )
+
+        for z in sorted(y, key=repr):
+          strs.append(f"x.{repr(z)[pos:]}._flip()")
+
+    if not strs:
+      def no_double_buffer():
+        pass
+      return no_double_buffer
+
+    src = """
+    def compile_double_buffer( s ):
+      def double_buffer():
+        {}
+      return double_buffer
+    """.format( "\n        ".join(strs) )
+
+    import py
+    # print(src)
+    l = locals()
+    exec(py.code.Source( src ).compile(), l)
+
+    top._sched.schedule_posedge_flip = [ l['compile_double_buffer']( top ) ]
 
 def dump_dag( top, V, E ):
   from graphviz import Digraph
@@ -144,6 +150,8 @@ def dump_dag( top, V, E ):
 
   for x in V:
     x_name = repr(x) if isinstance( x, CalleePort ) else x.__name__
+    if x in top._dsl.all_update_ff:
+      x_name += "_FF"
     try:
       x_host = repr(x.get_parent_object() if isinstance( x, CalleePort )
                     else top.get_update_block_host_component(x))
@@ -153,12 +161,16 @@ def dump_dag( top, V, E ):
 
   for (x, y) in E:
     x_name = repr(x) if isinstance( x, CalleePort ) else x.__name__
+    if x in top._dsl.all_update_ff:
+      x_name += "_FF"
     try:
       x_host = repr(x.get_parent_object() if isinstance( x, CalleePort )
                     else top.get_update_block_host_component(x))
     except:
       x_host = ""
     y_name = repr(y) if isinstance( y, CalleePort ) else y.__name__
+    if y in top._dsl.all_update_ff:
+      y_name += "_FF"
     try:
       y_host = repr(y.get_parent_object() if isinstance( y, CalleePort )
                     else top.get_update_block_host_component(y))

--- a/pymtl3/passes/sim/SimpleSchedulePass.py
+++ b/pymtl3/passes/sim/SimpleSchedulePass.py
@@ -132,7 +132,7 @@ class SimpleSchedulePass( BasePass ):
         def double_buffer():
           {}
         return double_buffer
-      """.format( "\n        ".join(strs) )
+      """.format( "\n          ".join(strs) )
 
       import py
       # print(src)

--- a/pymtl3/passes/sim/SimpleSchedulePass.py
+++ b/pymtl3/passes/sim/SimpleSchedulePass.py
@@ -124,21 +124,22 @@ class SimpleSchedulePass( BasePass ):
     if not strs:
       def no_double_buffer():
         pass
-      return no_double_buffer
+      top._sched.schedule_posedge_flip = [ no_double_buffer ]
 
-    src = """
-    def compile_double_buffer( s ):
-      def double_buffer():
-        {}
-      return double_buffer
-    """.format( "\n        ".join(strs) )
+    else:
+      src = """
+      def compile_double_buffer( s ):
+        def double_buffer():
+          {}
+        return double_buffer
+      """.format( "\n        ".join(strs) )
 
-    import py
-    # print(src)
-    l = locals()
-    exec(py.code.Source( src ).compile(), l)
+      import py
+      # print(src)
+      l = locals()
+      exec(py.code.Source( src ).compile(), l)
 
-    top._sched.schedule_posedge_flip = [ l['compile_double_buffer']( top ) ]
+      top._sched.schedule_posedge_flip = [ l['compile_double_buffer']( top ) ]
 
 def dump_dag( top, V, E ):
   from graphviz import Digraph

--- a/pymtl3/passes/sim/SimpleTickPass.py
+++ b/pymtl3/passes/sim/SimpleTickPass.py
@@ -12,6 +12,12 @@ from pymtl3.dsl.errors import UpblkCyclicError
 from pymtl3.passes.BasePass import BasePass
 from pymtl3.passes.errors import PassOrderError
 
+# Shunning: We are aware of the problem that there may be multiple places
+# that assembles the function for the user to tick the simulator.
+# I think LLVM applies passes based on the order they are inserted to the
+# pass manager. LLVM also has some local ordering mechanism to figure out
+# the dependencies between passes. Currently we haven't got to the point
+# where we have enough passes to manage, but we should keep this in mind.
 
 class SimpleTickPass( BasePass ):
 

--- a/pymtl3/passes/sim/test/DynamicSchedulePass_test.py
+++ b/pymtl3/passes/sim/test/DynamicSchedulePass_test.py
@@ -22,6 +22,7 @@ def _test_model( cls ):
   A.apply( DynamicSchedulePass() )
   A.apply( SimpleTickPass() )
   A.lock_in_simulation()
+  A.eval_combinational()
 
   T = 0
   while T < 5:

--- a/pymtl3/passes/sim/test/SimpleSchedulePass_test.py
+++ b/pymtl3/passes/sim/test/SimpleSchedulePass_test.py
@@ -1,0 +1,241 @@
+#=========================================================================
+# DynamicSchedulePass_test.py
+#=========================================================================
+#
+# Author : Shunning Jiang
+# Date   : Apr 19, 2019
+
+from pymtl3.datatypes import Bits8, Bits32, bitstruct
+from pymtl3.dsl import *
+from pymtl3.dsl.errors import UpblkCyclicError
+
+from ..GenDAGPass import GenDAGPass
+from ..SimpleSchedulePass import SimpleSchedulePass
+from ..SimpleTickPass import SimpleTickPass
+
+
+def _test_model( cls ):
+  A = cls()
+  A.elaborate()
+  A.apply( GenDAGPass() )
+  A.apply( SimpleSchedulePass() )
+  A.apply( SimpleTickPass() )
+  A.lock_in_simulation()
+  A.eval_combinational()
+
+  T = 0
+  while T < 5:
+    A.tick()
+    print(A.line_trace())
+    T += 1
+  return A
+
+# SimpleSchedulePass statically schedules the blocks and hence cannot
+# figure out cyclic dependency that is not actual combinational loops
+
+# disable these tests because I haven't figured out a way to close the
+# pdf viewer ...
+def _test_false_cyclic_dependency():
+
+  class Top(Component):
+
+    def construct( s ):
+      s.a = Wire(int)
+      s.b = Wire(int)
+      s.c = Wire(int)
+      s.d = Wire(int)
+      s.e = Wire(int)
+      s.f = Wire(int)
+      s.g = Wire(int)
+      s.h = Wire(int)
+      s.i = Wire(int)
+      s.j = Wire(int)
+
+      @s.update
+      def up1():
+        s.a = 10 + s.i
+        s.b = s.d + 1
+
+      @s.update
+      def up2():
+        s.c = s.a + 1
+        s.e = s.d + 1
+
+      @s.update
+      def up3():
+        s.d = s.c + 1
+        print("up3 prints out d =", s.d)
+
+      @s.update
+      def up4():
+        s.f = s.d + 1
+
+      @s.update
+      def up5():
+        s.g = s.c + 1
+        s.h = s.j + 1
+        print("up5 prints out h =", s.h)
+
+      @s.update
+      def up6():
+        s.i = s.i + 1
+
+      @s.update
+      def up7():
+        s.j = s.g + 1
+
+    def done( s ):
+      return True
+
+    def line_trace( s ):
+      return "a {} | b {} | c {} | d {} | e {} | f {} | g {} | h {} | i {} | j {}" \
+              .format( s.a, s.b, s.c, s.d, s.e, s.f, s.g, s.h, s.i, s.j )
+
+  try:
+    _test_model( Top )
+  except UpblkCyclicError as e:
+    print("{} is thrown\n{}".format( e.__class__.__name__, e ))
+    return
+  raise Exception("Should've thrown UpblkCyclicError.")
+
+def _test_combinational_loop():
+
+  class Top(Component):
+
+    def construct( s ):
+      s.a = Wire(int)
+      s.b = Wire(int)
+      s.c = Wire(int)
+      s.d = Wire(int)
+
+      @s.update
+      def up1():
+        s.b = s.d + 1
+
+      @s.update
+      def up2():
+        s.c = s.b + 1
+
+      @s.update
+      def up3():
+        s.d = s.c + 1
+        print("up3 prints out d =", s.d)
+
+    def done( s ):
+      return True
+
+    def line_trace( s ):
+      return "a {} | b {} | c {} | d {}" \
+              .format( s.a, s.b, s.c, s.d )
+
+  try:
+    _test_model( Top )
+  except UpblkCyclicError as e:
+    print("{} is thrown\n{}".format( e.__class__.__name__, e ))
+    return
+  raise Exception("Should've thrown UpblkCyclicError.")
+
+def test_very_deep_dag():
+
+  class Inner(Component):
+    def construct( s ):
+      s.in_ = InPort(int)
+      s.out = OutPort(int)
+
+      @s.update
+      def up():
+        s.out = s.in_ + 1
+
+    def done( s ):
+      return True
+
+    def line_trace( s ):
+      return "{} > {}".format( s.a, s.b, s.c, s.d )
+
+  class Top(Component):
+    def construct( s, N=2000 ):
+      s.inners = [ Inner() for i in range(N) ]
+      for i in range(N-1):
+        s.inners[i].out //= s.inners[i+1].in_
+
+    def done( s ):
+      return True
+    def line_trace( s ):
+      return ""
+
+  _test_model( Top )
+
+def test_sequential_break_loop():
+
+  class Top(Component):
+
+    def construct( s ):
+      s.b = Wire( Bits32 )
+      s.c = Wire( Bits32 )
+
+      @s.update
+      def up1():
+        s.b = s.c + 1
+
+      @s.update_ff
+      def up2():
+        if s.reset:
+          s.c <<= 0
+        else:
+          s.c <<= s.b + 1
+
+    def done( s ):
+      return True
+
+    def line_trace( s ):
+      return "b {} | c {}" \
+              .format( s.b, s.c )
+
+  A = _test_model( Top )
+  assert A.c > 5, "Is the sequential behavior actually captured?"
+
+def test_connect_slice_int():
+
+  class Top( Component ):
+    def construct( s ):
+      from pymtl3.datatypes import Bits8, Bits32
+      s.y = OutPort( Bits8 )
+      s.x = Wire( Bits32 )
+
+      s.y //= s.x[0:8]
+      @s.update
+      def sx():
+        s.x = 10 # Except
+
+  try:
+    _test_model( Top )
+  except TypeError as e:
+    assert str(e).startswith( "'int' object is not subscriptable" )
+    return
+  raise Exception("Should've thrown TypeError: 'int' object is not subscriptable")
+
+def test_const_connect_nested_struct_signal_to_struct():
+
+  @bitstruct
+  class SomeMsg1:
+    a: Bits8
+    b: Bits32
+
+  @bitstruct
+  class SomeMsg2:
+    a: SomeMsg1
+    b: Bits32
+
+  class Top( Component ):
+    def construct( s ):
+      s.out = OutPort(SomeMsg2)
+      connect( s.out, SomeMsg2(SomeMsg1(1,2),3) )
+
+  x = Top()
+  x.elaborate()
+  x.apply( GenDAGPass() )
+  x.apply( SimpleSchedulePass() )
+  x.apply( SimpleTickPass() )
+  x.lock_in_simulation()
+  x.tick()
+  assert x.out == SomeMsg2(SomeMsg1(1,2),3)

--- a/pymtl3/passes/tracing/CLLineTracePass.py
+++ b/pymtl3/passes/tracing/CLLineTracePass.py
@@ -16,12 +16,9 @@ class CLLineTracePass( BasePass ):
     self.default_trace_len = trace_len
 
   def __call__( self, top ):
-
-    # Create a new schedule
-
-    if hasattr( top, "_sched" ):
-      top._cl_trace = PassMetadata()
-      top._cl_trace.schedule = [ self.process_component( top ) ] + top._sched.schedule
+    if not hasattr( top, "_tracing" ):
+      top._tracing = PassMetadata()
+    top._tracing.clear_cl_trace = self.process_component( top )
 
   def process_component( self, top ):
 

--- a/pymtl3/passes/tracing/CollectSignalPass.py
+++ b/pymtl3/passes/tracing/CollectSignalPass.py
@@ -30,7 +30,7 @@ class CollectSignalPass( BasePass ):
 
         if not hasattr( top, "_tracing" ):
           top._tracing = PassMetadata()
-          top._tracing.collect_text_sigs = self.collect_sig_func( top, top._tracing )
+        top._tracing.collect_text_sigs = self.collect_sig_func( top, top._tracing )
 
   def collect_sig_func( self, top, wavmeta ):
 

--- a/pymtl3/passes/tracing/CollectSignalPass.py
+++ b/pymtl3/passes/tracing/CollectSignalPass.py
@@ -20,14 +20,6 @@ from pymtl3.passes.errors import ModelTypeError, PassOrderError
 
 class CollectSignalPass( BasePass ):
   def __call__( self, top ):
-    if not hasattr( top._sched, "schedule" ):
-      raise PassOrderError( "schedule" )
-
-    if hasattr( top, "_cl_trace" ):
-      schedule = top._cl_trace.schedule
-    else:
-      schedule = top._sched.schedule
-
     if hasattr( top, "config_tracing" ):
       top.config_tracing.check()
 
@@ -35,8 +27,10 @@ class CollectSignalPass( BasePass ):
         # TODO remove this check when we are able to handle text_ascii
         if top.config_tracing.tracing == 'text_ascii':
           raise Exception("Current we don't support text_ascii. Only 'text_fancy' is supported now.")
-        top._textwave = PassMetadata()
-        schedule.append( self.collect_sig_func( top, top._textwave ) )
+
+        if not hasattr( top, "_tracing" ):
+          top._tracing = PassMetadata()
+          top._tracing.collect_text_sigs = self.collect_sig_func( top, top._tracing )
 
   def collect_sig_func( self, top, wavmeta ):
 
@@ -49,11 +43,11 @@ class CollectSignalPass( BasePass ):
     for x in top._dsl.all_signals:
       if x.is_top_level_signal() and ( not repr(x).endswith('.clk') or x is top.clk ):
         if is_bitstruct_class( x._dsl.Type ):
-          wav_srcs.append( "wavmeta.sigs['{0}'].append( to_bits({0}).bin() )".format(x) )
+          wav_srcs.append( "wavmeta.text_sigs['{0}'].append( to_bits({0}).bin() )".format(x) )
         elif issubclass( x._dsl.Type, Bits ):
-          wav_srcs.append( "wavmeta.sigs['{0}'].append( {0}.bin() )".format(x) )
+          wav_srcs.append( "wavmeta.text_sigs['{0}'].append( {0}.bin() )".format(x) )
 
-    wavmeta.sigs = defaultdict(list)
+    wavmeta.text_sigs = defaultdict(list)
 
     # TODO use integer index instead of dict, should be easy
     src =  """

--- a/pymtl3/passes/tracing/PrintWavePass.py
+++ b/pymtl3/passes/tracing/PrintWavePass.py
@@ -20,6 +20,7 @@ import py
 
 from pymtl3.dsl import Const
 from pymtl3.passes.BasePass import BasePass, PassMetadata
+from pymtl3.passes.errors import PassOrderError
 
 
 class PrintWavePass( BasePass ):

--- a/pymtl3/passes/tracing/PrintWavePass.py
+++ b/pymtl3/passes/tracing/PrintWavePass.py
@@ -25,11 +25,13 @@ from pymtl3.passes.BasePass import BasePass, PassMetadata
 class PrintWavePass( BasePass ):
 
   def __call__( self, top ):
-
     if hasattr( top, "config_tracing" ):
       top.config_tracing.check()
 
       if top.config_tracing.tracing in [ 'text_ascii', 'text_fancy' ]:
+        if not hasattr( top._tracing, "text_sigs" ):
+          raise PassOrderError( "text_sigs" )
+
         # TODO remove this check when we are able to handle text_ascii
         if top.config_tracing.tracing == 'text_ascii':
           raise Exception("Current we don't support text_ascii. Only 'text_fancy' is supported now.")
@@ -79,7 +81,7 @@ def _help_print( self ):
   revstart, revstop = '\x1B[7m', '\x1B[0m'
   light_gray = '\033[47m'
   back='\033[0m'  #back to normal printing
-  all_signals = self._textwave.sigs
+  all_signals = self._tracing.text_sigs
   #spaces before cycle number
   max_length = 0
   for sig in all_signals:

--- a/pymtl3/passes/tracing/test/CollectSignalPass_test.py
+++ b/pymtl3/passes/tracing/test/CollectSignalPass_test.py
@@ -79,15 +79,17 @@ def test_toy():
   for in0, in1, out in zip(vector[0::3], vector[1::3], vector[2::3]):
     dut.in0 = in0
     dut.in1 = in1
+    dut.eval_combinational()
     dut.tick()
     assert dut.out == out
 
   #test
-  sig = dut._textwave.sigs
+  sig = dut._tracing.text_sigs
   siglist = ["s.in0","s.in1","s.out","s.clk","s.reset"]
   for i in siglist:
     assert i in sig,"signals not captured"
 
+  print(sig)
   for i in range(3): # in0, in1, and out
     partsig = sig[ siglist[i] ]
     signal_length = len(partsig)
@@ -96,4 +98,4 @@ def test_toy():
     for j in range(signal_length):
       assert testlist[i][j] == process_binary(partsig[j]),"collected wrong signals"
 
-  print("All signals captured in s._textwave!")
+  print("All signals captured in top._tracing.text_sigs!")

--- a/pymtl3/passes/tracing/test/PrintWavePass_test.py
+++ b/pymtl3/passes/tracing/test/PrintWavePass_test.py
@@ -72,6 +72,7 @@ def test_toy():
   for i, inlong, out in zip(vector[0::3], vector[1::3], vector[2::3]):
     dut.i = i
     dut.inlong = inlong
+    dut.eval_combinational()
     dut.tick()
     assert dut.out == out
 
@@ -81,7 +82,7 @@ def test_toy():
   with redirect_stdout(f):
     dut.print_textwave()
   out = f.getvalue()
-  for i in dut._textwave.sigs:
+  for i in dut._tracing.text_sigs:
     dot = i.find(".")
     sliced = i[dot+1:]
     if sliced != "reset" and sliced != "clk":
@@ -134,6 +135,7 @@ def test_widetoy():
   for i, inlong, out in zip(vector[0::3], vector[1::3], vector[2::3]):
     dut.i = i
     dut.inlong = inlong
+    dut.eval_combinational()
     dut.tick()
     assert dut.out == out
 
@@ -143,7 +145,7 @@ def test_widetoy():
   with redirect_stdout(f):
     dut.print_textwave()
   out = f.getvalue()
-  for i in dut._textwave.sigs:
+  for i in dut._tracing.text_sigs:
     dot = i.find(".")
     sliced = i[dot+1:]
     if sliced != "reset" and sliced != "clk":
@@ -203,6 +205,7 @@ def test_bitstruct():
   for i, inlong, out in zip(vector[0::3], vector[1::3], vector[2::3]):
     dut.i = i
     dut.inlong = inlong
+    dut.eval_combinational()
     dut.tick()
     assert dut.out == out
 
@@ -212,7 +215,7 @@ def test_bitstruct():
   with redirect_stdout(f):
     dut.print_textwave()
   out = f.getvalue()
-  for i in dut._textwave.sigs:
+  for i in dut._tracing.text_sigs:
     dot = i.find(".")
     sliced = i[dot+1:]
     if sliced != "reset" and sliced != "clk":

--- a/pymtl3/stdlib/test/test_utils.py
+++ b/pymtl3/stdlib/test/test_utils.py
@@ -32,6 +32,8 @@ def mk_test_case_table( raw_test_case_table ):
 #------------------------------------------------------------------------------
 # TestVectorSimulator
 #------------------------------------------------------------------------------
+# Now we have the same test vector simulator as pymtl2
+# https://github.com/cornell-brg/pymtl/blob/master/pclib/test/TestVectorSimulator.py
 
 class TestVectorSimulator:
 
@@ -55,10 +57,13 @@ class TestVectorSimulator:
 
       # Set inputs
       self.set_inputs_func( self.model, test_vector )
-      self.model.tick()
+
+      self.model.eval_combinational()
 
       # Print the line trace
       print(self.model.line_trace())
 
       # Verify outputs
       self.verify_outputs_func( self.model, test_vector )
+
+      self.model.tick()


### PR DESCRIPTION
In this PR I did the following:

1. I added eval_combinational to the component in SimpleTickPass when there is no method port in the design (I think this is an OK indicator of whether there are CL modules inside the DUT for now. Later we can also unmark update_once).

2. To accomplish 1., I need to actually split intra-cycle schedule from update_ff and posedge. I went ahead and abandoned the previous tick assembling scheme where each pass adds to a list. Then I reimplemented all the passes that adds a function to the schedule like vcd signal collections and such to create a function in their own scheme. In SimpleTickPass or other tick generation passes, I assemble all the functions from these passes with the schedule and ff with the desired order.

3. Then I actually need to tweak all the places where the simulation is done in a similar flavor to TestVectorSimulator or directly uses TestVectorSimulator. Now we have the same TestVectorSimulator implementation as v2.