### PR TITLE
Top level value port auto-eval

### DIFF
--- a/pymtl3/passes/sim/AutoEvalPass.py
+++ b/pymtl3/passes/sim/AutoEvalPass.py
@@ -1,0 +1,99 @@
+"""
+========================================================================
+AutoEvalPass.py
+========================================================================
+Wrap every top-level value port with @property that calls
+eval_combinational automatically.
+
+Author : Shunning Jiang
+Date   : Dec 14, 2019
+"""
+from pymtl3.dsl import MethodPort
+from pymtl3.dsl.errors import UpblkCyclicError
+from pymtl3.passes.BasePass import BasePass, PassMetadata
+from pymtl3.passes.errors import PassOrderError
+
+class AutoEvalPass( BasePass ):
+
+  def __call__( self, top ):
+    if not hasattr( top, "eval_combinational" ):
+      print("No eval_combinational detected, cannot add auto-eval")
+      return
+
+    if len(top.get_input_value_ports()) == 2: # only clock and reset
+      print("No top-level ports, no need to add auto-eval")
+      return
+
+    top._autoeval = PassMetadata()
+    top._autoeval.need_eval_comb = False
+
+    def gen_outport_property( name ):
+
+      def gen_getter( top ):
+        # if not elaborated, we don't do anything
+        if not hasattr( top._dsl, "elaborate_top" ):
+          try:
+            return getattr( top._dsl, "_"+name )
+          except AttributeError:
+            return None
+
+        if top is top._dsl.elaborate_top:
+          if top._autoeval.need_eval_comb:
+            top.eval_combinational()
+            top._autoeval.need_eval_comb = False
+        return getattr( top._autoeval, name )
+
+      def gen_setter( top, v ):
+        if not hasattr( top._dsl, "elaborate_top" ):
+          setattr( top._dsl, "_"+name, v )
+        setattr( top._autoeval, name, v )
+
+      return property(gen_getter).setter(gen_setter)
+
+    def gen_inport_property( name ):
+
+      def gen_getter( top ):
+        if not hasattr( top._dsl, "elaborate_top" ):
+          try:
+            return getattr( top._dsl, "_"+name )
+          except AttributeError:
+            return None
+        return getattr( top._autoeval, name )
+
+      def gen_setter( top, v ):
+        if not hasattr( top._dsl, "elaborate_top" ):
+          setattr( top._dsl, "_"+name, v )
+
+        if top is top._dsl.elaborate_top:
+          setattr( top._autoeval, name, v )
+          top._autoeval.need_eval_comb = True
+
+      return property(gen_getter).setter(gen_setter)
+
+    # Has to add @property to class ...
+    # # https://stackoverflow.com/a/1355444/6470797
+
+    cls = top.__class__
+
+    # For output value ports, we only need an enhanced property getter
+
+    for p in top.get_output_value_ports():
+      field_name = p._dsl.my_name
+
+      setattr( cls, field_name, gen_outport_property( p._dsl.my_name ) )
+
+    for p in top.get_input_value_ports():
+      field_name = p._dsl.my_name
+
+      setattr( cls, field_name, gen_inport_property( p._dsl.my_name ) )
+
+    def gen_wrapped_tick( top ):
+      tick = top.tick
+      def wrapped_tick():
+        if top._autoeval.need_eval_comb:
+          top._autoeval.need_eval_comb = False
+          top.eval_combinational()
+        tick()
+      return wrapped_tick
+
+    top.tick = gen_wrapped_tick( top )

--- a/pymtl3/passes/sim/AutoEvalPass.py
+++ b/pymtl3/passes/sim/AutoEvalPass.py
@@ -30,41 +30,45 @@ class AutoEvalPass( BasePass ):
     def gen_outport_property( name ):
 
       def gen_getter( top ):
-        # if not elaborated, we don't do anything
-        if not hasattr( top._dsl, "elaborate_top" ):
+        # if no eval_comb, we don't do anything
+        if not hasattr( top, "eval_combinational" ) or \
+           top is not top._dsl.elaborate_top:
           try:
             return getattr( top._dsl, "_"+name )
           except AttributeError:
             return None
 
-        if top is top._dsl.elaborate_top:
-          if top._autoeval.need_eval_comb:
-            top.eval_combinational()
-            top._autoeval.need_eval_comb = False
+        if top._autoeval.need_eval_comb:
+          top.eval_combinational()
+          top._autoeval.need_eval_comb = False
         return getattr( top._autoeval, name )
 
       def gen_setter( top, v ):
-        if not hasattr( top._dsl, "elaborate_top" ):
+        if not hasattr( top, "eval_combinational" ) or \
+           top is not top._dsl.elaborate_top:
           setattr( top._dsl, "_"+name, v )
-        setattr( top._autoeval, name, v )
+        else:
+          setattr( top._autoeval, name, v )
 
       return property(gen_getter).setter(gen_setter)
 
     def gen_inport_property( name ):
 
       def gen_getter( top ):
-        if not hasattr( top._dsl, "elaborate_top" ):
+        if not hasattr( top, "eval_combinational" ) or \
+           top is not top._dsl.elaborate_top:
           try:
             return getattr( top._dsl, "_"+name )
           except AttributeError:
             return None
+
         return getattr( top._autoeval, name )
 
       def gen_setter( top, v ):
-        if not hasattr( top._dsl, "elaborate_top" ):
+        if not hasattr( top, "eval_combinational" ) or \
+           top is not top._dsl.elaborate_top:
           setattr( top._dsl, "_"+name, v )
