### PR TITLE
Fix a bug in the checker of `vl_src` import option

### DIFF
--- a/pymtl3/passes/PassConfigs.py
+++ b/pymtl3/passes/PassConfigs.py
@@ -76,7 +76,7 @@ class BasePassConfigs:
     return inst
 
   def check( s ):
-    """Return whether the given options are valid by calling checkers."""
+    """Check whether the given options are valid by calling checkers."""
     for opt in s.opts:
       chk   = s._Checkers[opt]
       value = getattr( s, opt )

--- a/pymtl3/passes/backends/sverilog/import_/ImportConfigs.py
+++ b/pymtl3/passes/backends/sverilog/import_/ImportConfigs.py
@@ -213,6 +213,14 @@ class ImportConfigs( BasePassConfigs ):
   # Public APIs
   #-----------------------------------------------------------------------
 
+  # Override
+  def check( s ):
+    super().check()
+    
+    if not s.vl_flist and not os.path.isfile(expand(s.vl_src)):
+      raise InvalidPassOptionValue( 'vl_src', s.vl_src, s.PassName,
+                'vl_src should be a path to a file when vl_flist is empty!' )
+
   def create_vl_cmd( s ):
     top_module  =  f"--top-module {s.top_module}"
     src         = s.vl_src
@@ -358,7 +366,7 @@ class ImportConfigs( BasePassConfigs ):
                isinstance(p.get_dtype(), rdt.Vector) for n, p in all_ports), \
         f"Port map option currently requires all ports of {rtype.get_name()}"\
         f" to be a single vector port."
-    for name, _ in pm.items():
+    for name in pm.keys():
       if name not in all_port_names:
         raise InvalidPassOptionValue("port_map", pm, s.PassName,
           f"Port {name} does not exist in component {rtype.get_name()}!")

--- a/pymtl3/passes/backends/sverilog/import_/ImportConfigs.py
+++ b/pymtl3/passes/backends/sverilog/import_/ImportConfigs.py
@@ -162,8 +162,8 @@ class ImportConfigs( BasePassConfigs ):
 
     "port_map": Checker( lambda v: isinstance(v, dict), "expects a dict"),
 
-    "vl_src": Checker( lambda v: isinstance(v, str) and os.path.isfile(expand(v)) or \
-                s.vl_flist, "vl_src should be a path to a file when vl_flist is empty" ),
+    "vl_src": Checker( lambda v: isinstance(v, str) and (os.path.isfile(expand(v)) or not v),
+                "vl_src should be a path to a file or an empty string!" ),
 
     "vl_flist": Checker( lambda v: isinstance(v, str) and os.path.isfile(expand(v)) or v == "",
                          "expects a path to a file" ),
@@ -204,7 +204,7 @@ class ImportConfigs( BasePassConfigs ):
     'SYMRSVDWORD', 'SYNCASYNCNET', 'TASKNSVAR', 'TICKCOUNT', 'UNDRIVEN',
     'UNOPT', 'UNOPTFLAT', 'UNOPTTHREADS', 'UNPACKED', 'UNSIGNED', 'UNUSED',
     'USERINFO', 'USERWARN', 'USERERROR', 'USERFATAL', 'VARHIDDEN', 'WIDTH',
-    'WIDTHCONCAT'
+    'WIDTHCONCAT',
   ]
 
   PassName = 'sverilog.ImportPass'
@@ -243,11 +243,11 @@ class ImportConfigs( BasePassConfigs ):
 
   def create_cc_cmd( s ):
     c_flags = "-O0 -fPIC -fno-gnu-unique -shared" + \
-             ("" if s.is_default("c_flags") else f" {s.c_flags}")
+             ("" if s.is_default("c_flags") else f" {expand(s.c_flags)}")
     c_include_path = " ".join("-I"+p for p in s.get_all_includes() if p)
     out_file = s.get_shared_lib_path()
     c_src_files = " ".join(s.get_c_src_files())
-    ld_flags = s.ld_flags
+    ld_flags = expand(s.ld_flags)
     ld_libs = s.ld_libs
     coverage = "-DVM_COVERAGE" if s.coverage or \
                                   s.line_coverage or \
@@ -321,7 +321,7 @@ class ImportConfigs( BasePassConfigs ):
 
   def get_port_map( s ):
     pmap = s.port_map
-    return lambda name: pmap[name]
+    return lambda name: pmap[name] if name in pmap else name
 
   def get_module_to_parametrize( s ):
     return s.wrapped_module
@@ -350,20 +350,18 @@ class ImportConfigs( BasePassConfigs ):
   #-----------------------------------------------------------------------
 
   def check_p_map( s, rtype ):
-    """Check if each port name of `rtype` is in port map."""
+    """Check if each port name in the port map exists in component `rtype`."""
     pm = s.port_map
     all_ports = rtype.get_ports_packed()
