### PR TITLE
connect_bits2bitstruct

### DIFF
--- a/pymtl3/dsl/Connectable.py
+++ b/pymtl3/dsl/Connectable.py
@@ -36,6 +36,12 @@ class Connectable:
       except AttributeError:
         raise NotElaboratedError()
 
+  def get_type( s ):
+    try:
+      return s._dsl.Type
+    except AttriibuteError:
+      raise NotElaboratedError()
+
   def __ifloordiv__( s, other ):
     # Currently this basically implements connect( s, other ), but to
     # avoid circular import, we replicate the implementation of connect.

--- a/pymtl3/stdlib/connects/__init__.py
+++ b/pymtl3/stdlib/connects/__init__.py
@@ -1,1 +1,2 @@
 from .connect_pairs import connect_pairs
+from .connect_bits2bitstruct import connect_bits2bitstruct

--- a/pymtl3/stdlib/connects/__init__.py
+++ b/pymtl3/stdlib/connects/__init__.py
@@ -1,2 +1,2 @@
-from .connect_pairs import connect_pairs
 from .connect_bits2bitstruct import connect_bits2bitstruct
+from .connect_pairs import connect_pairs

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct.py
@@ -22,7 +22,7 @@ def _connect_bits2bitstruct_h( field, bits_signal, slices ):
   # are very few use cases; 2) the pack order of a list of fields is
   # somewhat ambiguous.
   if isinstance( field, list ):
-    assert False, "A list of fields is not supported at the moment."
+    assert False, 'A list of fields is not supported at the moment.'
 
   field_type = field.get_type()
 
@@ -51,13 +51,19 @@ def connect_bits2bitstruct( signal1, signal2 ):
   type2 = signal2.get_type()
 
   if is_bitstruct_class( type1 ):
-    assert issubclass( type2, Bits )
+    assert issubclass( type2, Bits ), \
+      f'{type1.__qualname__} is a bitstruct ' \
+      f'but {type2.__qualname__ is not a Bits type!}'
     bits_signal, bitstruct_signal = signal2, signal1
+
   elif is_bitstruct_class( type2 ):
-    assert issubclass( type1, Bits )
+    assert issubclass( type1, Bits ), \
+      f'{type2.__qualname__} is a bitstruct ' \
+      f'but {type1.__qualname__ is not a Bits type!}'
     bits_signal, bitstruct_signal = signal1, signal2
+
   else:
-    assert False, "Can only connect a bitstruct wire to bits wire"
+    assert False, 'Can only connect a bitstruct wire to bits wire'
 
   # Connect field to corresponding slice
   _connect_bits2bitstruct_h( bitstruct_signal, bits_signal, [] )

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct.py
@@ -8,7 +8,7 @@ has the same width.
 Author : Yanghui Ou
   Date : Feb 24, 2020
 '''
-from pymtl3 import Bits, connect
+from pymtl3 import Bits, connect, get_nbits
 from pymtl3.datatypes.bitstructs import _FIELDS, is_bitstruct_class
 
 #-------------------------------------------------------------------------
@@ -64,6 +64,12 @@ def connect_bits2bitstruct( signal1, signal2 ):
 
   else:
     assert False, 'Can only connect a bitstruct wire to bits wire'
+
+  bw1 = get_nbits( type1 )
+  bw2 = get_nbits( type2 )
+  assert bw1 == bw2, 'Bitwidth mismatch! ' \
+    f'{type1.__qualname__} is {bw1}-bit ' \
+    f'but {type2.__qualname__} is {bw2}-bit.'
 
   # Connect field to corresponding slice
   _connect_bits2bitstruct_h( bitstruct_signal, bits_signal, [] )

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct.py
@@ -16,7 +16,7 @@ from pymtl3.datatypes.bitstructs import _FIELDS, is_bitstruct_class
 #-------------------------------------------------------------------------
 # Helper function for connect_bits2bitstruct.
 
-def _connect_bits2bitstruct_h( field, bits_signal, slices ):
+def _connect_bits2bitstruct_h( field, bits_signal, start ):
 
   # NOTE: We do not support list of fields at the moment because: 1) there
   # are very few use cases; 2) the pack order of a list of fields is
@@ -27,18 +27,18 @@ def _connect_bits2bitstruct_h( field, bits_signal, slices ):
   field_type = field.get_type()
 
   if issubclass( field_type, Bits ):
-    start     = 0 if not slices else slices[-1].stop
     stop      = start + field_type.nbits
     cur_slice = slice( start, stop )
-    slices.append( cur_slice )
     connect( field, bits_signal[ cur_slice ] )
+    return stop
 
   else:
-    assert is_bitstruct_class( field_type )
     fields_dict = getattr( field_type, _FIELDS )
+    cur_stop    = start
     for fname, _ in reversed( list( fields_dict.items() ) ):
       subfield = getattr( field, fname )
-      _connect_bits2bitstruct_h( subfield, bits_signal, slices )
+      cur_stop = _connect_bits2bitstruct_h( subfield, bits_signal, cur_stop )
+    return cur_stop
 
 #-------------------------------------------------------------------------
 # connect_bits2bitstruct
@@ -72,4 +72,4 @@ def connect_bits2bitstruct( signal1, signal2 ):
     f'but {type2.__qualname__} is {bw2}-bit.'
 
   # Connect field to corresponding slice
-  _connect_bits2bitstruct_h( bitstruct_signal, bits_signal, [] )
+  _connect_bits2bitstruct_h( bitstruct_signal, bits_signal, 0 )

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct.py
@@ -9,7 +9,7 @@ Author : Yanghui Ou
   Date : Feb 24, 2020
 '''
 from pymtl3 import Bits, connect
