### PR TITLE
Revamp Bits strategy and implement Bitstruct strategy

### DIFF
--- a/pymtl3/datatypes/strategies.py
+++ b/pymtl3/datatypes/strategies.py
@@ -4,30 +4,96 @@ strategies.py
 ==========================================================================
 Hypothesis strategies for built-in data types.
 
-Author : Yanghui Ou
-  Date : June 16, 2019
+Author : Shunning Jiang, Yanghui Ou
+  Date : Dec 9, 2019
 """
 import hypothesis
 from hypothesis import strategies as st
 
-from .bits_import import mk_bits
+from .bits_import import Bits, mk_bits
+from .bitstructs import is_bitstruct_class
 
 #-------------------------------------------------------------------------
 # A generic bits strategy.
 #-------------------------------------------------------------------------
 
-@st.composite
-def bits( draw, nbits, signed=False ):
-  if nbits == 1:
-    value = draw( st.booleans() )
-  elif not signed:
-    min_value = 0
-    max_value = 2**nbits - 1
-    value = draw( st.integers(min_value, max_value) )
-  else:
-    min_value = - ( 2 ** (nbits-1) )
-    max_value = 2**(nbits-1) - 1
-    value = draw( st.integers(min_value, max_value) )
+# Return the SearchStrategy for Bits_nbits with the support to limit
+# min/max value and setting signedness
 
+def bits( nbits, signed=False, min_value=None, max_value=None ):
   BitsN = mk_bits( nbits )
-  return BitsN( value )
+
+  if (min_value is not None or max_value is not None) and signed:
+    raise ValueError("bits strategy currently doesn't support setting "
+                     "signedness and min/max value at the same time")
+
+  if min_value is None:
+    min_value = (-(2**(nbits-1))) if signed else 0
+  if max_value is None:
+    max_value = (2**(nbits-1)-1)  if signed else (2**nbits - 1)
+
+  strat = st.booleans() if nbits == 1 else st.integers( min_value, max_value )
+
+  @st.composite
+  def strategy_bits( draw ):
+    return BitsN( draw( strat ) )
+
+  # RETURN A STRATEGY INSTEAD OF FUNCTION
+  return strategy_bits()
+
+# Helper function to handle a list of Bits/structs
+def _list( types ):
+  # Bitstruct type construction already guarantees that all elements in
+  # the list have the same type. Hence we just need to use the first type
+  type_ = types[0]
+
+  # a list of types, recursive
+  if isinstance( type_, list ):
+    strat = _list( type_ )
+  # nested bitstruct, RECURSIVE
+  elif is_bitstruct_class( type_ ):
+    strat = bitstruct( type_ )
+  # bits field, directly use bits strategy
+  else:
+    assert issubclass( type_, Bits )
+    strat = bits( type_.nbits, False )
+
+  @st.composite
+  def strategy_list( draw ):
+    return [ draw(strat) for _ in types ]
+
+  return strategy_list()
+
+# Return the SearchStrategy for bitstruct type T
+
+def bitstruct( T ):
+  types = T.__bitstruct_fields__.values()
+
+  # We capture the fields of T inside a list inside closure of the
+  # strategy. For each field, we recursively compose a strategy based on
+  # the type. The type can be a list of types, a Bits type, or a nested
+  # bitstruct. For nested bitstruct, we recursively call the bitstruct(T)
+  # function to construct the strategy
+
+  strats = [ None ] * len( types )
+  for i, type_ in enumerate( types ):
+    # a list of types, call helper function
+    if isinstance( type_, list ):
+      strats[i] = _list( type_ )
+    # nested bitstruct, RECURSIVE
+    elif is_bitstruct_class( type_ ):
+      strats[i] = bitstruct( type_ )
+    # bits field, directly use bits strategy
+    else:
+      assert issubclass( type_, Bits )
+      strats[i] = bits( type_.nbits, False )
+    assert strats[i] is not None
+
+  @st.composite
+  def strategy_bitstruct( draw ):
+    # Since strats already preserves the order of bitstruct fields,
+    # we can directly asterisk the generatort to pass in as *args
+    return T( * (draw(strat) for strat in strats) )
+
+  # RETURN A STRATEGY INSTEAD OF FUNCTION
+  return strategy_bitstruct()

--- a/pymtl3/datatypes/strategies.py
+++ b/pymtl3/datatypes/strategies.py
@@ -48,8 +48,10 @@ def bits( nbits, signed=False, min_value=None, max_value=None ):
 def bitslists( types, limit_dict=None ):
   # Make sure limit_dict becomes a dict, not None
   limit_dict = limit_dict or {}
-  assert isinstance( limit_dict, dict ), "bitslists only takes a dictionary " \
-                                         "e.g. { 0:(1,2), 1:(3,4) } to specify min/max limit"
+  if not isinstance( limit_dict, dict ):
+    raise TypeError( f"bitlist '{types}' doesn't not take '{limit_dict}' " \
+                      "to specify min/max limit. Here only a dictionary " \
+                      "like { 0:range(1,2), 1:range(3,4) } is accepted. " )
 
   # We capture the strategies inside a list inside closure of the
   # strategy. For each element, we recursively compose a strategy based on
@@ -73,8 +75,10 @@ def bitslists( types, limit_dict=None ):
 def bitstructs( T, limit_dict=None ):
   # Make sure limit_dict becomes a dict, not None
   limit_dict = limit_dict or {}
-  assert isinstance( limit_dict, dict ), "bitstruct only takes a dictionary " \
-                                         "e.g. { 'x':(1,2), 'y':(3,4) } to specify min/max limit"
+  if not isinstance( limit_dict, dict ):
+    raise TypeError( f"bitstruct '{T}' doesn't not take '{limit_dict}' " \
+                      "to specify min/max limit. Here only a dictionary " \
+                      "like { 'x':range(1,2), 'y':range(3,4), 'z': { ... } } is accepted. " )
 
   # We capture the fields of T inside a list inside closure of the
   # strategy. For each field, we recursively compose a strategy based on

--- a/pymtl3/datatypes/strategies.py
+++ b/pymtl3/datatypes/strategies.py
@@ -14,9 +14,8 @@ from .bits_import import Bits, mk_bits
 from .bitstructs import is_bitstruct_class
 
 #-------------------------------------------------------------------------
-# A generic bits strategy.
+# strategies.bits
 #-------------------------------------------------------------------------
-
 # Return the SearchStrategy for Bits_nbits with the support to limit
 # min/max value and setting signedness
 
@@ -38,56 +37,51 @@ def bits( nbits, signed=False, min_value=None, max_value=None ):
   def strategy_bits( draw ):
     return BitsN( draw( strat ) )
 
-  # RETURN A STRATEGY INSTEAD OF FUNCTION
-  return strategy_bits()
+  return strategy_bits() # RETURN A STRATEGY INSTEAD OF FUNCTION
 
-# Helper function to handle a list of Bits/structs
-def _list( types ):
-  # Bitstruct type construction already guarantees that all elements in
-  # the list have the same type. Hence we just need to use the first type
-  type_ = types[0]
+#-------------------------------------------------------------------------
+# strategies.bitslist
+#-------------------------------------------------------------------------
+# Return the SearchStrategy for a list of Bits with the support of
+# dictionary based min/max value limit
 
-  # a list of types, recursive
-  if isinstance( type_, list ):
-    strat = _list( type_ )
-  # nested bitstruct, RECURSIVE
-  elif is_bitstruct_class( type_ ):
-    strat = bitstruct( type_ )
-  # bits field, directly use bits strategy
-  else:
-    assert issubclass( type_, Bits )
-    strat = bits( type_.nbits, False )
+def bitslist( types, limit_dict=None ):
+  # Make sure limit_dict becomes a dict, not None
+  limit_dict = limit_dict or {}
+  assert isinstance( limit_dict, dict ), "bitslist only takes a dictionary " \
+                                         "e.g. { 0:(1,2), 1:(3,4) } to specify min/max limit"
+
+  # We capture the strategies inside a list inside closure of the
+  # strategy. For each element, we recursively compose a strategy based on
+  # the type and the field limit.
+
+  strats = [ _strategy_dispatch( type_, limit_dict.get( i, None ) )
+              for i, type_ in enumerate(types) ]
 
   @st.composite
   def strategy_list( draw ):
-    return [ draw(strat) for _ in types ]
+    return [ draw(strat) for strat in strats ]
 
-  return strategy_list()
+  return strategy_list() # RETURN A STRATEGY INSTEAD OF FUNCTION
 
-# Return the SearchStrategy for bitstruct type T
+#-------------------------------------------------------------------------
+# strategies.bitstruct
+#-------------------------------------------------------------------------
+# Return the SearchStrategy for bitstruct type T with the support of
+# dictionary-based min/max value limit
 
-def bitstruct( T ):
-  types = T.__bitstruct_fields__.values()
+def bitstruct( T, limit_dict=None ):
+  # Make sure limit_dict becomes a dict, not None
+  limit_dict = limit_dict or {}
+  assert isinstance( limit_dict, dict ), "bitstruct only takes a dictionary " \
+                                         "e.g. { 'x':(1,2), 'y':(3,4) } to specify min/max limit"
 
   # We capture the fields of T inside a list inside closure of the
   # strategy. For each field, we recursively compose a strategy based on
-  # the type. The type can be a list of types, a Bits type, or a nested
-  # bitstruct. For nested bitstruct, we recursively call the bitstruct(T)
-  # function to construct the strategy
+  # the type and the field limit.
 
-  strats = [ None ] * len( types )
-  for i, type_ in enumerate( types ):
-    # a list of types, call helper function
-    if isinstance( type_, list ):
-      strats[i] = _list( type_ )
-    # nested bitstruct, RECURSIVE
-    elif is_bitstruct_class( type_ ):
-      strats[i] = bitstruct( type_ )
-    # bits field, directly use bits strategy
-    else:
-      assert issubclass( type_, Bits )
-      strats[i] = bits( type_.nbits, False )
-    assert strats[i] is not None
+  strats = [ _strategy_dispatch( type_, limit_dict.get( name, None ) )
+              for name, type_ in T.__bitstruct_fields__.items() ]
 
   @st.composite
   def strategy_bitstruct( draw ):
@@ -95,5 +89,29 @@ def bitstruct( T ):
     # we can directly asterisk the generatort to pass in as *args
     return T( * (draw(strat) for strat in strats) )
 
-  # RETURN A STRATEGY INSTEAD OF FUNCTION
-  return strategy_bitstruct()
+  return strategy_bitstruct() # RETURN A STRATEGY INSTEAD OF FUNCTION
+
+# Dispatch to construct corresponding strategy based on given type
+# The type can be a list of types, a Bits type, or a nested
+# bitstruct. For nested bitstruct, we recursively call the bitstruct(T)
+# function to construct the strategy
+def _strategy_dispatch( T, limit ):
+
+  # a list of types
+  if isinstance( T, list ):
+    return bitslist( T, limit )
+
+  # nested bitstruct
+  if is_bitstruct_class( T ):
+    return bitstruct( T, limit )
+
+  # bits field, "leaf node", directly use bits strategy
+  assert issubclass( T, Bits )
+  if limit is None:
+    return bits( T.nbits )
+
+  # bits field with limit
+  assert isinstance( limit, tuple )
+  min_value, max_value = limit
+  assert min_value < max_value
+  return bits( T.nbits, False, min_value, max_value )

--- a/pymtl3/datatypes/test/bitstructs_test.py
+++ b/pymtl3/datatypes/test/bitstructs_test.py
@@ -451,6 +451,8 @@ def test_mk_high_d_list_inside():
   assert a.x == Bits4(0)
   assert a.y == [ [ [ [ Bits4(), Bits4(), Bits4()] ] for _ in range(6) ] for _ in range(10) ]
 
+  print(a)
+
 def test_high_d_list_struct_inside():
   @bitstruct
   class A:
@@ -474,3 +476,5 @@ def test_mk_high_d_list_struct_inside():
   b = B()
   assert b.x == Bits4(0)
   assert b.y == [ [ [ [ A(), A(), A()] ] for _ in range(6) ] for _ in range(10) ]
+
+  print(b)

--- a/pymtl3/datatypes/test/strategies_test.py
+++ b/pymtl3/datatypes/test/strategies_test.py
@@ -62,7 +62,7 @@ def test_bits16_limited():
 def test_bitslist( length ):
   print("")
   @hypothesis.given(
-    blist = pst.bitslist([mk_bits(i+10) for i in range(length)])
+    blist = pst.bitslists([mk_bits(i+10) for i in range(length)])
   )
   @hypothesis.settings( max_examples=16 )
   def actual_test( blist ):
@@ -78,16 +78,16 @@ def test_bitslist_nested_limit():
   type_ = [ [Bits10, Bits11, Bits12], [Bits13, Bits14] ]
   limit_dict = {
     0: {
-      0: (0xa0,0xaf),
-      2: (0xb0,0xbf),
+      0: range(0xa0,0xb0),
+      2: range(0xb0,0xc0),
     },
     1: {
-      1: (0xc0,0xcf),
+      1: range(0xc0,0xd0),
     },
   }
   print("")
   @hypothesis.given(
-    blist = pst.bitslist(type_, limit_dict)
+    blist = pst.bitslists(type_, limit_dict)
   )
   @hypothesis.settings( max_examples=16 )
   def actual_test( blist ):
@@ -142,7 +142,7 @@ class NNestedPoint:
 def test_bitstruct( T ):
   print("")
   @hypothesis.given(
-    bs = pst.bitstruct(T)
+    bs = pst.bitstructs(T)
   )
   @hypothesis.settings( max_examples=16 )
   def actual_test( bs ):
@@ -155,16 +155,16 @@ def test_bitstruct( T ):
 def test_nested_point_limited():
   limit_dict = {
     'p1': {
-      'x': (0xe0,0xef),
+      'x': range(0xe0,0xf0),
     },
     'p2': {
-      'y': (0xf0,0xff),
+      'y': range(0xf0,0x100),
     }
   }
 
   print("")
   @hypothesis.given(
-    bs = pst.bitstruct(NestedPoint, limit_dict)
+    bs = pst.bitstructs(NestedPoint, limit_dict)
   )
   @hypothesis.settings( max_examples=16 )
   def actual_test( bs ):
@@ -179,16 +179,16 @@ def test_nested_point_limited():
 def test_nnested_point_limited():
   limit_dict = {
     'p1': {
-      'x': (0xe0,0xef),
+      'x': range(0xe0,0xef),
     },
     'p2': {
-      'y': (0xf0,0xff),
+      'y': range(0xf0,0xff),
     },
     'p3': {
       0: {
         'z': {
-          0: (0xa0, 0xaf),
-          1: (0xb0, 0xbf),
+          0: range(0xa0, 0xaf),
+          1: range(0xb0, 0xbf),
         }
       }
     }
@@ -196,15 +196,15 @@ def test_nnested_point_limited():
 
   print("")
   @hypothesis.given(
-    bs = pst.bitstruct(NNestedPoint, limit_dict)
+    bs = pst.bitstructs(NNestedPoint, limit_dict)
   )
   @hypothesis.settings( max_examples=16 )
   def actual_test( bs ):
     assert isinstance( bs, NNestedPoint )
-    assert 0xe0 <= bs.p1.x <= 0xef
-    assert 0xf0 <= bs.p2.y <= 0xff
-    assert 0xa0 <= bs.p3[0].z[0] <= 0xaf
-    assert 0xb0 <= bs.p3[0].z[1] <= 0xbf
+    assert 0xe0 <= bs.p1.x < 0xef
+    assert 0xf0 <= bs.p2.y < 0xff
+    assert 0xa0 <= bs.p3[0].z[0] < 0xaf
+    assert 0xb0 <= bs.p3[0].z[1] < 0xbf
     print( bs )
 
   print("-"*10,NNestedPoint,"-"*10)

--- a/pymtl3/datatypes/test/strategies_test.py
+++ b/pymtl3/datatypes/test/strategies_test.py
@@ -27,7 +27,6 @@ def test_bits_unsigned( nbits ):
     assert bits.nbits == nbits
     print( bits, bits.uint() )
 
-  print("-"*10,nbits,"-"*10)
   actual_test()
 
 @pytest.mark.parametrize( 'nbits', [1, 3, 4, 8, 16, 32] )
@@ -41,7 +40,6 @@ def test_bits_signed( nbits ):
     assert bits.nbits == nbits
     print( bits, bits.int() )
 
-  print("-"*10,nbits,"-"*10)
   actual_test()
 
 def test_bits16_limited():
@@ -55,7 +53,6 @@ def test_bits16_limited():
     assert 2 <= bits.uint() <= 11
     print( bits, bits.uint() )
 
-  print("-"*10,16,'limited',"-"*10)
   actual_test()
 
 @pytest.mark.parametrize( 'length', [5,10,15,20] )
@@ -71,7 +68,6 @@ def test_bitslist( length ):
     # print out the fraction of generated random value versus the full range
     print( blist, [ f'{(int(blist[i])/(2**(10+i))*100):.2f}%' for i in range(length)] )
 
-  print("-"*10,f'[{length}]',"-"*10)
   actual_test()
 
 def test_bitslist_nested_limit():
@@ -101,9 +97,7 @@ def test_bitslist_nested_limit():
     assert 0xc0 <= blist[1][1] <= 0xcf
     print(blist)
 
-  print("-"*10,'list_nested_limit!',"-"*10)
   actual_test()
-
 
 def test_bitslist_nested_user_strategy():
   type_ = [ [Bits10, Bits11, Bits12], Bits13 ]
@@ -123,8 +117,20 @@ def test_bitslist_nested_user_strategy():
     assert 0 <= blist[1] <= 10
     print(blist)
 
-  print("-"*10,'list_user_strategy!',"-"*10)
   actual_test()
+
+def test_bitslist_nested_user_strategy_wrong_type():
+  type_ = [ [Bits10, Bits11, Bits12], Bits13 ]
+  limit_dict = {
+    0: 123,
+  }
+
+  try:
+    bs = pst.bitslists( type_, limit_dict )
+  except TypeError as e:
+    print(e)
+    return
+  raise Exception("Should've thrown TypeError")
 
 @bitstruct
 class Point1D:
@@ -170,7 +176,6 @@ def test_bitstruct( T ):
     assert isinstance( bs, T )
     print( bs )
 
-  print("-"*10,T,"-"*10)
   actual_test()
 
 def test_nested_point_limited():
@@ -194,7 +199,6 @@ def test_nested_point_limited():
     assert 0xf0 <= bs.p2.y <= 0xff
     print( bs )
 
-  print("-"*10,NestedPoint,"-"*10)
   actual_test()
 
 def test_nnested_point_limited():
@@ -228,7 +232,6 @@ def test_nnested_point_limited():
     assert 0xb0 <= bs.p3[0].z[1] < 0xbf
     print( bs )
 
-  print("-"*10,NNestedPoint,"-"*10)
   actual_test()
 
 def test_nested_point_user_strategy():
@@ -251,7 +254,6 @@ def test_nested_point_user_strategy():
     assert 2 <= bs.p2.y < 4
     print( bs )
 
-  print("-"*10,NestedPoint,"-"*10)
   actual_test()
 
 def test_nested_point_user_strategy_wrong_type():
@@ -264,7 +266,7 @@ def test_nested_point_user_strategy_wrong_type():
 
   try:
     bs = pst.bitstructs(NestedPoint, limit_dict)
-  except AssertionError as e:
+  except TypeError as e:
     print(e)
     return
-  raise Exception("Should've thrown AssertionError")
+  raise Exception("Should've thrown TypeError")

--- a/pymtl3/datatypes/test/strategies_test.py
+++ b/pymtl3/datatypes/test/strategies_test.py
@@ -253,3 +253,18 @@ def test_nested_point_user_strategy():
 
   print("-"*10,NestedPoint,"-"*10)
   actual_test()
+
+def test_nested_point_user_strategy_wrong_type():
+  limit_dict = {
+    'p1': {
+      'x': range(0xe0,0xf0),
+    },
+    'p2': 123
+  }
+
+  try:
+    bs = pst.bitstructs(NestedPoint, limit_dict)
+  except AssertionError as e:
+    print(e)
+    return
+  raise Exception("Should've thrown AssertionError")

--- a/pymtl3/datatypes/test/strategies_test.py
+++ b/pymtl3/datatypes/test/strategies_test.py
@@ -13,10 +13,11 @@ import pytest
 
 from pymtl3.datatypes import strategies as pst
 from pymtl3.datatypes.bits_import import *
+from pymtl3.datatypes.bitstructs import bitstruct
 
 
 @pytest.mark.parametrize( 'nbits', [1, 3, 4, 8, 16, 32] )
-def test_unsigned( nbits ):
+def test_bits_unsigned( nbits ):
   print("")
   @hypothesis.given(
     bits = pst.bits(nbits)
@@ -25,10 +26,12 @@ def test_unsigned( nbits ):
   def actual_test( bits ):
     assert bits.nbits == nbits
     print( bits, bits.uint() )
+
+  print("-"*10,nbits,"-"*10)
   actual_test()
 
 @pytest.mark.parametrize( 'nbits', [1, 3, 4, 8, 16, 32] )
-def test_signed( nbits ):
+def test_bits_signed( nbits ):
   print("")
   @hypothesis.given(
     bits = pst.bits(nbits, True)
@@ -37,4 +40,66 @@ def test_signed( nbits ):
   def actual_test( bits ):
     assert bits.nbits == nbits
     print( bits, bits.int() )
+
+  print("-"*10,nbits,"-"*10)
+  actual_test()
+
+def test_bits16_limited():
+  print("")
+  @hypothesis.given(
+    bits = pst.bits(16, min_value=2, max_value=11)
+  )
+  @hypothesis.settings( max_examples=16 )
+  def actual_test( bits ):
+    assert bits.nbits == 16
+    assert 2 <= bits.uint() <= 11
+    print( bits, bits.uint() )
+
+  print("-"*10,16,'limited',"-"*10)
+  actual_test()
+@bitstruct
+class Point1D:
+  x: Bits12
+
+@bitstruct
+class Point2D:
+  x: Bits16
+  y: Bits20
+
+@bitstruct
+class Point3D:
+  x: Bits100
+  y: Bits4
+  z: Bits8
+
+@bitstruct
+class Point3Dx2:
+  x: [ Bits100, Bits100 ]
+  y: [ Bits4, Bits4 ]
+  z: [ Bits8, Bits8 ]
+
+@bitstruct
+class NestedPoint:
+  p1: Point1D
+  p2: Point2D
+  p3: Point3D
+
+@bitstruct
+class NNestedPoint:
+  p1: Point1D
+  p2: Point2D
+  p3: [ Point3Dx2, Point3Dx2 ]
+
+@pytest.mark.parametrize( 'T', [Point1D, Point2D, Point3D, Point3Dx2, NestedPoint , NNestedPoint] )
+def test_bitstruct( T ):
+  print("")
+  @hypothesis.given(
+    bs = pst.bitstruct(T)
+  )
+  @hypothesis.settings( max_examples=16 )
+  def actual_test( bs ):
+    assert isinstance( bs, T )
+    print( bs )
+
+  print("-"*10,T,"-"*10)
   actual_test()

--- a/pymtl3/datatypes/test/strategies_test.py
+++ b/pymtl3/datatypes/test/strategies_test.py
@@ -105,6 +105,27 @@ def test_bitslist_nested_limit():
   actual_test()
 
 
+def test_bitslist_nested_user_strategy():
+  type_ = [ [Bits10, Bits11, Bits12], Bits13 ]
+  limit_dict = {
+    1: pst.bits(13, min_value=0, max_value=10)
+  }
+  print("")
+  @hypothesis.given(
+    blist = pst.bitslists(type_, limit_dict)
+  )
+  @hypothesis.settings( max_examples=16 )
+  def actual_test( blist ):
+    assert blist[0][0].nbits == 10
+    assert blist[0][1].nbits == 11
+    assert blist[0][2].nbits == 12
+    assert blist[1].nbits == 13
+    assert 0 <= blist[1] <= 10
+    print(blist)
+
+  print("-"*10,'list_user_strategy!',"-"*10)
+  actual_test()
+
 @bitstruct
 class Point1D:
   x: Bits12
@@ -208,4 +229,27 @@ def test_nnested_point_limited():
     print( bs )
 
   print("-"*10,NNestedPoint,"-"*10)
+  actual_test()
+
+def test_nested_point_user_strategy():
+  limit_dict = {
+    'p1': {
+      'x': range(0xe0,0xf0),
+    },
+    'p2': pst.bitstructs( Point2D, {'x':range(0,2),'y':range(2,4)} )
+  }
+
+  print("")
+  @hypothesis.given(
+    bs = pst.bitstructs(NestedPoint, limit_dict)
+  )
+  @hypothesis.settings( max_examples=16 )
+  def actual_test( bs ):
+    assert isinstance( bs, NestedPoint )
+    assert 0xe0 <= bs.p1.x <= 0xef
+    assert 0 <= bs.p2.x < 2
+    assert 2 <= bs.p2.y < 4
+    print( bs )
+
+  print("-"*10,NestedPoint,"-"*10)
   actual_test()


### PR DESCRIPTION
Now I think we should create strategies in a generator-like style. At strategy construction time, our bitwidth/bitstruct types are already fixed, which means all the arguments won't change during runtime. As a result, we should be able to capture them in closure and return a strategy with minimum metadata access like object dict access or creating types.

Based on these, I reimplemented Bits strategy and added custom min_value/max_value support since there can be cases where the full range of value doesn't make sense. I also write a bitstruct strategy based on recursive construction of strategy list, and the real strategy is very succinct and simple.

For complete functionality, I think I still need to implement setting min/max value limit from the top-level bitstruct using a trie-like data structure. I open the PR early to get some feedback on style.