### PR TITLE
Add ExternalTrace ImportConfig

### DIFF
--- a/pymtl3/passes/backends/sverilog/import_/ImportConfigs.py
+++ b/pymtl3/passes/backends/sverilog/import_/ImportConfigs.py
@@ -32,6 +32,14 @@ class ImportConfigs( BasePassConfigs ):
     # Map pymtl names to Verilog names
     "port_map" : {},
 
+    # Enable external line trace?
+    # Once enabled, the `line_trace()` method of the imported component
+    # will return a string read from the external `line_trace()` function.
+    # This means your Verilog module has to have a `line_trace` function
+    # that provides the line trace string which has less than 512 characters.
+    # Default to False
+    "external_trace" : False,
+
     # Verilator code generation options
     # These options will be passed to verilator to generate the C simulator.
     # By default, verilator is called with `--cc`.
@@ -148,8 +156,8 @@ class ImportConfigs( BasePassConfigs ):
   }
 
   Checkers = {
-    ("import_", "enable_assert", "vl_W_lint", "vl_W_style", "vl_W_fatal",
-     "vl_trace", "verbose", "has_clk", "has_reset", "coverage") :
+    ("import_", "enable_assert", "external_trace", "vl_W_lint", "vl_W_style",
+     "vl_W_fatal", "vl_trace", "verbose", "has_clk", "has_reset", "coverage") :
       Checker( lambda v: isinstance(v, bool), "expects a boolean" ),
 
     ("c_flags", "ld_flags", "ld_libs") :

--- a/pymtl3/passes/backends/sverilog/import_/ImportPass.py
+++ b/pymtl3/passes/backends/sverilog/import_/ImportPass.py
@@ -205,6 +205,7 @@ class ImportPass( BasePass ):
     dump_vcd = int(config.vl_trace)
     vcd_timescale = config.vl_trace_timescale
     half_cycle_time = config.vl_trace_cycle_time // 2
+    external_trace = int(config.external_trace)
     wrapper_name = config.get_c_wrapper_path()
     config.vprint("\n=====Generate C wrapper=====")
 
@@ -336,6 +337,12 @@ constraint_list = [
     # Internal line trace
     in_line_trace = s.gen_internal_line_trace_py( packed_ports )
 
+    # External trace function definition
+    if config.external_trace:
+      external_trace_c_def = f'void trace( V{config.top_module}_t *, char * );'
+    else:
+      external_trace_c_def = ''
+
     # Fill in the python wrapper template
     if not cached:
       with open( template_name, 'r' ) as template:
@@ -356,7 +363,9 @@ constraint_list = [
             constraint_str  = constraint_str,
             line_trace      = line_trace,
             in_line_trace   = in_line_trace,
-            dump_vcd        = int(config.vl_trace)
+            dump_vcd        = int(config.vl_trace),
+            external_trace  = int(config.external_trace),
+            trace_c_def     = external_trace_c_def,
           )
           output.write( py_wrapper )
 
@@ -952,7 +961,7 @@ m->{name}{sub} = {deference}model->{name}{sub};
       full_name = 's.mangled__'+s._verilator_name(name)
       ret.append( template.format( **locals() ) )
     ret.append( 'return lt' )
-    make_indent( ret, 2 )
+    make_indent( ret, 3 )
     return '\n'.join( ret )
 
   #-------------------------------------------------------------------------

--- a/pymtl3/passes/backends/sverilog/import_/test/ImportedObject_test.py
+++ b/pymtl3/passes/backends/sverilog/import_/test/ImportedObject_test.py
@@ -79,16 +79,16 @@ def test_reg_external_trace( do_test ):
 
   a.in_ = Bits32(1)
   a.tick()
-  assert a.line_trace().replace(' ', '') == 'q=0'
+  assert a.line_trace() == 'q =          0'
   a.in_ = Bits32(2)
   a.tick()
-  assert a.line_trace().replace(' ', '') == 'q=1'
+  assert a.line_trace() == 'q =          1'
   a.in_ = Bits32(-1)
   a.tick()
-  assert a.line_trace().replace(' ', '') == 'q=2'
+  assert a.line_trace() == 'q =          2'
   a.tick()
   # 0xFFFFFFFF unsigned
-  assert a.line_trace().replace(' ', '') == 'q=4294967295'
+  assert a.line_trace() == 'q = 4294967295'
 
 def test_reg_incomplete_portmap( do_test ):
   def tv_in( m, test_vector ):

--- a/pymtl3/passes/backends/sverilog/import_/test/ImportedObject_test.py
+++ b/pymtl3/passes/backends/sverilog/import_/test/ImportedObject_test.py
@@ -57,12 +57,12 @@ def test_reg( do_test ):
   do_test( a )
 
 def test_reg_external_trace( do_test ):
-  class VReg( Component ):
+  class VRegTrace( Component ):
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
       s.config_sverilog_import = ImportConfigs(
-          vl_src = get_dir(__file__)+'VReg.sv',
+          vl_src = get_dir(__file__)+'VRegTrace.sv',
           vl_include = [ get_dir(__file__) ],
           port_map = {
             "in_" : "d",
@@ -70,7 +70,7 @@ def test_reg_external_trace( do_test ):
           },
           external_trace = True,
       )
-  a = VReg()
+  a = VRegTrace()
   a.elaborate()
   ipass = ImportPass()
   a.config_sverilog_import.fill_missing( a )

--- a/pymtl3/passes/backends/sverilog/import_/test/ImportedObject_test.py
+++ b/pymtl3/passes/backends/sverilog/import_/test/ImportedObject_test.py
@@ -6,6 +6,7 @@
 """Test if the imported object works correctly."""
 
 
+from pymtl3 import SimulationPass
 from pymtl3.datatypes import Bits1, Bits32, Bits64, clog2, mk_bits
 from pymtl3.dsl import Component, InPort, Interface, OutPort, Placeholder, connect
 from pymtl3.passes.rtlir.util.test_utility import do_test
@@ -54,6 +55,40 @@ def test_reg( do_test ):
   a._tv_in = tv_in
   a._tv_out = tv_out
   do_test( a )
+
+def test_reg_external_trace( do_test ):
+  class VReg( Component ):
+    def construct( s ):
+      s.in_ = InPort( Bits32 )
+      s.out = OutPort( Bits32 )
+      s.config_sverilog_import = ImportConfigs(
+          vl_src = get_dir(__file__)+'VReg.sv',
+          vl_include = [ get_dir(__file__) ],
+          port_map = {
+            "in_" : "d",
+            "out" : "q",
+          },
+          external_trace = True,
+      )
+  a = VReg()
+  a.elaborate()
+  ipass = ImportPass()
+  a.config_sverilog_import.fill_missing( a )
+  a = ipass.get_imported_object( a )
+  a.apply( SimulationPass() )
+
+  a.in_ = Bits32(1)
+  a.tick()
+  assert a.line_trace().replace(' ', '') == 'q=0'
+  a.in_ = Bits32(2)
+  a.tick()
+  assert a.line_trace().replace(' ', '') == 'q=1'
+  a.in_ = Bits32(-1)
+  a.tick()
+  assert a.line_trace().replace(' ', '') == 'q=2'
+  a.tick()
+  # 0xFFFFFFFF unsigned
+  assert a.line_trace().replace(' ', '') == 'q=4294967295'
 
 def test_reg_incomplete_portmap( do_test ):
   def tv_in( m, test_vector ):

--- a/pymtl3/passes/backends/sverilog/import_/test/VReg.sv
+++ b/pymtl3/passes/backends/sverilog/import_/test/VReg.sv
@@ -1,3 +1,5 @@
+`include "trace.v"
+
 module VReg(
   input  logic          clk,
   input  logic          reset,
@@ -7,5 +9,16 @@ module VReg(
   always_ff @(posedge clk) begin
     q <= d;
   end
+
+  logic [`VC_TRACE_NBITS-1:0] str;
+  logic [512*8-1:0] q_str;
+  `VC_TRACE_BEGIN
+  begin
+    /* $display("q = %d\n", q); */
+    $sformat(q_str, "%d", q);
+    vc_trace.append_str( trace_str, "q = " );
+    vc_trace.append_str( trace_str, q_str );
+  end
+  `VC_TRACE_END
 
 endmodule

--- a/pymtl3/passes/backends/sverilog/import_/test/VReg.sv
+++ b/pymtl3/passes/backends/sverilog/import_/test/VReg.sv
@@ -1,5 +1,3 @@
-`include "trace.v"
-
 module VReg(
   input  logic          clk,
   input  logic          reset,
@@ -9,16 +7,5 @@ module VReg(
   always_ff @(posedge clk) begin
     q <= d;
   end
-
-  logic [`VC_TRACE_NBITS-1:0] str;
-  logic [512*8-1:0] q_str;
-  `VC_TRACE_BEGIN
-  begin
-    /* $display("q = %d\n", q); */
-    $sformat(q_str, "%d", q);
-    vc_trace.append_str( trace_str, "q = " );
-    vc_trace.append_str( trace_str, q_str );
-  end
-  `VC_TRACE_END
 
 endmodule

