### PR TITLE
Fix a Yosys translation bug related to SizeCast and BitStruct

### DIFF
--- a/pymtl3/passes/backends/sverilog/testcases/test_cases.py
+++ b/pymtl3/passes/backends/sverilog/testcases/test_cases.py
@@ -80,11 +80,15 @@ CaseSizeCastPaddingStructPort = set_attributes( CaseSizeCastPaddingStructPort,
     ''',
     'REF_SRC',
     '''\
+        typedef struct packed {
+          logic [31:0] foo;
+        } Bits32Foo;
+
         module DUT
         (
           input logic [0:0] clk,
-          input logic [31:0] in_,
-          output logic [31:0] out,
+          input Bits32Foo in_,
+          output logic [63:0] out,
           input logic [0:0] reset
         );
 

--- a/pymtl3/passes/backends/sverilog/testcases/test_cases.py
+++ b/pymtl3/passes/backends/sverilog/testcases/test_cases.py
@@ -63,11 +63,37 @@ from pymtl3.passes.testcases import (
     CasePassThroughComp,
     CaseReducesInx3OutComp,
     CaseSequentialPassThroughComp,
+    CaseSizeCastPaddingStructPort,
     CaseStructPackedArrayUpblkComp,
     CaseSVerilogReservedComp,
     NestedStructPackedPlusScalar,
     ThisIsABitStructWithSuperLongName,
     set_attributes,
+)
+
+CaseSizeCastPaddingStructPort = set_attributes( CaseSizeCastPaddingStructPort,
+    'REF_UPBLK',
+    '''\
+        always_comb begin : upblk
+          out = 64'( in_ );
+        end
+    ''',
+    'REF_SRC',
+    '''\
+        module DUT
+        (
+          input logic [0:0] clk,
+          input logic [31:0] in_,
+          output logic [31:0] out,
+          input logic [0:0] reset
+        );
+
+          always_comb begin : upblk
+            out = 64'( in_ );
+          end
+
+        endmodule
+    '''
 )
 
 CasePassThroughComp = set_attributes( CasePassThroughComp,

--- a/pymtl3/passes/backends/sverilog/translation/behavioral/test/SVBehavioralTranslatorL3_test.py
+++ b/pymtl3/passes/backends/sverilog/translation/behavioral/test/SVBehavioralTranslatorL3_test.py
@@ -14,6 +14,7 @@ from ....testcases import (
     CaseBits32FooInBits32OutComp,
     CaseConstStructInstComp,
     CaseNestedStructPackedArrayUpblkComp,
+    CaseSizeCastPaddingStructPort,
     CaseStructPackedArrayUpblkComp,
 )
 from ..SVBehavioralTranslatorL3 import BehavioralRTLIRToSVVisitorL3
@@ -40,6 +41,7 @@ def run_test( case, m ):
       CaseConstStructInstComp,
       CaseStructPackedArrayUpblkComp,
       CaseNestedStructPackedArrayUpblkComp,
+      CaseSizeCastPaddingStructPort,
     ]
 )
 def test_sverilog_behavioral_L3( case ):