+    all_port_names = map(lambda x: x[0], rtype.get_ports_packed())
     assert all(isinstance(p, rt.Port) and \
                isinstance(p.get_dtype(), rdt.Vector) for n, p in all_ports), \
         f"Port map option currently requires all ports of {rtype.get_name()}"\
         f" to be a single vector port."
-    for name, port in all_ports:
-      if name not in pm:
+    for name, _ in pm.items():
+      if name not in all_port_names:
         raise InvalidPassOptionValue("port_map", pm, s.PassName,
-          f"Port {name} of {rtype.get_name()} should be mapped to a new name!")
-    if len(all_ports) != len(pm):
-      raise InvalidPassOptionValue("port_map", pm, s.PassName,
-        f"All ports of {rtype.get_name()} should be mapped to a new name!")
+          f"Port {name} does not exist in component {rtype.get_name()}!")
 
   def get_all_includes( s ):
     includes = s.c_include_path

--- a/pymtl3/passes/backends/sverilog/import_/ImportConfigs.py
+++ b/pymtl3/passes/backends/sverilog/import_/ImportConfigs.py
@@ -353,7 +353,7 @@ class ImportConfigs( BasePassConfigs ):
     """Check if each port name in the port map exists in component `rtype`."""
     pm = s.port_map
     all_ports = rtype.get_ports_packed()
-    all_port_names = map(lambda x: x[0], rtype.get_ports_packed())
+    all_port_names = list(map(lambda x: x[0], rtype.get_ports_packed()))
     assert all(isinstance(p, rt.Port) and \
                isinstance(p.get_dtype(), rdt.Vector) for n, p in all_ports), \
         f"Port map option currently requires all ports of {rtype.get_name()}"\

--- a/pymtl3/passes/backends/sverilog/import_/test/ImportedObject_test.py
+++ b/pymtl3/passes/backends/sverilog/import_/test/ImportedObject_test.py
@@ -55,6 +55,36 @@ def test_reg( do_test ):
   a._tv_out = tv_out
   do_test( a )
 
+def test_reg_incomplete_portmap( do_test ):
+  def tv_in( m, test_vector ):
+    m.in_ = Bits32( test_vector[0] )
+  def tv_out( m, test_vector ):
+    if test_vector[1] != '*':
+      assert m.out == Bits32( test_vector[1] )
+  class VReg( Component ):
+    def construct( s ):
+      s.in_ = InPort( Bits32 )
+      s.out = OutPort( Bits32 )
+      s.config_sverilog_import = ImportConfigs(
+          vl_src = get_dir(__file__)+'VReg.sv',
+          port_map = {
+            "in_" : "d",
+            "out" : "q",
+          }
+      )
+  a = VReg()
+  a._test_vectors = [
+    [    1,    '*' ],
+    [    2,      1 ],
+    [   -1,      2 ],
+    [   -2,     -1 ],
+    [   42,     -2 ],
+    [  -42,     42 ],
+  ]
+  a._tv_in = tv_in
+  a._tv_out = tv_out
+  do_test( a )
+
 def test_adder( do_test ):
   def tv_in( m, test_vector ):
     m.in0 = Bits32( test_vector[0] )

--- a/pymtl3/passes/backends/sverilog/import_/test/VAdder.sv
+++ b/pymtl3/passes/backends/sverilog/import_/test/VAdder.sv
@@ -1,12 +1,12 @@
 module VAdder #( parameter nbits = 32 )
 (
-  input clk,
-  input reset,
-  input [nbits-1:0] in0,
-  input [nbits-1:0] in1,
-  input cin,
-  output [nbits-1:0] out,
-  output cout
+  input  logic clk,
+  input  logic reset,
+  input  logic [nbits-1:0] in0,
+  input  logic [nbits-1:0] in1,
+  input  logic cin,
+  output logic [nbits-1:0] out,
+  output logic cout
 );
 
   logic [nbits:0] temp;

--- a/pymtl3/passes/backends/sverilog/import_/test/VReg.sv
+++ b/pymtl3/passes/backends/sverilog/import_/test/VReg.sv
@@ -1,10 +1,9 @@
 module VReg(
-  input           clk,
-  input           reset,
-  output [32-1:0] q,
-  input  [32-1:0] d
+  input  logic          clk,
+  input  logic          reset,
+  output logic [32-1:0] q,
+  input  logic [32-1:0] d
 );
-  logic q;
   always_ff @(posedge clk) begin
     q <= d;
   end


### PR DESCRIPTION
1. Fix an invalid name reference in the checker of `vl_src`
2. Improve the port map checker. Now you can only specify the names of ports that is different from the Verilog module you try to import (see `test_reg_incomplete_portmap`).