-from pymtl3.datatypes.bitstructs import is_bitstruct_class, _FIELDS
+from pymtl3.datatypes.bitstructs import _FIELDS, is_bitstruct_class
 
 #-------------------------------------------------------------------------
 # _connect_bits2bitstruct_h

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct.py
@@ -72,4 +72,6 @@ def connect_bits2bitstruct( signal1, signal2 ):
     f'but {type2.__qualname__} is {bw2}-bit.'
 
   # Connect field to corresponding slice
-  _connect_bits2bitstruct_h( bitstruct_signal, bits_signal, 0 )
+  stop = _connect_bits2bitstruct_h( bitstruct_signal, bits_signal, 0 )
+  assert stop == bw1, 'Sanity check failed! Might be a bug. ' \
+    'Please create a Github issue.'

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct.py
@@ -36,9 +36,7 @@ def _connect_bits2bitstruct_h( field, bits_signal, slices ):
   else:
     assert is_bitstruct_class( field_type )
     fields_dict = getattr( field_type, _FIELDS )
-    fields_lst  = list( fields_dict.items() )
-    fields_lst.reverse() # reverse is faster than [::-1]
-    for fname, _ in fields_lst:
+    for fname, _ in reversed( list( fields_dict.items() ) ):
       subfield = getattr( field, fname )
       _connect_bits2bitstruct_h( subfield, bits_signal, slices )
 

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct.py
@@ -1,0 +1,62 @@
+'''
+==========================================================================
+connect_bits2bitstruct.py
+==========================================================================
+A connect function that connects a bits signal and a bitsrtuct signal that
+has the same width.
+
+Author : Yanghui Ou
+  Date : Feb 24, 2020
+'''
+from pymtl3 import Bits, connect
+from pymtl3.datatypes.bitstructs import is_bitstruct_class, _FIELDS
+
+#-------------------------------------------------------------------------
+# _connect_bits2bitstruct_h
+#-------------------------------------------------------------------------
+# Helper function for connect_bitstruct.
+
+def _connect_bits2bitstruct_h( field, bits_signal, slices ):
+  field_type = field.get_type()
+
+  # NOTE: We do not support list of fields at the moment because: 1) there
+  # are very few use cases; 2) the pack order of a list of fields is
+  # somewhat ambiguous.
+  if isinstance( field, list ):
+    assert False, "A list of fields is not supported at the moment."
+
+  if issubclass( field_type, Bits ):
+    start     = 0 if not slices else slices[-1].stop
+    stop      = start + field_type.nbits
+    cur_slice = slice( start, stop )
+    slices.append( cur_slice )
+    connect( field, bits_signal[ cur_slice ] )
+
+  else:
+    assert is_bitstruct_class( field_type )
+    fields_dict = getattr( field_type, _FIELDS )
+    fields_lst  = list( fields_dict.items() )
+    fields_lst.reverse() # reverse is faster than [::-1]
+    for fname, _ in fields_lst:
+      subfield = getattr( field, fname )
+      _connect_bits2bitstruct_h( subfield, bits_signal, slices )
+
+#-------------------------------------------------------------------------
+# connect_bitstruct
+#-------------------------------------------------------------------------
+
+def connect_bits2bitstruct( signal1, signal2 ):
+  type1 = signal1.get_type()
+  type2 = signal2.get_type()
+
+  if is_bitstruct_class( type1 ):
+    assert issubclass( type2, Bits )
+    bits_signal, bitstruct_signal = signal2, signal1
+  elif is_bitstruct_class( type2 ):
+    assert issubclass( type1, Bits )
+    bits_signal, bitstruct_signal = signal1, signal2
+  else:
+    assert False, "Can only connect a bitstruct wire to bits wire"
+
+  # Connect field to corresponding slice
+  _connect_bits2bitstruct_h( bitstruct_signal, bits_signal, [] )

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct.py
@@ -52,14 +52,16 @@ def connect_bits2bitstruct( signal1, signal2 ):
 
   if is_bitstruct_class( type1 ):
     assert issubclass( type2, Bits ), \