--- a/pymtl3/passes/backends/yosys/testcases/test_cases.py
+++ b/pymtl3/passes/backends/yosys/testcases/test_cases.py
@@ -79,14 +79,17 @@ CaseSizeCastPaddingStructPort = set_attributes( CaseSizeCastPaddingStructPort,
         module DUT
         (
           input logic [0:0] clk,
-          input logic [31:0] in_,
+          input logic [31:0] in___foo,
           output logic [63:0] out,
           input logic [0:0] reset
         );
+          logic [31:0] in_;
 
           always_comb begin : upblk
             out = { { 32 { 1'b0 } }, in_ };
           end
+
+          assign in_[31:0] = in___foo;
 
         endmodule
     '''

--- a/pymtl3/passes/backends/yosys/testcases/test_cases.py
+++ b/pymtl3/passes/backends/yosys/testcases/test_cases.py
@@ -59,11 +59,37 @@ from pymtl3.passes.backends.sverilog.testcases import (
     CasePassThroughComp,
     CaseReducesInx3OutComp,
     CaseSequentialPassThroughComp,
+    CaseSizeCastPaddingStructPort,
     CaseStructPackedArrayUpblkComp,
     CaseSVerilogReservedComp,
     NestedStructPackedPlusScalar,
     ThisIsABitStructWithSuperLongName,
     set_attributes,
+)
+
+CaseSizeCastPaddingStructPort = set_attributes( CaseSizeCastPaddingStructPort,
+    'REF_UPBLK',
+    '''\
+        always_comb begin : upblk
+          out = { { 32 { 1'b0 } }, in_ };
+        end
+    ''',
+    'REF_SRC',
+    '''\
+        module DUT
+        (
+          input logic [0:0] clk,
+          input logic [31:0] in_,
+          output logic [63:0] out,
+          input logic [0:0] reset
+        );
+
+          always_comb begin : upblk
+            out = { { 32 { 1'b0 } }, in_ };
+          end
+
+        endmodule
+    '''
 )
 
 CaseBits32x2ConcatFreeVarComp = set_attributes( CaseBits32x2ConcatFreeVarComp,

--- a/pymtl3/passes/backends/yosys/translation/behavioral/YosysBehavioralTranslatorL1.py
+++ b/pymtl3/passes/backends/yosys/translation/behavioral/YosysBehavioralTranslatorL1.py
@@ -129,6 +129,7 @@ class YosysBehavioralRTLIRToSVVisitorL1( BehavioralRTLIRToSVVisitorL1 ):
     value = None if not hasattr(node.value, "_value") else node.value._value
 
     if value is None:
+      node.value._top_expr = 1
       value_str = s.visit( node.value )
       cur_nbits = node.value.Type.get_dtype().get_length()
       if cur_nbits == nbits:

--- a/pymtl3/passes/backends/yosys/translation/behavioral/test/YosysBehavioralTranslatorL3_test.py
+++ b/pymtl3/passes/backends/yosys/translation/behavioral/test/YosysBehavioralTranslatorL3_test.py
@@ -15,6 +15,7 @@ from ....testcases import (
     CaseBits32FooInBits32OutComp,
     CaseConstStructInstComp,
     CaseNestedStructPackedArrayUpblkComp,
+    CaseSizeCastPaddingStructPort,
     CaseStructPackedArrayUpblkComp,
 )
 from ..YosysBehavioralTranslatorL3 import YosysBehavioralRTLIRToSVVisitorL3
@@ -41,6 +42,7 @@ def run_test( case, m ):
       CaseConstStructInstComp,
       CaseStructPackedArrayUpblkComp,
       CaseNestedStructPackedArrayUpblkComp,
+      CaseSizeCastPaddingStructPort,
     ]
 )
 def test_yosys_behavioral_L3( case ):

--- a/pymtl3/passes/testcases/test_cases.py
+++ b/pymtl3/passes/testcases/test_cases.py
@@ -951,6 +951,27 @@ class CaseScopeTmpWireOverwriteConflictComp:
 # Test cases without errors
 #-------------------------------------------------------------------------
 
+class CaseSizeCastPaddingStructPort:
+  class DUT( Component ):
+    def construct( s ):
+      s.in_ = InPort( Bits32Foo )
+      s.out = OutPort( Bits64 )
+      @s.update
+      def upblk():
+        s.out = Bits64( s.in_ )
+  TV_IN = \
+  _set(
+      'in_', Bits32Foo, 0,
+  )
+  TV_OUT = \
+  _check( 'out', Bits64, 1 )
+  TEST_VECTOR = \
+  [
+      [    0,     concat(   Bits32(0),     Bits32(0)  ) ],
+      [   42,     concat(   Bits32(0),     Bits32(42) ) ],
+      [   -1,     concat(   Bits32(0),     Bits32(-1) ) ],
+  ]
+
 class CaseBits32x2ConcatComp:
   class DUT( Component ):
     def construct( s ):


### PR DESCRIPTION
This PR fixes a bug where a BitStruct port inside a `SizeCast` was not correctly name-mangled. A test case is added to check for this in our regression test suite. 