### PR TITLE
Correct the imemresp_q/drop order in tinyrv0

### DIFF
--- a/examples/ex03_proc/MiscRTL.py
+++ b/examples/ex03_proc/MiscRTL.py
@@ -8,15 +8,15 @@ Author : Shunning Jiang
   Date : June 13, 2019
 """
 from pymtl3 import *
-from pymtl3.stdlib.ifcs import RecvIfcRTL, SendIfcRTL
+from pymtl3.stdlib.ifcs import GetIfcRTL, GiveIfcRTL
 from pymtl3.stdlib.rtl import RegRst
 
 from .TinyRV0InstRTL import *
 
 # State Constants
 
-SNOOP = Bits1(0)
-WAIT  = Bits1(1)
+SNOOP = b1(0)
+WAIT  = b1(1)
 
 #-------------------------------------------------------------------------
 # DropUnit
@@ -28,53 +28,50 @@ WAIT  = Bits1(1)
 
 class DropUnitRTL( Component ):
 
-  def construct( s, Type ):
+  def construct( s, dtype ):
 
-    s.drop = InPort( Bits1 )
-    s.in_  = RecvIfcRTL( Type )
-    s.out  = SendIfcRTL( Type )
+    s.drop = InPort()
+    s.in_  = GetIfcRTL( dtype )
+    s.out  = GiveIfcRTL( dtype )
 
-    s.in_.msg //= s.out.msg
+    s.out.ret //= s.in_.ret
 
-    s.snoop_state = RegRst( Bits1, reset_value=0 )
+    s.snoop_state = Wire()
 
-    @s.update
+    #------------------------------------------------------------------
+    # state_transitions
+    #------------------------------------------------------------------
+
+    @s.update_ff
     def state_transitions():
-      curr_state = s.snoop_state.out
 
-      s.snoop_state.in_ = curr_state
+      if s.reset:
+        s.snoop_state <<= SNOOP
 
-      if s.snoop_state.out == SNOOP:
-        # we wait if we haven't received the response yet
-        if s.drop & (~s.out.rdy | ~s.in_.en):
-          s.snoop_state.in_ = WAIT
+      elif s.snoop_state == SNOOP:
+        if s.drop & ~s.in_.rdy:
+          s.snoop_state <<= WAIT
 
-      elif s.snoop_state.out == WAIT:
-        # we are done waiting if the response arrives
-        if s.in_.en:
-          s.snoop_state.in_ = SNOOP
+      elif s.snoop_state == WAIT:
+        if s.in_.rdy:
+          s.snoop_state <<= SNOOP
 
-    @s.update
-    def state_output_val():
-      if   s.snoop_state.out == SNOOP:
-        s.out.en = s.in_.en & ~s.drop # if in is enabled, s.in_.rdy and s.out.rdy must be True
-
-      elif s.snoop_state.out == WAIT:
-        s.out.en = b1(0)
-
-      else:
-        s.out.en = b1(0)
+    #------------------------------------------------------------------
+    # set_outputs
+    #------------------------------------------------------------------
 
     @s.update
-    def state_output_rdy():
-      if   s.snoop_state.out == SNOOP:
-        s.in_.rdy = s.out.rdy
+    def set_outputs():
+      s.out.rdy = b1(0)
+      s.in_.en  = b1(0)
 
-      elif s.snoop_state.out == WAIT:
-        s.in_.rdy = b1(1)
+      if   s.snoop_state == SNOOP:
+        s.out.rdy = s.in_.rdy & ~s.drop
+        s.in_.en  = s.out.en
 
-      else:
-        s.in_.rdy = b1(1)
+      elif s.snoop_state == WAIT:
+        s.out.rdy = b1(0)
+        s.in_.en  = s.in_.rdy
 
 #-------------------------------------------------------------------------
 # Generate intermediate (imm) based on type


### PR DESCRIPTION
Recently I found a bug due to the transition from val/rdy to en/rdy. Basically we need to put the drop unit _after_ the bypass queue to correctly drop the response. Putting the drop unit between memory and the imemresp_q will let some response slip through and sit in the bypass queue due to stall in the pipeline.