### PR TITLE
add clone in bitstruct and bits to get rid of deepcopy

### DIFF
--- a/pymtl3/datatypes/PythonBits.py
+++ b/pymtl3/datatypes/PythonBits.py
@@ -30,6 +30,9 @@ class Bits:
   def clone( self ):
     return Bits( self.nbits, self.value )
 
+  def __deepcopy__( self, memo ):
+    return Bits( self.nbits, self.value )
+
   def __call__( self ):
     return Bits( self.nbits )
 

--- a/pymtl3/datatypes/PythonBits.py
+++ b/pymtl3/datatypes/PythonBits.py
@@ -27,6 +27,9 @@ class Bits:
   def _flip( self ):
     self.value = self._next
 
+  def clone( self ):
+    return Bits( self.nbits, self.value )
+
   def __call__( self ):
     return Bits( self.nbits )
 

--- a/pymtl3/datatypes/bitstructs.py
+++ b/pymtl3/datatypes/bitstructs.py
@@ -330,7 +330,6 @@ def _mk_ff_fn( fields ):
 # def clone( self ):
 #   return self.__class__( self.x.clone(), [ self.y[0].clone(), self.y[1].clone() ]  )
 
-
 def _gen_list_clone_strs( type_, prefix='' ):
   if isinstance( type_, list ):
     return "[" + ",".join( [ _gen_list_clone_strs( type_[0], f"{prefix}[{i}]" )
@@ -350,6 +349,22 @@ def _mk_clone_fn( fields ):
     clone_strs + [ ')' ],
   )
 
+def _mk_deepcopy_fn():
+  clone_strs = [ 'return self.__class__(' ]
+
+  for name, type_ in fields.items():
+    clone_strs.append( "  " + _gen_list_clone_strs( type_, f'self.{name}' ) + "," )
+
+  return _create_fn(
+    'clone',
+    [ 'self' ],
+    clone_strs + [ ')' ],
+  )
+  return _create_fn(
+    '__deepcopy__',
+    [ 'self', 'memo' ],
+    clone_strs + [ ')' ],
+  )
 #-------------------------------------------------------------------------
 # _check_valid_array
 #-------------------------------------------------------------------------
@@ -501,11 +516,12 @@ def _process_class( cls, add_init=True, add_str=True, add_repr=True,
   cls.__ilshift__, cls._flip = _mk_ff_fn( fields )
 
   # Shunning: add clone
-  assert not 'clone' in cls.__dict__
+  assert not 'clone' in cls.__dict__ and not '__deepcopy__' in cls.__dict__
 
   cls.clone = _mk_clone_fn( fields )
 
   assert not 'get_field_type' in cls.__dict__
+  cls.__deepcopy__ = _mk_deepcopy_fn()
 
   def get_field_type( cls, name ):
     if name in cls.__bitstruct_fields__:

--- a/pymtl3/datatypes/bitstructs.py
+++ b/pymtl3/datatypes/bitstructs.py
@@ -349,17 +349,12 @@ def _mk_clone_fn( fields ):
     clone_strs + [ ')' ],
   )
 
-def _mk_deepcopy_fn():
+def _mk_deepcopy_fn( fields ):
   clone_strs = [ 'return self.__class__(' ]
 
   for name, type_ in fields.items():
     clone_strs.append( "  " + _gen_list_clone_strs( type_, f'self.{name}' ) + "," )
 
-  return _create_fn(
-    'clone',
-    [ 'self' ],
-    clone_strs + [ ')' ],
-  )
   return _create_fn(
     '__deepcopy__',
     [ 'self', 'memo' ],
@@ -520,8 +515,9 @@ def _process_class( cls, add_init=True, add_str=True, add_repr=True,
 
   cls.clone = _mk_clone_fn( fields )
 
+  cls.__deepcopy__ = _mk_deepcopy_fn( fields )
+
   assert not 'get_field_type' in cls.__dict__
-  cls.__deepcopy__ = _mk_deepcopy_fn()
 
   def get_field_type( cls, name ):
     if name in cls.__bitstruct_fields__:

--- a/pymtl3/datatypes/test/bitstructs_test.py
+++ b/pymtl3/datatypes/test/bitstructs_test.py
@@ -410,6 +410,30 @@ def test_list_same_class():
   assert a.x == Bits4(0)
   assert a.y == [ Bits4(0), Bits4(0) ]
 
+  b = a.clone()
+  assert a == b
+
+  b.x = Bits4(3)
+
+  assert a.x != b.x
+  assert a.y[0] == b.y[0]
+  assert a.y[1] == b.y[1]
+  assert a != b
+
+  b.y[0] = Bits4(4)
+
+  assert a.x != b.x
+  assert a.y[0] != b.y[0]
+  assert a.y[1] == b.y[1]
+  assert a != b
+
+  b.y[1] = Bits4(4)
+
+  assert a.x != b.x
+  assert a.y[0] != b.y[0]
+  assert a.y[1] != b.y[1]
+  assert a != b
+
 def test_crazy_list_not_same_class():
   @bitstruct
   class A:
@@ -478,3 +502,7 @@ def test_mk_high_d_list_struct_inside():
   assert b.y == [ [ [ [ A(), A(), A()] ] for _ in range(6) ] for _ in range(10) ]
 
   print(b)
+  c = b.clone()
+  c.y[9][2][0][2].x = Bits4(3)
+  print(c.y[9][2][0][2])
+  assert b != c

--- a/pymtl3/passes/autotick/OpenLoopCLPass.py
+++ b/pymtl3/passes/autotick/OpenLoopCLPass.py
@@ -316,18 +316,25 @@ class OpenLoopCLPass( BasePass ):
 
         copy_srcs  = []
         check_srcs = []
-        print_srcs = []
+        # print_srcs = []
 
         for j, var in enumerate(variables):
-          copy_srcs .append( "_____tmp_{} = deepcopy({})".format( j, var ) )
-          check_srcs.append( "{} == _____tmp_{}".format( var, j ) )
-          print_srcs.append( "print '{}', {}, _____tmp_{}".format( var, var, j ) )
+          if issubclass( var._dsl.Type, Bits ):
+            copy_srcs.append( "t{} = {}.value".format( j, var ) )
+          elif is_bitstruct_class( var._dsl.Type ):
+            copy_srcs.append( "t{} = {}.clone()".format( j, var ) )
+          else:
+            copy_srcs.append( "t{} = deepcopy({})".format( j, var ) )
+
+          check_srcs.append( "{} == t{}".format( var, j ) )
+          # print_srcs.append( "print '{}', {}, _____tmp_{}".format( var, var, j ) )
 
         scc_block_src = template.format( scc_id,
                                          "; ".join( copy_srcs ),
                                          " and ".join( check_srcs ),
                                          ", ".join( [ x.__name__ for x in scc] ) )
                                          # "; ".join( print_srcs ) )
+
         update_schedule.append( gen_wrapped_SCCblk( top, tmp_schedule, scc_block_src ) )
 
     # Shunning: we call line trace related pass here.

--- a/pymtl3/passes/autotick/OpenLoopCLPass.py
+++ b/pymtl3/passes/autotick/OpenLoopCLPass.py
@@ -324,9 +324,9 @@ class OpenLoopCLPass( BasePass ):
           elif is_bitstruct_class( var._dsl.Type ):
             copy_srcs.append( f"t{j} = {var}.clone()" )
           else:
-            copy_srcs.append( "t{j} = deepcopy({var})" )
+            copy_srcs.append( f"t{j} = deepcopy({var})" )
 
-          check_srcs.append( "{var} == t{j}" )
+          check_srcs.append( f"{var} == t{j}" )
           # print_srcs.append( f"print '{var}', {var}, _____tmp_{j}" )
 
         scc_block_src = template.format( scc_id,

--- a/pymtl3/passes/autotick/OpenLoopCLPass.py
+++ b/pymtl3/passes/autotick/OpenLoopCLPass.py
@@ -320,14 +320,14 @@ class OpenLoopCLPass( BasePass ):
 
         for j, var in enumerate(variables):
           if issubclass( var._dsl.Type, Bits ):
-            copy_srcs.append( "t{} = {}.value".format( j, var ) )
+            copy_srcs.append( f"t{j} = {var}.value" )
           elif is_bitstruct_class( var._dsl.Type ):
-            copy_srcs.append( "t{} = {}.clone()".format( j, var ) )
+            copy_srcs.append( f"t{j} = {var}.clone()" )
           else:
-            copy_srcs.append( "t{} = deepcopy({})".format( j, var ) )
+            copy_srcs.append( "t{j} = deepcopy({var})" )
 
-          check_srcs.append( "{} == t{}".format( var, j ) )
-          # print_srcs.append( "print '{}', {}, _____tmp_{}".format( var, var, j ) )
+          check_srcs.append( "{var} == t{j}" )
+          # print_srcs.append( f"print '{var}', {var}, _____tmp_{j}" )
 
         scc_block_src = template.format( scc_id,
                                          "; ".join( copy_srcs ),

--- a/pymtl3/passes/sim/DynamicSchedulePass.py
+++ b/pymtl3/passes/sim/DynamicSchedulePass.py
@@ -277,14 +277,14 @@ class DynamicSchedulePass( BasePass ):
 
         for j, var in enumerate(variables):
           if issubclass( var._dsl.Type, Bits ):
-            copy_srcs.append( "t{j} = {var}.value" )
+            copy_srcs.append( f"t{j} = {var}.value" )
           elif is_bitstruct_class( var._dsl.Type ):
-            copy_srcs.append( "t{j} = {var}.clone()" )
+            copy_srcs.append( f"t{j} = {var}.clone()" )
           else:
-            copy_srcs.append( "t{j} = deepcopy({var})" )
+            copy_srcs.append( f"t{j} = deepcopy({var})" )
 
-          check_srcs.append( "{var} == t{j}" )
-          # print_srcs.append( "print '{var}', {var}, _____tmp_{j}" )
+          check_srcs.append( f"{var} == t{j}" )
+          # print_srcs.append( f"print '{var}', {var}, _____tmp_{j}" )
 
         scc_block_src = template.format( scc_id,
                                          "; ".join( copy_srcs ),

--- a/pymtl3/passes/sim/DynamicSchedulePass.py
+++ b/pymtl3/passes/sim/DynamicSchedulePass.py
@@ -277,14 +277,14 @@ class DynamicSchedulePass( BasePass ):
 
         for j, var in enumerate(variables):
           if issubclass( var._dsl.Type, Bits ):
-            copy_srcs.append( "t{} = {}.value".format( j, var ) )
+            copy_srcs.append( "t{j} = {var}.value" )
           elif is_bitstruct_class( var._dsl.Type ):
-            copy_srcs.append( "t{} = {}.clone()".format( j, var ) )
+            copy_srcs.append( "t{j} = {var}.clone()" )
           else:
-            copy_srcs.append( "t{} = deepcopy({})".format( j, var ) )
+            copy_srcs.append( "t{j} = deepcopy({var})" )
 
-          check_srcs.append( "{} == t{}".format( var, j ) )
-          # print_srcs.append( "print '{}', {}, _____tmp_{}".format( var, var, j ) )
+          check_srcs.append( "{var} == t{j}" )
+          # print_srcs.append( "print '{var}', {var}, _____tmp_{j}" )
 
         scc_block_src = template.format( scc_id,
                                          "; ".join( copy_srcs ),


### PR DESCRIPTION
This PR accelerates the simulation performance under dynamic scheduling by specifically using .clone() in Bits and bit structs. We used to use deepcopy and it can really dominate the simulation performance when there is a lot of bitstructs.