-
-        if top is top._dsl.elaborate_top:
+        else:
           setattr( top._autoeval, name, v )
           top._autoeval.need_eval_comb = True
 

--- a/pymtl3/passes/sim/AutoEvalPass.py
+++ b/pymtl3/passes/sim/AutoEvalPass.py
@@ -13,6 +13,7 @@ from pymtl3.dsl.errors import UpblkCyclicError
 from pymtl3.passes.BasePass import BasePass, PassMetadata
 from pymtl3.passes.errors import PassOrderError
 
+
 class AutoEvalPass( BasePass ):
 
   def __call__( self, top ):

--- a/pymtl3/passes/sim/test/AutoEvalPass_test.py
+++ b/pymtl3/passes/sim/test/AutoEvalPass_test.py
@@ -64,6 +64,7 @@ def test_wrapped_comb_adder():
   a.apply( SimpleTickPass() )
   a.apply( AutoEvalPass() )
   a.lock_in_simulation()
+  a.tick()
 
   assert not a._autoeval.need_eval_comb
 

--- a/pymtl3/passes/sim/test/AutoEvalPass_test.py
+++ b/pymtl3/passes/sim/test/AutoEvalPass_test.py
@@ -14,6 +14,7 @@ from ..GenDAGPass import GenDAGPass
 from ..SimpleSchedulePass import SimpleSchedulePass
 from ..SimpleTickPass import SimpleTickPass
 
+
 class Adder(Component):
   def construct( s ):
     s.in0 = InPort( Bits32 )

--- a/pymtl3/passes/sim/test/AutoEvalPass_test.py
+++ b/pymtl3/passes/sim/test/AutoEvalPass_test.py
@@ -1,0 +1,81 @@
+#=========================================================================
+# DynamicSchedulePass_test.py
+#=========================================================================
+#
+# Author : Shunning Jiang
+# Date   : Apr 19, 2019
+
+from pymtl3.datatypes import Bits8, Bits32, bitstruct
+from pymtl3.dsl import *
+from pymtl3.dsl.errors import UpblkCyclicError
+
+from ..AutoEvalPass import AutoEvalPass
+from ..GenDAGPass import GenDAGPass
+from ..SimpleSchedulePass import SimpleSchedulePass
+from ..SimpleTickPass import SimpleTickPass
+
+class Adder(Component):
+  def construct( s ):
+    s.in0 = InPort( Bits32 )
+    s.in1 = InPort( Bits32 )
+    s.out = OutPort( Bits32 )
+    @s.update
+    def add():
+      s.out = s.in0 + s.in1
+
+def test_comb_adder():
+  a = Adder()
+  a.elaborate()
+  a.apply( GenDAGPass() )
+  a.apply( SimpleSchedulePass() )
+  a.apply( SimpleTickPass() )
+  a.apply( AutoEvalPass() )
+  a.lock_in_simulation()
+  a.tick()
+
+  assert not a._autoeval.need_eval_comb
+
+  a.in0 = Bits32(10)
+  assert a._autoeval.need_eval_comb
+
+  a.in1 = Bits32(10)
+  assert a._autoeval.need_eval_comb
+
+  # NO need to call eval_combinational!
+  assert a.out == 20
+  assert not a._autoeval.need_eval_comb
+
+  assert a.out == 20
+  assert not a._autoeval.need_eval_comb
+
+class WrapAdder(Component):
+  def construct( s ):
+    s.in0 = InPort( Bits32 )
+    s.in1 = InPort( Bits32 )
+    s.out = OutPort( Bits32 )
+
+    s.adder = Adder()( in0 = s.in0, in1 = s.in1, out = s.out )
+
+def test_wrapped_comb_adder():
+  a = WrapAdder()
+  a.elaborate()
+  a.apply( GenDAGPass() )
+  a.apply( SimpleSchedulePass() )
+  a.apply( SimpleTickPass() )
+  a.apply( AutoEvalPass() )
+  a.lock_in_simulation()
+
+  assert not a._autoeval.need_eval_comb
+
+  a.in0 = Bits32(10)
+  assert a._autoeval.need_eval_comb
+
+  a.in1 = Bits32(10)
+  assert a._autoeval.need_eval_comb
+
+  # NO need to call eval_combinational!
+  assert a.out == 20
+  assert not a._autoeval.need_eval_comb
+
+  assert a.out == 20
+  assert not a._autoeval.need_eval_comb


### PR DESCRIPTION
AutoEval is a pass that slightly enhances the simulation functionality to serve those users who just set/read the top-level port to test the design behavior. It avoids spamming eval_combinational every cycle and automatically evaluates combinational logic when the user manipulates the top-level signals.

- After calling tick, the need_eval_comb flag is set to False.

- Then, whenever a top-level **InPort** gets written, it sets need_eval_comb to True under the hood, but doesn't call eval_combinational right away. As a result, when there are several top-level port assignments, the framework won't spam eval_combinational calls.

- Whenever a top-level **OutPort** gets read out, it first checks if eval_comb is True. If so, it calls eval_combinational. This is to reflect combinational changes immediately. This also allows you to arbitrarily interleave InPort assignment and OutPort read.

- Finally, at the beginning of tick(), it checks if need_eval_comb flag is set to True. If so, it calls eval_comb first, and then do the routine. This calls eval_combinational.

Currently I haven't added this to any pass group.