+      f'Connecting {type1.__qualname__} to {type2.__qualname__}: ' \
       f'{type1.__qualname__} is a bitstruct ' \
-      f'but {type2.__qualname__ is not a Bits type!}'
+      f'but {type2.__qualname__} is not a Bits type!'
     bits_signal, bitstruct_signal = signal2, signal1
 
   elif is_bitstruct_class( type2 ):
     assert issubclass( type1, Bits ), \
+      f'Connecting {type1.__qualname__} to {type2.__qualname__}: ' \
       f'{type2.__qualname__} is a bitstruct ' \
-      f'but {type1.__qualname__ is not a Bits type!}'
+      f'but {type1.__qualname__} is not a Bits type!'
     bits_signal, bitstruct_signal = signal1, signal2
 
   else:

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct.py
@@ -14,7 +14,7 @@ from pymtl3.datatypes.bitstructs import _FIELDS, is_bitstruct_class
 #-------------------------------------------------------------------------
 # _connect_bits2bitstruct_h
 #-------------------------------------------------------------------------
-# Helper function for connect_bitstruct.
+# Helper function for connect_bits2bitstruct.
 
 def _connect_bits2bitstruct_h( field, bits_signal, slices ):
 
@@ -43,7 +43,7 @@ def _connect_bits2bitstruct_h( field, bits_signal, slices ):
       _connect_bits2bitstruct_h( subfield, bits_signal, slices )
 
 #-------------------------------------------------------------------------
-# connect_bitstruct
+# connect_bits2bitstruct
 #-------------------------------------------------------------------------
 
 def connect_bits2bitstruct( signal1, signal2 ):

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct.py
@@ -17,13 +17,14 @@ from pymtl3.datatypes.bitstructs import is_bitstruct_class, _FIELDS
 # Helper function for connect_bitstruct.
 
 def _connect_bits2bitstruct_h( field, bits_signal, slices ):
-  field_type = field.get_type()
 
   # NOTE: We do not support list of fields at the moment because: 1) there
   # are very few use cases; 2) the pack order of a list of fields is
   # somewhat ambiguous.
   if isinstance( field, list ):
     assert False, "A list of fields is not supported at the moment."