--- a/pymtl3/passes/backends/sverilog/import_/test/VRegTrace.sv
+++ b/pymtl3/passes/backends/sverilog/import_/test/VRegTrace.sv
@@ -1,0 +1,24 @@
+`include "trace.v"
+
+module VRegTrace(
+  input  logic          clk,
+  input  logic          reset,
+  output logic [32-1:0] q,
+  input  logic [32-1:0] d
+);
+  always_ff @(posedge clk) begin
+    q <= d;
+  end
+
+  logic [`VC_TRACE_NBITS-1:0] str;
+  logic [512*8-1:0] q_str;
+  `VC_TRACE_BEGIN
+  begin
+    /* $display("q = %d\n", q); */
+    $sformat(q_str, "%d", q);
+    vc_trace.append_str( trace_str, "q = " );
+    vc_trace.append_str( trace_str, q_str );
+  end
+  `VC_TRACE_END
+
+endmodule

--- a/pymtl3/passes/backends/sverilog/import_/test/trace.v
+++ b/pymtl3/passes/backends/sverilog/import_/test/trace.v
@@ -1,0 +1,285 @@
+//========================================================================
+// Line Tracing
+//========================================================================
+
+`ifndef VC_TRACE_V
+`define VC_TRACE_V
+
+// NOTE: This macro is declared outside of the module to allow some vc
+// modules to see it and use it in their own params. Verilog does not
+// allow other modules to hierarchically reference the nbits localparam
+// inside this module in constant expressions (e.g., localparams).
+
+`define VC_TRACE_NCHARS 512
+`define VC_TRACE_NBITS  512*8
+
+module vc_Trace
+(
+  input logic clk,
+  input logic reset
+);
+
+  integer len0;
+  integer len1;
+  integer idx0;
+  integer idx1;
+
+  // NOTE: If you change these, then you also need to change the
+  // hard-coded constant in the declaration of the trace function at the
+  // bottom of this file.
+  // NOTE: You would also need to change the VC_TRACE_NBITS and
+  // VC_TRACE_NCHARS macro at the top of this file.
+
+  localparam nchars = 512;
+  localparam nbits  = 512*8;
+
+  // This is the actual trace storage used when displaying a trace
+
+  logic [nbits-1:0] storage;
+
+  // Meant to be accesible from outside module
+
+  integer cycles_next = 0;
+  integer cycles      = 0;
+
+  // Get trace level from command line
+
+  logic [3:0] level;
+
+`ifndef VERILATOR
+  initial begin
+    if ( !$value$plusargs( "trace=%d", level ) ) begin
+      level = 0;
+    end
+  end
+`else
+  initial begin
+    level = 1;
+  end
+`endif // !`ifndef VERILATOR
+
+  // Track cycle count
+
+  always_ff @( posedge clk ) begin
+    cycles <= ( reset ) ? 0 : cycles_next;
+  end
+
+  //----------------------------------------------------------------------
+  // append_str
+  //----------------------------------------------------------------------
+  // Appends a string to the trace.
+
+  task append_str
+  (
+    inout logic [nbits-1:0] trace,
+    input logic [nbits-1:0] str
+  );
+  begin
+
+    len0 = 1;
+    while ( str[len0*8+:8] != 0 ) begin
+      len0 = len0 + 1;
+    end
+
+    idx0 = trace[31:0];
+
+    for ( idx1 = len0-1; idx1 >= 0; idx1 = idx1 - 1 )
+    begin
+      trace[ idx0*8 +: 8 ] = str[ idx1*8 +: 8 ];
+      idx0 = idx0 - 1;
+    end
+
+    trace[31:0] = idx0;
+
+  end
+  endtask
+
+  //----------------------------------------------------------------------
+  // append_str_ljust
+  //----------------------------------------------------------------------
+  // Appends a left-justified string to the trace.
+
+  task append_str_ljust
+  (
+    inout logic [nbits-1:0] trace,
+    input logic [nbits-1:0] str
+  );
+  begin
+
+    idx0 = trace[31:0];
+    idx1 = nchars;
+
+    while ( str[ idx1*8-1 -: 8 ] != 0 ) begin
+      trace[ idx0*8 +: 8 ] = str[ idx1*8-1 -: 8 ];
+      idx0 = idx0 - 1;
+      idx1 = idx1 - 1;
+    end
+
+    trace[31:0] = idx0;
+
+  end
+  endtask
+
+  //----------------------------------------------------------------------
+  // append_chars
+  //----------------------------------------------------------------------
+  // Appends the given number of characters to the trace.
+
+  task append_chars
+  (
+    inout logic   [nbits-1:0] trace,
+    input logic         [7:0] char,
+    input integer             num
+  );
+  begin
+
+    idx0 = trace[31:0];
+
+    for ( idx1 = 0;
+          idx1 < num;
+          idx1 = idx1 + 1 )
+    begin
+      trace[idx0*8+:8] = char;
+      idx0 = idx0 - 1;
+    end
+
+    trace[31:0] = idx0;
+
+  end
+  endtask
+
+  //----------------------------------------------------------------------
+  // append_val_str
+  //----------------------------------------------------------------------
+  // Append a string modified by val signal.
+
+  task append_val_str
+  (
+    inout logic [nbits-1:0] trace,
+    input logic             val,
+    input logic [nbits-1:0] str
+  );
+  begin
+
+    len1 = 0;
+    while ( str[len1*8+:8] != 0 ) begin
+      len1 = len1 + 1;
+    end
+
+    if ( val )
+      append_str( trace, str );
+    else if ( !val )
+      append_chars( trace, " ", len1 );
+    else begin
+      append_str( trace, "x" );
+      append_chars( trace, " ", len1-1 );
+    end
+
+  end
+  endtask
+
+  //----------------------------------------------------------------------
+  // val_rdy_str
+  //----------------------------------------------------------------------
+  // Append a string modified by val/rdy signals.
+
+  task append_val_rdy_str
+  (
+    inout logic [nbits-1:0] trace,
+    input logic             val,
+    input logic             rdy,
+    input logic [nbits-1:0] str
+  );
+  begin
+
+    len1 = 0;
+    while ( str[len1*8+:8] != 0 ) begin
+      len1 = len1 + 1;
+    end
+
+    if ( rdy && val ) begin
+      append_str( trace, str );
+    end
+    else if ( rdy && !val ) begin
+      append_chars( trace, " ", len1 );
+    end
+    else if ( !rdy && val ) begin
+      append_str( trace, "#" );
+      append_chars( trace, " ", len1-1 );
+    end
+    else if ( !rdy && !val ) begin
+      append_str( trace, "." );
+      append_chars( trace, " ", len1-1 );
+    end
+    else begin
+      append_str( trace, "x" );
+      append_chars( trace, " ", len1-1 );
+    end
+
+  end
+  endtask
+
+endmodule
+
+//------------------------------------------------------------------------
+// VC_TRACE_NBITS_TO_NCHARS
+//------------------------------------------------------------------------
+// Macro to determine number of characters for a net
+
+`define VC_TRACE_NBITS_TO_NCHARS( nbits_ ) ((nbits_+3)/4)
+
+//------------------------------------------------------------------------
+// VC_TRACE_BEGIN
+//------------------------------------------------------------------------
+
+//`define VC_TRACE_BEGIN                                                  \
+//  export "DPI-C" task line_trace;                                       \
+//  vc_Trace vc_trace(clk,reset);                                         \
+//  task line_trace( inout bit [(512*8)-1:0] trace_str );
+
+`ifndef VERILATOR
+`define VC_TRACE_BEGIN                                                  \
+  vc_Trace vc_trace(clk,reset);                                         \
+                                                                        \
+  task display_trace;                                                   \
+  begin                                                                 \
+                                                                        \
+    if ( vc_trace.level > 0 ) begin                                     \
+      vc_trace.storage[15:0] = vc_trace.nchars-1;                       \
+                                                                        \
+      line_trace( vc_trace.storage );                                   \
+                                                                        \
+      $write( "%4d: ", vc_trace.cycles );                               \
+                                                                        \
+      vc_trace.idx0 = vc_trace.storage[15:0];                           \
+      for ( vc_trace.idx1 = vc_trace.nchars-1;                          \
+            vc_trace.idx1 > vc_trace.idx0;                              \
+            vc_trace.idx1 = vc_trace.idx1 - 1 )                         \
+      begin                                                             \
+        $write( "%s", vc_trace.storage[vc_trace.idx1*8+:8] );           \
+      end                                                               \
+      $write("\n");                                                     \
+                                                                        \
+    end                                                                 \
+                                                                        \
+    vc_trace.cycles_next = vc_trace.cycles + 1;                         \
+                                                                        \
+  end                                                                   \
+  endtask                                                               \
+                                                                        \
+  task line_trace( inout bit [(512*8)-1:0] trace_str );
+`else
+`define VC_TRACE_BEGIN                                                  \
+  export "DPI-C" task line_trace;                                       \
+  vc_Trace vc_trace(clk,reset);                                         \
+  task line_trace( inout bit [(512*8)-1:0] trace_str );
+`endif
+
+//------------------------------------------------------------------------
+// VC_TRACE_END
+//------------------------------------------------------------------------
+
+`define VC_TRACE_END \
+  endtask
+
+`endif /* VC_TRACE_V */

--- a/pymtl3/passes/backends/sverilog/import_/verilator_wrapper.c.template
+++ b/pymtl3/passes/backends/sverilog/import_/verilator_wrapper.c.template
@@ -15,6 +15,14 @@
 // set to true when VCD tracing is enabled in Verilator
 #define DUMP_VCD {dump_vcd}
 
+// set to true when Verilog module has line tracing
+#define VLINETRACE {external_trace}
+
+#if VLINETRACE
+#include "obj_dir_{component_name}/V{component_name}__Syms.h"
+#include "svdpi.h"
+#endif
+
 //------------------------------------------------------------------------
 // CFFI Interface
 //------------------------------------------------------------------------
@@ -47,6 +55,10 @@ extern "C" {{
   void eval( V{component_name}_t * );
   void assert_en( bool en );
 
+  #if VLINETRACE
+  void trace( V{component_name}_t *, char * );
+  #endif
+
 }}
 
 //------------------------------------------------------------------------
@@ -60,7 +72,9 @@ vluint64_t g_main_time = 0;
 
 double sc_time_stamp()
 {{
+
   return g_main_time;
+
 }}
 
 //------------------------------------------------------------------------
@@ -105,6 +119,7 @@ V{component_name}_t * create_model( const char *vcd_filename ) {{
 {port_inits}
 
   return m;
+
 }}
 
 //------------------------------------------------------------------------
@@ -179,3 +194,76 @@ void assert_en( bool en ) {{
   Verilated::assertOn(en);
 
 }}
+
+//------------------------------------------------------------------------
+// trace()
+//------------------------------------------------------------------------
+// Note that we assume a trace string buffer of 512 characters. This is
+// assumed in a couple of places, including the Python wrapper template
+// and the Verilog vc/trace.v code. So if we change it, we need to change
+// it everywhere.
+
+#if VLINETRACE
+void trace( V{component_name}_t * m, char* str ) {{
+
+  V{component_name} * model = (V{component_name} *) m->model;
+
+  const int nchars = 512;
+  const int nwords = nchars/4;
+
+  uint32_t words[nwords];
+  words[0] = nchars-1;
+
+  // Setup scope for accessing the line tracing function throug DPI.
+  // Note, I tried using just this:
+  //
+  //  svSetScope( svGetScopeFromName("TOP.v.verilog_module") );
+  //
+  // but it did not seem to work. We would see correct line tracing for
+  // the first test case but not any of the remaining tests cases. After
+  // digging around a bit, it seemed like the line_trace task was still
+  // associated with the very first model as opposed to the newly
+  // instantiated models. Directly setting the scope seemed to fix
+  // this issue.
+  //
+  // Note that this issue implies that the mysterious extra .v is no
+  // longer present:
+  //
+  //  https://www.veripool.org/issues/1050-Verilator-Extra-v-in-full-signal-pathnames
+  //
+  // So now we need to explicitly use the model name instead of
+  // Vscope_v__verilog_module.
+
+  svSetScope( &model->__VlSymsp->__Vscope_{component_name} );
+  model->line_trace( words );
+
+  // Note that the way the line tracing works, the line tracing function
+  // will store how the last character used in the line trace in the
+  // first element of the word array. The line tracing functions store
+  // the line trace starting from the most-signicant character due to the
+  // way that Verilog handles strings.
+
+  int nchar_last  = words[0];
+  int nchars_used = ( nchars - 1 - nchar_last );
+
+  // We subtract since one of the words (i.e., 4 characters) is for
+  // storing the nchars_used.
+
+  assert ( nchars_used < (nchars - 4) );
+
+  // Now we need to iterate from the most-significant character to the
+  // last character written by the line tracing functions and copy these
+  // characters into the given character array. So we are kind of
+  // flipping the order of the characters due to the different between
+  // how Verilog and C handle strings.
+
+  int j = 0;
+  for ( int i = nchars-1; i > nchar_last; i-- ) {{
+    char c = static_cast<char>( words[i/4] >> (8*(i%4)) );
+    str[j] = c;
+    j++;
+  }}
+  str[j] = '\0';
+
+}}
+#endif

--- a/pymtl3/passes/backends/sverilog/import_/verilator_wrapper.py.template
+++ b/pymtl3/passes/backends/sverilog/import_/verilator_wrapper.py.template
@@ -58,6 +58,7 @@ class {component_name}( Component ):
       void destroy_model( V{component_name}_t *);
       void eval( V{component_name}_t * );
       void assert_en( bool en );
+      {trace_c_def}
 
     """)
 
@@ -118,6 +119,10 @@ class {component_name}( Component ):
     # Construct the model
     s._ffi_m = s._ffi_inst.create_model( s.ffi.new("char[]", verilator_vcd_file) )
 
+    # Buffer for line tracing
+    s._line_trace_str = s.ffi.new('char[512]')
+    s._convert_string = s.ffi.string
+
     # Use non-attribute varialbe to reduce CPython bytecode count
     _ffi_m = s._ffi_m
     _ffi_inst = s._ffi_inst
@@ -163,6 +168,10 @@ class {component_name}( Component ):
     s._ffi_inst.assert_en( en )
 
   def line_trace( s ):
+    if {external_trace}:
+      s._ffi_inst.trace( s._ffi_m, s._line_trace_str )
+      return s._convert_string( s._line_trace_str ).decode('ascii')
+    else:
 {line_trace}
 
   def internal_line_trace( s ):


### PR DESCRIPTION
`ExternalTrace` config will bring the Verilog line trace string to PyMTL through DPI call. It essentially ports the same functionality from PyMTL v2 to PyMTL 3.