### PR TITLE
Support non-zero Verilator initial values

### DIFF
--- a/pymtl3/passes/backends/sverilog/import_/ImportConfigs.py
+++ b/pymtl3/passes/backends/sverilog/import_/ImportConfigs.py
@@ -98,6 +98,10 @@ class ImportConfigs( BasePassConfigs ):
 
     # Verilator misc options
 
+    # What is the inital value of signals?
+    # Should be one of ['zeros', 'ones', 'rand']
+    "vl_xinit" : "zeros",
+
     # --trace
     # Expects a boolean value
     "vl_trace" : False,
@@ -173,6 +177,9 @@ class ImportConfigs( BasePassConfigs ):
 
     "vl_include": Checker( lambda v: isinstance(v, list) and all(os.path.isdir(expand(p)) for p in v),
                             "expects a path to directory"),
+
+    "vl_xinit": Checker( lambda v: v in ['zeros', 'ones', 'rand'],
+                  "vl_xinit should be one of ['zeros', 'ones', 'rand']" ),
 
     "vl_trace_timescale": Checker( lambda v: isinstance(v, str) and len(v) > 2 and v[-1] == 's' and \
                                     v[-2] in ['p', 'n', 'u', 'm'] and \
@@ -336,6 +343,16 @@ class ImportConfigs( BasePassConfigs ):
 
   def get_param_include( s ):
     return s.v_module2param
+
+  def get_vl_xinit_value( s ):
+    if s.vl_xinit == 'zeros':
+      return 0
+    elif s.vl_xinit == 'ones':
+      return 1
+    elif s.vl_xinit == 'rand':
+      return 2
+    else:
+      raise InvalidPassOptionValue("vl_xinit should be one of 'zeros', 'ones', or 'rand'!")
 
   def get_c_wrapper_path( s ):
     return f"{s.top_module}_v.cpp"

--- a/pymtl3/passes/backends/sverilog/import_/ImportPass.py
+++ b/pymtl3/passes/backends/sverilog/import_/ImportPass.py
@@ -206,6 +206,7 @@ class ImportPass( BasePass ):
     vcd_timescale = config.vl_trace_timescale
     half_cycle_time = config.vl_trace_cycle_time // 2
     wrapper_name = config.get_c_wrapper_path()
+    verilator_xinit_value = config.get_vl_xinit_value()
     config.vprint("\n=====Generate C wrapper=====")
 
     # The wrapper template should be in the same directory as this file

--- a/pymtl3/passes/backends/sverilog/import_/test/ImportedObject_test.py
+++ b/pymtl3/passes/backends/sverilog/import_/test/ImportedObject_test.py
@@ -55,6 +55,35 @@ def test_reg( do_test ):
   a._tv_out = tv_out
   do_test( a )
 
+def test_vl_uninit( do_test ):
+  # Use a latch to test if verilator has correctly set up
+  # the inital signal values
+  def tv_in( m, test_vector ):
+    m.in_ = Bits32( test_vector[0] )
+  def tv_out( m, test_vector ):
+    assert m.out == Bits32( test_vector[1] )
+  class VUninit( Component ):
+    def construct( s ):
+      s.in_ = InPort( Bits32 )
+      s.out = OutPort( Bits32 )
+      s.config_sverilog_import = ImportConfigs(
+          vl_src = get_dir(__file__)+'VUninit.sv',
+          port_map = {
+            "in_" : "d",
+            "out" : "q",
+          },
+          vl_xinit = 'ones',
+      )
+  a = VUninit()
+  a._test_vectors = [
+    [    0, 4294967295 ],
+    [    2, 4294967295 ],
+    [   42,         42 ],
+  ]
+  a._tv_in = tv_in
+  a._tv_out = tv_out
+  do_test( a )
+
 def test_reg_incomplete_portmap( do_test ):
   def tv_in( m, test_vector ):
     m.in_ = Bits32( test_vector[0] )

--- a/pymtl3/passes/backends/sverilog/import_/test/VUninit.sv
+++ b/pymtl3/passes/backends/sverilog/import_/test/VUninit.sv
@@ -1,0 +1,13 @@
+module VUninit(
+  input  logic          clk,
+  input  logic          reset,
+  output logic [32-1:0] q,
+  input  logic [32-1:0] d
+);
+
+  always_comb begin
+    if (d == 32'd42)
+      q = 32'd42;
+  end
+
+endmodule

--- a/pymtl3/passes/backends/sverilog/import_/verilator_wrapper.c.template
+++ b/pymtl3/passes/backends/sverilog/import_/verilator_wrapper.c.template
@@ -74,7 +74,7 @@ V{component_name}_t * create_model( const char *vcd_filename ) {{
   V{component_name}_t * m;
   V{component_name}   * model;
 
-  Verilated::randReset( 0 );
+  Verilated::randReset( {verilator_xinit_value} );
 
   m     = (V{component_name}_t *) malloc( sizeof(V{component_name}_t) );
   model = new V{component_name}();


### PR DESCRIPTION
`vl_xinit` import config is added in this PR. This option could be one of `zeros`, `ones`, and `rand` to set the initial value of signals in Verilator to be all zeros, all ones, and random values.