+
+  field_type = field.get_type()
 
   if issubclass( field_type, Bits ):
     start     = 0 if not slices else slices[-1].stop

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct_test.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct_test.py
@@ -1,0 +1,96 @@
+'''
+==========================================================================
+connect_bits2bitstruct_test.py
+==========================================================================
+Unit tests for connect_bits2bitstruct.
+
+Author : Yanghui Ou
+  Date : Feb 24, 2020
+'''
+from pymtl3 import *
+from .connect_bits2bitstruct import connect_bits2bitstruct
+
+#-------------------------------------------------------------------------
+# Bitstructs for unit tests
+#-------------------------------------------------------------------------
+
+@bitstruct
+class Point:
+  x : Bits8
+  y : Bits4
+
+@bitstruct
+class Nested:
+  z    : Bits6
+  pt   : Point
+  flag : Bits1
+
+#-------------------------------------------------------------------------
+# Components for unit tests
+#-------------------------------------------------------------------------
+
+class Bits2Bitstruct( Component ):
+  def construct( s ):
+    s.pt_bits      = InPort ( Bits12 )
+    s.pt_bitstruct = OutPort( Point  )
+    connect_bits2bitstruct( s.pt_bits, s.pt_bitstruct )
+
+class Bitstruct2Bits( Component ):
+  def construct( s ):
+    s.pt_bitstruct = InPort ( Point  )
+    s.pt_bits      = OutPort( Bits12 )
+    connect_bits2bitstruct( s.pt_bitstruct, s.pt_bits )
+
+class Bits2BitstructNested( Component ):
+  def construct( s ):
+    s.pt_bits      = InPort ( Bits19 )
+    s.pt_bitstruct = OutPort( Nested )
+    connect_bits2bitstruct( s.pt_bits, s.pt_bitstruct )
+
+class Bitstruct2BitsNested( Component ):
+  def construct( s ):
+    s.pt_bitstruct = InPort ( Nested )
+    s.pt_bits      = OutPort( Bits19 )
+    connect_bits2bitstruct( s.pt_bitstruct, s.pt_bits )
+
+#-------------------------------------------------------------------------
+# Unit test fos connect_bits2bitstruct
+#-------------------------------------------------------------------------
+
+def test_connet_bitstruct_simple():
+  a = Bits2Bitstruct()
+  a.elaborate()
+  a.apply( SimulationPass() )
+  a.pt_bits = b12( 0xeda )
+  a.eval_combinational()
+  assert a.pt_bitstruct.x == 0xed
+  assert a.pt_bitstruct.y == 0xa
+
+  b = Bitstruct2Bits()
+  b.elaborate()
+  b.apply( SimulationPass() )
+  b.pt_bitstruct.x = b8( 0xed )
+  b.pt_bitstruct.y = b4( 0xa  )
+  b.eval_combinational()
+  assert b.pt_bits == 0xeda
+
+def test_connect_bits2bitstruct_nested():
+  a = Bits2BitstructNested()
+  a.elaborate()
+  a.apply( SimulationPass() )
+  a.pt_bits = concat( b6(0x3f), b12(0xeda), b1(1) )
+  a.eval_combinational()
+  assert a.pt_bitstruct.z    == 0x3f
+  assert a.pt_bitstruct.pt.x == 0xed
+  assert a.pt_bitstruct.pt.y == 0xa
+  assert a.pt_bitstruct.flag == 1
+
+  b = Bitstruct2BitsNested()
+  b.elaborate()
+  b.apply( SimulationPass() )
+  b.pt_bitstruct.z    = b6( 0x3f )
+  b.pt_bitstruct.pt.x = b8( 0xed )
+  b.pt_bitstruct.pt.y = b4( 0xa  )
+  b.pt_bitstruct.flag = b1( 0x1  )
+  b.eval_combinational()
+  assert b.pt_bits == concat( b6(0x3f), b12(0xeda), b1(1) )

--- a/pymtl3/stdlib/connects/connect_bits2bitstruct_test.py
+++ b/pymtl3/stdlib/connects/connect_bits2bitstruct_test.py
@@ -8,6 +8,7 @@ Author : Yanghui Ou
   Date : Feb 24, 2020
 '''
 from pymtl3 import *
+
 from .connect_bits2bitstruct import connect_bits2bitstruct
 
 #-------------------------------------------------------------------------


### PR DESCRIPTION
Very small PR that adds `connect_bits2bitstruct` in stdlib and a `get_type` API for connectables.