### PR TITLE
Major syntax changes

### DIFF
--- a/examples/ex01_basics/IncrMethodModular_test.py
+++ b/examples/ex01_basics/IncrMethodModular_test.py
@@ -64,7 +64,7 @@ class IncrMethodModular( Component ):
     connect( s.read,  s.buf2.read  )
 
     # upB reads from buf1, increments the value by 1, and writes to buf2
-    @s.update
+    @update
     def upB():
       s.buf2.write( s.buf1.read() + b8(1) )
 
@@ -91,13 +91,13 @@ class IncrTestBench( Component ):
     # ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''/\
 
     # UpA writes data to input
-    @s.update
+    @update
     def upA():
       s.incr.write( s.incr_in )
       s.incr_in += 10
 
     # UpC reads data from output
-    @s.update
+    @update
     def upC():
       s.incr_out = s.incr.read()
 

--- a/examples/ex01_basics/IncrMethodPorts_test.py
+++ b/examples/ex01_basics/IncrMethodPorts_test.py
@@ -68,19 +68,19 @@ class IncrMethodPorts( Component ):
     s.buf2 = Buffer()
 
     # UpA writes data to buf1
-    @s.update
+    @update
     def upA():
       s.buf1.write( s.incr_in )
       s.incr_in += b8(10)
 
     # UpB reads data from buf1, increments it by 1, and writes to buf2
-    @s.update
+    @update
     def upB():
       tmp = s.buf1.read()
       s.buf2.write( tmp + b8(1) )
 
     # UpC reads data from buf2
-    @s.update
+    @update
     def upC():
       s.incr_out = s.buf2.read()
 

--- a/examples/ex01_basics/IncrPyObjs_test.py
+++ b/examples/ex01_basics/IncrPyObjs_test.py
@@ -46,7 +46,7 @@ class IncrPyObjs( Component ):
     s.buf2 = Buffer()
 
     # UpA writes data to buf1
-    @s.update
+    @update
     def upA():
       s.buf1.write( s.incr_in )
       s.incr_in += b8(10)
@@ -57,7 +57,7 @@ class IncrPyObjs( Component ):
     #; The upB update block should read data from buf1, increment it by
     #; one, and write the result to buf2 using method calls.
 
-    @s.update
+    @update
     def upB():
       tmp = s.buf1.read()
       s.buf2.write( tmp + b8(1) )
@@ -65,7 +65,7 @@ class IncrPyObjs( Component ):
     # ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''/\
 
     # UpC reads data from buf2
-    @s.update
+    @update
     def upC():
       s.incr_out = s.buf2.read()
 

--- a/examples/ex01_basics/IncrPyVars_test.py
+++ b/examples/ex01_basics/IncrPyVars_test.py
@@ -30,7 +30,7 @@ class IncrPyVars( Component ):
     s.buf2 = b8(0)
 
     # UpA writes data to buf1
-    @s.update
+    @update
     def upA():
       s.buf1 = s.incr_in
       s.incr_in += b8(10)
@@ -41,14 +41,14 @@ class IncrPyVars( Component ):
     #; The upB update block should read data from buf1, increment it by
     #; one, and write the result to buf2
 
-    @s.update
+    @update
     def upB():
       s.buf2 = s.buf1 + b8(1)
 
     # ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''/\
 
     # UpC reads data from buf2
-    @s.update
+    @update
     def upC():
       s.incr_out = s.buf2
 

--- a/examples/ex01_basics/IncrValueModular_test.py
+++ b/examples/ex01_basics/IncrValueModular_test.py
@@ -41,7 +41,7 @@ class IncrValueModular( Component ):
     connect( s.in_, s.buf1 )
     s.out //= s.buf2
 
-    @s.update
+    @update
     def upB():
       s.buf2 = s.buf1 + b8(1)
 
@@ -68,13 +68,13 @@ class IncrTestBench( Component ):
     # ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''/\
 
     # UpA writes data to input
-    @s.update
+    @update
     def upA():
       s.incr.in_ = s.incr_in
       s.incr_in += b8(10)
 
     # UpC read data from output
-    @s.update
+    @update
     def upC():
       s.incr_out = s.incr.out
 

--- a/examples/ex01_basics/IncrWires_test.py
+++ b/examples/ex01_basics/IncrWires_test.py
@@ -31,7 +31,7 @@ class IncrWires( Component ):
     s.buf2 = Wire( Bits8 )
 
     # UpA writes data to buf1
-    @s.update
+    @update
     def upA():
       s.buf1 = s.incr_in
       s.incr_in += b8(10)
@@ -44,14 +44,14 @@ class IncrWires( Component ):
     #; experiment with change all three update blocks to update_on_edge
     #; and observe the change in the line trace.
 
-    @s.update
+    @update
     def upB():
       s.buf2 = s.buf1 + b8(1)
 
     # ''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''''/\
 
     # UpC read data from buf2
-    @s.update
+    @update
     def upC():
       s.incr_out = s.buf2
 

--- a/examples/ex02_cksum/ChecksumCL.py
+++ b/examples/ex02_cksum/ChecksumCL.py
@@ -45,9 +45,10 @@ class ChecksumCL( Component ):
     #; the checksum using the checksum function from ChecksumFL, and
     #; send the result through the send interface.
 
-    s.in_q = PipeQueueCL( num_entries=2 )( enq = s.recv )
+    s.in_q = PipeQueueCL( num_entries=2 )
+    s.in_q.enq //= s.recv
 
-    @s.update
+    @update
     def up_checksum_cl():
       if s.in_q.deq.rdy() and s.send.rdy():
         bits = s.in_q.deq()

--- a/examples/ex02_cksum/ChecksumRTL.py
+++ b/examples/ex02_cksum/ChecksumRTL.py
@@ -36,7 +36,7 @@ class StepUnit( Component ):
 
     # Logic
 
-    @s.update
+    @update
     def up_step():
       temp1 = b32(s.word_in) + s.sum1_in
       s.sum1_out = temp1 & b32(0xffff)
@@ -90,12 +90,12 @@ class ChecksumRTL( Component ):
     s.sum1 //= s.steps[-1].sum1_out
     s.sum2 //= s.steps[-1].sum2_out
 
-    @s.update
+    @update
     def up_rtl_send():
       s.send.en  = s.in_q.deq.rdy & s.send.rdy
       s.in_q.deq.en = s.in_q.deq.rdy & s.send.rdy
 
-    @s.update
+    @update
     def up_rtl_sum():
       s.send.msg = ( s.sum2 << 16 ) | s.sum1
 

--- a/examples/ex02_cksum/test/ChecksumCL_test.py
+++ b/examples/ex02_cksum/test/ChecksumCL_test.py
@@ -114,7 +114,7 @@ class ChecksumCL_Tests( BaseTests ):
   #; example, change the update block in the CL implementation to be
   #; something like this:
   #;
-  #;   @s.update
+  #;   @update
   #;   def up_checksum_cl():
   #;     if s.pipe.enq.rdy() and s.in_q.deq.rdy():
   #;       bits = s.in_q.deq()

--- a/examples/ex03_proc/MiscRTL.py
+++ b/examples/ex03_proc/MiscRTL.py
@@ -42,7 +42,7 @@ class DropUnitRTL( Component ):
     # state_transitions
     #------------------------------------------------------------------
 
-    @s.update_ff
+    @update_ff
     def state_transitions():
 
       if s.reset:
@@ -60,7 +60,7 @@ class DropUnitRTL( Component ):
     # set_outputs
     #------------------------------------------------------------------
 
-    @s.update
+    @update
     def set_outputs():
       s.out.rdy = b1(0)
       s.in_.en  = b1(0)
@@ -88,7 +88,7 @@ class ImmGenRTL( Component ):
     s.inst     = InPort( dtype )
     s.imm      = OutPort( dtype )
 
-    @s.update
+    @update
     def up_immgen():
       s.imm = dtype(0)
 
@@ -123,7 +123,7 @@ class AluRTL( Component ):
     s.out      = OutPort( dtype )
     s.ops_ne   = OutPort( Bits1 )
 
-    @s.update
+    @update
     def comb_logic():
       if   s.fn == b4(0): s.out = s.in0               # COPY OP0
       elif s.fn == b4(1): s.out = s.in1               # COPY OP1

--- a/examples/ex03_proc/NullXcel.py
+++ b/examples/ex03_proc/NullXcel.py
@@ -23,11 +23,13 @@ class NullXcelRTL(Component):
 
     s.xcel = XcelMinionIfcRTL( xreq_class, xresp_class )
 
-    s.xcelreq_q = NormalQueueRTL( xreq_class, 2 )( enq = s.xcel.req )
+    s.xcelreq_q = NormalQueueRTL( xreq_class, 2 )
+    s.xcelreq_q.enq //= s.xcel.req
 
-    s.xr0 = RegEn( dtype )( in_ = s.xcelreq_q.deq.ret.data )
+    s.xr0 = RegEn( dtype )
+    s.xr0.in_ //= s.xcelreq_q.deq.ret.data
 
-    @s.update
+    @update
     def up_null_xcel():
 
       if s.xcelreq_q.deq.rdy & s.xcel.resp.rdy:

--- a/examples/ex03_proc/ProcCL.py
+++ b/examples/ex03_proc/ProcCL.py
@@ -52,10 +52,17 @@ class ProcCL( Component ):
 
     # Buffers to hold input messages
 
-    s.imemresp_q  = DelayPipeDeqCL(0)( enq = s.imem.resp )
-    s.dmemresp_q  = DelayPipeDeqCL(1)( enq = s.dmem.resp )
-    s.mngr2proc_q = DelayPipeDeqCL(1)( enq = s.mngr2proc )
-    s.xcelresp_q  = DelayPipeDeqCL(0)( enq = s.xcel.resp )
+    s.imemresp_q  = DelayPipeDeqCL(0)
+    s.imemresp_q.enq //= s.imem.resp
+
+    s.dmemresp_q  = DelayPipeDeqCL(1)
+    s.dmemresp_q.enq //= s.dmem.resp
+
+    s.mngr2proc_q = DelayPipeDeqCL(1)
+    s.mngr2proc_q.enq //= s.mngr2proc
+
+    s.xcelresp_q  = DelayPipeDeqCL(0)
+    s.xcelresp_q.enq //= s.xcel.resp
 
     s.pc = b32( 0x200 )
     s.R  = RegisterFile( 32 )
@@ -67,7 +74,7 @@ class ProcCL( Component ):
     s.DXM_status = PipelineStatus.idle
     s.W_status   = PipelineStatus.idle
 
-    @s.update
+    @update
     def F():
       s.F_status = PipelineStatus.idle
 
@@ -92,7 +99,7 @@ class ProcCL( Component ):
 
     s.raw_inst = b32(0)
 
-    @s.update
+    @update
     def DXM():
       s.redirected_pc_DXM = -1
       s.DXM_status = PipelineStatus.idle
@@ -188,7 +195,7 @@ class ProcCL( Component ):
 
     s.rd = b5(0)
 
-    @s.update
+    @update
     def W():
       s.commit_inst = Bits1(0)
       s.W_status = PipelineStatus.idle

--- a/examples/ex03_proc/ProcCtrlRTL.py
+++ b/examples/ex03_proc/ProcCtrlRTL.py
@@ -26,67 +26,67 @@ class ProcCtrl( Component ):
 
     # imem ports
 
-    s.imemreq_en    = OutPort( Bits1 )
-    s.imemreq_rdy   = InPort ( Bits1 )
-    s.imemresp_en   = OutPort( Bits1 )
-    s.imemresp_rdy  = InPort( Bits1 )
-    s.imemresp_drop = OutPort( Bits1 )
+    s.imemreq_en    = OutPort()
+    s.imemreq_rdy   = InPort ()
+    s.imemresp_en   = OutPort()
+    s.imemresp_rdy  = InPort()
+    s.imemresp_drop = OutPort()
 
     # dmem ports
-    s.dmemreq_en    = OutPort( Bits1 )
-    s.dmemreq_rdy   = InPort ( Bits1 )
+    s.dmemreq_en    = OutPort()
+    s.dmemreq_rdy   = InPort ()
     s.dmemreq_type  = OutPort( Bits4 )
-    s.dmemresp_en   = OutPort( Bits1 )
-    s.dmemresp_rdy  = InPort ( Bits1 )
+    s.dmemresp_en   = OutPort()
+    s.dmemresp_rdy  = InPort ()
 
     # mngr ports
 
     # Get interface
-    s.mngr2proc_en  = OutPort( Bits1 )
-    s.mngr2proc_rdy = InPort ( Bits1 )
+    s.mngr2proc_en  = OutPort()
+    s.mngr2proc_rdy = InPort ()
 
     # Send interface
-    s.proc2mngr_en  = OutPort( Bits1 )
-    s.proc2mngr_rdy = InPort ( Bits1 )
+    s.proc2mngr_en  = OutPort()
+    s.proc2mngr_rdy = InPort ()
 
     # Send interface
-    s.xcelreq_rdy   = InPort ( Bits1 )
-    s.xcelreq_en    = OutPort( Bits1 )
-    s.xcelreq_type  = OutPort( Bits1 )
+    s.xcelreq_rdy   = InPort ()
+    s.xcelreq_en    = OutPort()
+    s.xcelreq_type  = OutPort()
 
     # Get interface
-    s.xcelresp_rdy  = InPort ( Bits1 )
-    s.xcelresp_en   = OutPort( Bits1 )
+    s.xcelresp_rdy  = InPort ()
+    s.xcelresp_en   = OutPort()
 
     # Control signals (ctrl->dpath)
 
-    s.reg_en_F         = OutPort( Bits1 )
-    s.pc_sel_F         = OutPort( Bits1 )
+    s.reg_en_F         = OutPort()
+    s.pc_sel_F         = OutPort()
 
-    s.reg_en_D         = OutPort( Bits1 )
+    s.reg_en_D         = OutPort()
     s.op1_byp_sel_D    = OutPort( Bits2 )
     s.op2_byp_sel_D    = OutPort( Bits2 )
     s.op2_sel_D        = OutPort( Bits2 )
     s.imm_type_D       = OutPort( Bits3 )
 
-    s.reg_en_X         = OutPort( Bits1 )
+    s.reg_en_X         = OutPort()
     s.alu_fn_X         = OutPort( Bits4 )
 
-    s.reg_en_M         = OutPort( Bits1 )
+    s.reg_en_M         = OutPort()
     s.wb_result_sel_M  = OutPort( Bits2 )
 
-    s.reg_en_W         = OutPort( Bits1 )
+    s.reg_en_W         = OutPort()
     s.rf_waddr_W       = OutPort( Bits5 )
-    s.rf_wen_W         = OutPort( Bits1 )
+    s.rf_wen_W         = OutPort()
 
     # Status signals (dpath->ctrl)
 
     s.inst_D = InPort ( Bits32 )
-    s.ne_X   = InPort ( Bits1 )
+    s.ne_X   = InPort ()
 
     # Output val_W for counting
 
-    s.commit_inst = OutPort( Bits1 )
+    s.commit_inst = OutPort()
 
     #-----------------------------------------------------------------------
     # Control unit logic
@@ -109,11 +109,11 @@ class ProcCtrl( Component ):
     # processor. We should always AND outgoing control signals with valid
     # signal.
 
-    s.val_F = Wire( Bits1 )
-    s.val_D = Wire( Bits1 )
-    s.val_X = Wire( Bits1 )
-    s.val_M = Wire( Bits1 )
-    s.val_W = Wire( Bits1 )
+    s.val_F = Wire()
+    s.val_D = Wire()
+    s.val_X = Wire()
+    s.val_M = Wire()
+    s.val_W = Wire()
 
     # Managing the stall and squash signals is one of the most important,
     # yet also one of the most complex, aspects of designing a pipelined
@@ -125,47 +125,47 @@ class ProcCtrl( Component ):
     # harzard, then ostall_A would need to factor in the stalling
     # condition for this pipeline harzard.
 
-    s.ostall_F = Wire( Bits1 )  # can ostall due to imemresp_val
-    s.ostall_D = Wire( Bits1 )  # can ostall due to mngr2proc_val or other hazards
-    s.ostall_X = Wire( Bits1 )  # can ostall due to dmemreq_rdy
-    s.ostall_M = Wire( Bits1 )  # can ostall due to dmemresp_val
-    s.ostall_W = Wire( Bits1 )  # can ostall due to proc2mngr_rdy
+    s.ostall_F = Wire()  # can ostall due to imemresp_val
+    s.ostall_D = Wire()  # can ostall due to mngr2proc_val or other hazards
+    s.ostall_X = Wire()  # can ostall due to dmemreq_rdy
+    s.ostall_M = Wire()  # can ostall due to dmemresp_val
+    s.ostall_W = Wire()  # can ostall due to proc2mngr_rdy
 
     # The stall_A signal should be used to indicate when stage A is indeed
     # stalling. stall_A will be a function of ostall_A and all the ostall
     # signals of stages in front of it in the pipeline.
 
-    s.stall_F = Wire( Bits1 )
-    s.stall_D = Wire( Bits1 )
-    s.stall_X = Wire( Bits1 )
-    s.stall_M = Wire( Bits1 )
-    s.stall_W = Wire( Bits1 )
+    s.stall_F = Wire()
+    s.stall_D = Wire()
+    s.stall_X = Wire()
+    s.stall_M = Wire()
+    s.stall_W = Wire()
 
     # We denote the squash signals _originating_ from stage A as
     # osquash_A. For example, if stage A needs to squash the stages behind
     # A in the pipeline, then osquash_A would need to factor in this
     # squash condition.
 
-    s.osquash_D = Wire( Bits1 ) # can osquash due to unconditional jumps
-    s.osquash_X = Wire( Bits1 ) # can osquash due to taken branches
+    s.osquash_D = Wire() # can osquash due to unconditional jumps
+    s.osquash_X = Wire() # can osquash due to taken branches
 
     # The squash_A signal should be used to indicate when stage A is being
     # squashed. squash_A will _not_ be a function of osquash_A, since
     # osquash_A means to squash the stages _behind_ A in the pipeline, but
     # not to squash A itself.
 
-    s.squash_F = Wire( Bits1 )
-    s.squash_D = Wire( Bits1 )
+    s.squash_F = Wire()
+    s.squash_D = Wire()
 
     #---------------------------------------------------------------------
     # F stage
     #---------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_reg_en_F():
       s.reg_en_F = ~s.stall_F | s.squash_F
 
-    @s.update_ff
+    @update_ff
     def reg_F():
       if s.reset:
         s.val_F <<= b1( 0 )
@@ -174,25 +174,25 @@ class ProcCtrl( Component ):
 
     # forward declaration of branch (no jump) logic
 
-    s.pc_redirect_X = Wire( Bits1 )
+    s.pc_redirect_X = Wire()
 
     # pc sel logic
 
-    @s.update
+    @update
     def comb_PC_sel_F():
       if   s.pc_redirect_X:
         s.pc_sel_F = b1( 1 ) # branch target
       else:
         s.pc_sel_F = b1( 0 ) # use pc+4
 
-    s.next_val_F = Wire( Bits1 )
+    s.next_val_F = Wire()
 
-    @s.update
+    @update
     def comb_F_squash():
       s.squash_F = s.val_F & ( s.osquash_D | s.osquash_X  )
       s.imemresp_drop = s.squash_F
 
-    @s.update
+    @update
     def comb_F():
 
       # ostall due to imemresp
@@ -220,11 +220,11 @@ class ProcCtrl( Component ):
     # D stage
     #---------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_reg_en_D():
       s.reg_en_D = ~s.stall_D | s.squash_D
 
-    @s.update_ff
+    @update_ff
     def reg_D():
       if s.reset:
         s.val_D <<= Bits1(0)
@@ -233,29 +233,30 @@ class ProcCtrl( Component ):
 
     # Decoder, translate 32-bit instructions to symbols
 
-    s.inst_type_decoder_D = DecodeInstType()( in_ = s.inst_D )
+    s.inst_type_decoder_D = DecodeInstType()
+    s.inst_type_decoder_D.in_ //= s.inst_D
 
     # Signals generated by control signal table
 
-    s.inst_val_D       = Wire( Bits1 )
-    s.br_type_D        = Wire( Bits1 )
-    s.rs1_en_D         = Wire( Bits1 )
-    s.rs2_en_D         = Wire( Bits1 )
+    s.inst_val_D       = Wire()
+    s.br_type_D        = Wire()
+    s.rs1_en_D         = Wire()
+    s.rs2_en_D         = Wire()
     s.alu_fn_D         = Wire( Bits4 )
     s.dmemreq_type_D   = Wire( Bits2 )
-    s.rf_wen_pending_D = Wire( Bits1 )
+    s.rf_wen_pending_D = Wire()
     s.rf_waddr_sel_D   = Wire( Bits3 )
-    s.csrw_D           = Wire( Bits1 )
-    s.csrr_D           = Wire( Bits1 )
-    s.proc2mngr_en_D   = Wire( Bits1 )
-    s.mngr2proc_D      = Wire( Bits1 )
+    s.csrw_D           = Wire()
+    s.csrr_D           = Wire()
+    s.proc2mngr_en_D   = Wire()
+    s.mngr2proc_D      = Wire()
     s.wb_result_sel_D  = Wire( Bits2 )
-    s.xcelreq_D        = Wire( Bits1 )
+    s.xcelreq_D        = Wire()
 
     # actual waddr, selected base on rf_waddr_sel_D
 
     s.rf_waddr_D = Wire( Bits5 )
-    s.xcelreq_type_D = Wire( Bits1 )
+    s.xcelreq_type_D = Wire()
 
     # Control signal table
 
@@ -316,7 +317,7 @@ class ProcCtrl( Component ):
 
     # control signal table
 
-    @s.update
+    @update
     def comb_control_table_D():
       inst = s.inst_type_decoder_D.out
       #                                     br     rs1 imm    op2    rs2 alu      dmm wbmux rf  cs cs
@@ -385,17 +386,17 @@ class ProcCtrl( Component ):
 
     # ostall due to hazards
 
-    s.ostall_ld_X_rs1_D = Wire( Bits1 )
-    s.ostall_ld_X_rs2_D = Wire( Bits1 )
+    s.ostall_ld_X_rs1_D = Wire()
+    s.ostall_ld_X_rs2_D = Wire()
 
-    s.ostall_xcel_X_rs1_D = Wire( Bits1 )
-    s.ostall_xcel_X_rs2_D = Wire( Bits1 )
+    s.ostall_xcel_X_rs1_D = Wire()
+    s.ostall_xcel_X_rs2_D = Wire()
 
-    s.ostall_hazard_D   = Wire( Bits1 )
+    s.ostall_hazard_D   = Wire()
 
     # ostall due to mngr2proc
 
-    s.ostall_mngr_D     = Wire( Bits1 )
+    s.ostall_mngr_D     = Wire()
 
     # bypassing logic
 
@@ -404,7 +405,7 @@ class ProcCtrl( Component ):
     byp_m = b2( 2 )
     byp_w = b2( 3 )
 
-    @s.update
+    @update
     def comb_bypass_D():
 
       s.op1_byp_sel_D = byp_d
@@ -433,7 +434,7 @@ class ProcCtrl( Component ):
     # Although bypassing is added, we might still have RAW when there is
     # lw instruction in X stage
 
-    @s.update
+    @update
     def comb_hazard_D():
       s.ostall_ld_X_rs1_D = s.rs1_en_D & s.val_X & s.rf_wen_pending_X \
                             & ( s.inst_D[ RS1 ] == s.rf_waddr_X ) & ( s.rf_waddr_X != b5(0) ) \
@@ -454,9 +455,9 @@ class ProcCtrl( Component ):
       s.ostall_hazard_D   = s.ostall_ld_X_rs1_D   | s.ostall_ld_X_rs2_D | \
                             s.ostall_xcel_X_rs1_D | s.ostall_xcel_X_rs2_D
 
-    s.next_val_D = Wire( Bits1 )
+    s.next_val_D = Wire()
 
-    @s.update
+    @update
     def comb_D():
 
       # ostall due to mngr2proc not ready
@@ -482,20 +483,20 @@ class ProcCtrl( Component ):
     # X stage
     #---------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_reg_en_X():
       s.reg_en_X  = ~s.stall_X
 
     s.inst_type_X      = Wire( Bits8 )
-    s.rf_wen_pending_X = Wire( Bits1 )
-    s.proc2mngr_en_X   = Wire( Bits1 )
+    s.rf_wen_pending_X = Wire()
+    s.proc2mngr_en_X   = Wire()
     s.dmemreq_type_X   = Wire( Bits2 )
     s.wb_result_sel_X  = Wire( Bits2 )
-    s.br_type_X        = Wire( Bits1 )
-    s.xcelreq_X        = Wire( Bits1 )
-    s.xcelreq_type_X   = Wire( Bits1 )
+    s.br_type_X        = Wire()
+    s.xcelreq_X        = Wire()
+    s.xcelreq_type_X   = Wire()
 
-    @s.update_ff
+    @update_ff
     def reg_X():
       if s.reset:
         s.val_X <<= b1( 0 )
@@ -514,16 +515,16 @@ class ProcCtrl( Component ):
 
     # Branch logic
 
-    @s.update
+    @update
     def comb_br_X():
       s.pc_redirect_X = s.val_X & (s.br_type_X == br_ne) & s.ne_X
 
-    s.ostall_dmem_X = Wire( Bits1 )
-    s.ostall_xcel_X = Wire( Bits1 )
+    s.ostall_dmem_X = Wire()
+    s.ostall_xcel_X = Wire()
 
-    s.next_val_X    = Wire( Bits1 )
+    s.next_val_X    = Wire()
 
-    @s.update
+    @update
     def comb_X():
 
       # ostall due to dmemreq
@@ -565,17 +566,17 @@ class ProcCtrl( Component ):
     # M stage
     #---------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_reg_en_M():
       s.reg_en_M = ~s.stall_M
 
     s.inst_type_M      = Wire( Bits8 )
-    s.rf_wen_pending_M = Wire( Bits1 )
-    s.proc2mngr_en_M   = Wire( Bits1 )
+    s.rf_wen_pending_M = Wire()
+    s.proc2mngr_en_M   = Wire()
     s.dmemreq_type_M   = Wire( Bits2 )
-    s.xcelreq_M        = Wire( Bits1 )
+    s.xcelreq_M        = Wire()
 
-    @s.update_ff
+    @update_ff
     def reg_M():
       if s.reset:
         s.val_M            <<= b1( 0 )
@@ -589,11 +590,11 @@ class ProcCtrl( Component ):
         s.wb_result_sel_M  <<= s.wb_result_sel_X
         s.xcelreq_M        <<= s.xcelreq_X
 
-    s.ostall_xcel_M = Wire( Bits1 )
-    s.ostall_dmem_M = Wire( Bits1 )
-    s.next_val_M    = Wire( Bits1 )
+    s.ostall_xcel_M = Wire()
+    s.ostall_dmem_M = Wire()
+    s.next_val_M    = Wire()
 
-    @s.update
+    @update
     def comb_M():
 
       # ostall due to xcel resp or dmem resp
@@ -620,15 +621,15 @@ class ProcCtrl( Component ):
     # W stage
     #---------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_reg_en_W():
       s.reg_en_W = ~s.stall_W
 
     s.inst_type_W      = Wire( Bits8 )
-    s.proc2mngr_en_W   = Wire( Bits1 )
-    s.rf_wen_pending_W = Wire( Bits1 )
+    s.proc2mngr_en_W   = Wire()
+    s.rf_wen_pending_W = Wire()
 
-    @s.update_ff
+    @update_ff
     def reg_W():
       if s.reset:
         s.val_W <<= b1( 0 )
@@ -639,9 +640,9 @@ class ProcCtrl( Component ):
         s.rf_waddr_W       <<= s.rf_waddr_M
         s.proc2mngr_en_W   <<= s.proc2mngr_en_M
 
-    s.ostall_proc2mngr_W = Wire( Bits1 )
+    s.ostall_proc2mngr_W = Wire()
 
-    @s.update
+    @update
     def comb_W():
 
       # set RF write enable if valid

--- a/examples/ex03_proc/ProcDpathRTL.py
+++ b/examples/ex03_proc/ProcDpathRTL.py
@@ -87,10 +87,9 @@ class ProcDpath( Component ):
 
     # PC+4 incrementer
 
-    s.pc_incr_F = Incrementer( Bits32, amount=4 )(
-      in_ = s.pc_F,
-      out = s.pc_plus4_F,
-    )
+    s.pc_incr_F = m = Incrementer( Bits32, amount=4 )
+    m.in_ //= s.pc_F
+    m.out //= s.pc_plus4_F
 
     # forward delaration for branch target and jal target
 
@@ -98,19 +97,18 @@ class ProcDpath( Component ):
 
     # PC sel mux
 
-    s.pc_sel_mux_F = Mux( Bits32, 2 )(
-      in_ = { 0: s.pc_plus4_F, 1: s.br_target_X },
-      sel = s.pc_sel_F,
-      out = s.imemreq_addr,
-    )
+    s.pc_sel_mux_F = m = Mux( Bits32, 2 )
+    m.in_[0] //= s.pc_plus4_F
+    m.in_[1] //= s.br_target_X
+    m.sel //= s.pc_sel_F
+    m.out //= s.imemreq_addr
 
     # PC register
 
-    s.pc_reg_F = RegEnRst( Bits32, reset_value=c_reset_vector-4 )(
-      en  = s.reg_en_F,
-      in_ = s.pc_sel_mux_F.out,
-      out = s.pc_F,
-    )
+    s.pc_reg_F = m = RegEnRst( Bits32, reset_value=c_reset_vector-4 )
+    m.en  //= s.reg_en_F
+    m.in_ //= s.pc_sel_mux_F.out
+    m.out //= s.pc_F
 
     #---------------------------------------------------------------------
     # D stage
@@ -120,15 +118,16 @@ class ProcDpath( Component ):
     # This value is basically passed from F stage for the corresponding
     # instruction to use, e.g. branch to (PC+imm)
 
-    s.pc_reg_D = m = RegEnRst( Bits32 )( en = s.reg_en_D, in_ = s.pc_F )
+    s.pc_reg_D = m = RegEnRst( Bits32 )
+    m.en  //= s.reg_en_D
+    m.in_ //= s.pc_F
 
     # Instruction reg
 
-    s.inst_D_reg = m = RegEnRst( Bits32, reset_value=c_reset_inst )(
-      en  = s.reg_en_D,
-      in_ = s.imemresp_data,
-      out = s.inst_D # to ctrl
-    )
+    s.inst_D_reg = m = RegEnRst( Bits32, reset_value=c_reset_inst )
+    m.en  //= s.reg_en_D
+    m.in_ //= s.imemresp_data
+    m.out //= s.inst_D # to ctrl
 
     # Register File
     # The rf_rdata_D wires, albeit redundant in some sense, are used to
@@ -139,19 +138,20 @@ class ProcDpath( Component ):
 
     s.rf_wdata_W  = Wire( Bits32 )
 
-    s.rf = RegisterFile( Bits32, nregs=32, rd_ports=2, wr_ports=1, const_zero=True )(
-      raddr = { 0: s.inst_D[ RS1 ],
-                1: s.inst_D[ RS2 ], },
-      rdata = { 0: s.rf_rdata0_D,
-                1: s.rf_rdata1_D, },
-      wen   = { 0: s.rf_wen_W },
-      waddr = { 0: s.rf_waddr_W },
-      wdata = { 0: s.rf_wdata_W },
-    )
+    s.rf = m = RegisterFile( Bits32, nregs=32, rd_ports=2, wr_ports=1, const_zero=True )
+    m.raddr[0] //= s.inst_D[ RS1 ]
+    m.rdata[0] //= s.rf_rdata0_D
+    m.raddr[1] //= s.inst_D[ RS2 ]
+    m.rdata[1] //= s.rf_rdata1_D
+    m.wen[0]   //= s.rf_wen_W
+    m.waddr[0] //= s.rf_waddr_W
+    m.wdata[0] //= s.rf_wdata_W
 
     # Immediate generator
 
-    s.immgen_D = ImmGenRTL()( imm_type = s.imm_type_D, inst = s.inst_D )
+    s.immgen_D = m = ImmGenRTL()
+    m.imm_type //= s.imm_type_D
+    m.inst     //= s.inst_D
 
     s.bypass_X = Wire( Bits32 )
     s.bypass_M = Wire( Bits32 )
@@ -159,41 +159,37 @@ class ProcDpath( Component ):
 
     # op1 bypass mux
 
-    s.op1_byp_mux_D = Mux( Bits32, 4 )(
-      in_ = { 0: s.rf_rdata0_D,
-              1: s.bypass_X,
-              2: s.bypass_M,
-              3: s.bypass_W, },
-      sel = s.op1_byp_sel_D,
-    )
+    s.op1_byp_mux_D = m = Mux( Bits32, 4 )
+    m.in_[0] //= s.rf_rdata0_D
+    m.in_[1] //= s.bypass_X
+    m.in_[2] //= s.bypass_M
+    m.in_[3] //= s.bypass_W
+    m.sel    //= s.op1_byp_sel_D
 
     # op2 bypass mux
 
-    s.op2_byp_mux_D = Mux( Bits32, 4 )(
-      in_ = { 0: s.rf_rdata1_D,
-              1: s.bypass_X,
-              2: s.bypass_M,
-              3: s.bypass_W, },
-      sel = s.op2_byp_sel_D,
-    )
+    s.op2_byp_mux_D = m = Mux( Bits32, 4 )
+    m.in_[0] //= s.rf_rdata1_D
+    m.in_[1] //= s.bypass_X
+    m.in_[2] //= s.bypass_M
+    m.in_[3] //= s.bypass_W
+    m.sel    //= s.op2_byp_sel_D
 
     # op2 sel mux
     # This mux chooses among RS2, imm, and the mngr2proc.
     # Basically we are using two muxes here for pedagogy.
 
-    s.op2_sel_mux_D = Mux( Bits32, 3 )(
-      in_ = { 0: s.op2_byp_mux_D.out,
-              1: s.immgen_D.imm,
-              2: s.mngr2proc_data, },
-      sel = s.op2_sel_D,
-    )
+    s.op2_sel_mux_D = m = Mux( Bits32, 3 )
+    m.in_[0] //= s.op2_byp_mux_D.out
+    m.in_[1] //= s.immgen_D.imm
+    m.in_[2] //= s.mngr2proc_data
+    m.sel    //= s.op2_sel_D
 
     # Risc-V always calcs branch target by adding imm(generated above) to PC
 
-    s.pc_plus_imm_D = Adder( Bits32 )(
-      in0 = s.pc_reg_D.out,
-      in1 = s.immgen_D.imm,
-    )
+    s.pc_plus_imm_D = m = Adder( Bits32 )
+    m.in0 //= s.pc_reg_D.out
+    m.in1 //= s.immgen_D.imm
 
     #---------------------------------------------------------------------
     # X stage
@@ -203,25 +199,22 @@ class ProcDpath( Component ):
     # Since branches are resolved in X stage, we register the target,
     # which is already calculated in D stage, to X stage.
 
-    s.br_target_reg_X = RegEnRst( Bits32, reset_value=0 )(
-      en  = s.reg_en_X,
-      in_ = s.pc_plus_imm_D.out,
-      out = s.br_target_X,
-    )
+    s.br_target_reg_X = m = RegEnRst( Bits32, reset_value=0 )
+    m.en  //= s.reg_en_X
+    m.in_ //= s.pc_plus_imm_D.out
+    m.out //= s.br_target_X
 
     # op1 reg
 
-    s.op1_reg_X = RegEnRst( Bits32, reset_value=0 )(
-      en  = s.reg_en_X,
-      in_ = s.op1_byp_mux_D.out,
-    )
+    s.op1_reg_X = m = RegEnRst( Bits32, reset_value=0 )
+    m.en  //= s.reg_en_X
+    m.in_ //= s.op1_byp_mux_D.out
 
     # op2 reg
 
-    s.op2_reg_X = m = RegEnRst( Bits32, reset_value=0 )(
-      en  = s.reg_en_X,
-      in_ = s.op2_sel_mux_D.out,
-    )
+    s.op2_reg_X = m = RegEnRst( Bits32, reset_value=0 )
+    m.en  //= s.reg_en_X
+    m.in_ //= s.op2_sel_mux_D.out
 
     # Send out xcelreq msg
     s.xcelreq_data //= s.op1_reg_X.out
@@ -232,21 +225,20 @@ class ProcDpath( Component ):
     # we could utilize ALU to do address calculation, we need one more
     # register to hold the R[rs2] we want to store to memory.
 
-    s.store_reg_X = RegEnRst( Bits32, reset_value=0 )(
-      en  = s.reg_en_X,
-      in_ = s.op2_byp_mux_D.out, # R[rs2]
-      out = s.dmemreq_data,
-    )
+    s.store_reg_X = m = RegEnRst( Bits32, reset_value=0 )
+    m.en  //= s.reg_en_X
+    m.in_ //= s.op2_byp_mux_D.out # R[rs2]
+    m.out //= s.dmemreq_data
 
     # ALU
 
-    s.alu_X = AluRTL()(
-      in0     = s.op1_reg_X.out,
-      in1     = s.op2_reg_X.out,
-      fn      = s.alu_fn_X,
-      ops_ne  = s.ne_X,
-      out     = ( s.bypass_X, s.dmemreq_addr )
-    )
+    s.alu_X = m = AluRTL()
+    m.in0    //= s.op1_reg_X.out
+    m.in1    //= s.op2_reg_X.out
+    m.fn     //= s.alu_fn_X
+    m.ops_ne //= s.ne_X
+    m.out    //= s.bypass_X
+    m.out    //= s.dmemreq_addr
 
     #---------------------------------------------------------------------
     # M stage
@@ -254,20 +246,18 @@ class ProcDpath( Component ):
 
     # Alu execution result reg
 
-    s.ex_result_reg_M = m = RegEnRst( Bits32, reset_value=0 )(
-      en  = s.reg_en_M,
-      in_ = s.alu_X.out
-    )
+    s.ex_result_reg_M = m = RegEnRst( Bits32, reset_value=0 )
+    m.en  //= s.reg_en_M
+    m.in_ //= s.alu_X.out
 
     # Writeback result selection mux
 
-    s.wb_result_sel_mux_M = Mux( Bits32, 3 )(
-      in_ = { 0: s.ex_result_reg_M.out,
-              1: s.dmemresp_data,
-              2: s.xcelresp_data, },
-      sel = s.wb_result_sel_M,
-      out = s.bypass_M,
-    )
+    s.wb_result_sel_mux_M = m = Mux( Bits32, 3 )
+    m.in_[0] //= s.ex_result_reg_M.out
+    m.in_[1] //= s.dmemresp_data
+    m.in_[2] //= s.xcelresp_data
+    m.sel //= s.wb_result_sel_M
+    m.out //= s.bypass_M
 
     #---------------------------------------------------------------------
     # W stage
@@ -275,8 +265,9 @@ class ProcDpath( Component ):
 
     # Writeback result reg
 
-    s.wb_result_reg_W = RegEnRst( Bits32, reset_value=0 )(
-      en  = s.reg_en_W,
-      in_ = s.wb_result_sel_mux_M.out,
-      out = ( s.bypass_W, s.rf_wdata_W, s.proc2mngr_data ),
-    )
+    s.wb_result_reg_W = m = RegEnRst( Bits32, reset_value=0 )
+    m.en  //= s.reg_en_W
+    m.in_ //= s.wb_result_sel_mux_M.out
+    m.out //= s.bypass_W
+    m.out //= s.rf_wdata_W
+    m.out //= s.proc2mngr_data

--- a/examples/ex03_proc/ProcFL.py
+++ b/examples/ex03_proc/ProcFL.py
@@ -40,7 +40,7 @@ class ProcFL( Component ):
     s.R = RegisterFile(32)
     s.raw_inst = None
 
-    @s.update
+    @update
     def up_ProcFL():
       if s.reset:
         s.PC = b32( 0x200 )

--- a/examples/ex03_proc/ProcRTL.py
+++ b/examples/ex03_proc/ProcRTL.py
@@ -53,112 +53,110 @@ class ProcRTL( Component ):
 
     # Bypass queues
 
-    s.imemreq_q   = BypassQueue2RTL( req_class, 2 )( deq = s.imem.req )
+    s.imemreq_q   = BypassQueue2RTL( req_class, 2 )
 
     # We have to turn input receive interface into get interface
 
-    s.imemresp_q  = BypassQueueRTL( resp_class, 1 )( enq = s.imem.resp )
-    s.dmemresp_q  = BypassQueueRTL( resp_class, 1 )( enq = s.dmem.resp )
-    s.mngr2proc_q = BypassQueueRTL( Bits32, 1 )( enq = s.mngr2proc )
-    s.xcelresp_q  = BypassQueueRTL( xresp_class, 1 )( enq = s.xcel.resp )
+    s.imemresp_q  = BypassQueueRTL( resp_class, 1 )
+    s.dmemresp_q  = BypassQueueRTL( resp_class, 1 )
+    s.mngr2proc_q = BypassQueueRTL( Bits32, 1 )
+    s.xcelresp_q  = BypassQueueRTL( xresp_class, 1 )
 
     # imem drop unit
 
     s.imemresp_drop = m = DropUnitRTL( Bits32 )
-    connect_pairs(
-      m.in_.en,  s.imemresp_q.deq.en,
-      m.in_.rdy, s.imemresp_q.deq.rdy,
-      m.in_.ret, s.imemresp_q.deq.ret.data,
-    )
+    m.in_.en  //= s.imemresp_q.deq.en
+    m.in_.rdy //= s.imemresp_q.deq.rdy
+    m.in_.ret //= s.imemresp_q.deq.ret.data
+
+    # connect all the queues
+
+    s.imemreq_q.deq   //= s.imem.req
+    s.imemresp_q.enq  //= s.imem.resp
+    s.dmemresp_q.enq  //= s.dmem.resp
+    s.mngr2proc_q.enq //= s.mngr2proc
+    s.xcelresp_q.enq  //= s.xcel.resp
 
     # Control
 
-    s.ctrl  = ProcCtrl()(
+    s.ctrl = m = ProcCtrl()
 
-      # imem port
-      imemresp_drop = s.imemresp_drop.drop,
-      imemreq_en    = s.imemreq_q.enq.en,
-      imemreq_rdy   = s.imemreq_q.enq.rdy,
-      imemresp_en   = s.imemresp_drop.out.en,
-      imemresp_rdy  = s.imemresp_drop.out.rdy,
+    # imem port
+    m.imemresp_drop //= s.imemresp_drop.drop
+    m.imemreq_en    //= s.imemreq_q.enq.en
+    m.imemreq_rdy   //= s.imemreq_q.enq.rdy
+    m.imemresp_en   //= s.imemresp_drop.out.en
+    m.imemresp_rdy  //= s.imemresp_drop.out.rdy
 
-      # dmem port
-      dmemreq_en    = s.dmem.req.en,
-      dmemreq_rdy   = s.dmem.req.rdy,
-      dmemreq_type  = s.dmem.req.msg.type_,
-      dmemresp_en   = s.dmemresp_q.deq.en,
-      dmemresp_rdy  = s.dmemresp_q.deq.rdy,
+    # dmem port
+    m.dmemreq_en    //= s.dmem.req.en
+    m.dmemreq_rdy   //= s.dmem.req.rdy
+    m.dmemreq_type  //= s.dmem.req.msg.type_
+    m.dmemresp_en   //= s.dmemresp_q.deq.en
+    m.dmemresp_rdy  //= s.dmemresp_q.deq.rdy
 
-      # xcel port
-      xcelreq_en    = s.xcel.req.en,
-      xcelreq_rdy   = s.xcel.req.rdy,
-      xcelresp_en   = s.xcelresp_q.deq.en,
-      xcelresp_rdy  = s.xcelresp_q.deq.rdy,
+    # xcel port
+    m.xcelreq_type  //= s.xcel.req.msg.type_
 
-      # proc2mngr and mngr2proc
-      proc2mngr_en  = s.proc2mngr.en,
-      proc2mngr_rdy = s.proc2mngr.rdy,
-      mngr2proc_en  = s.mngr2proc_q.deq.en,
-      mngr2proc_rdy = s.mngr2proc_q.deq.rdy,
+    m.xcelreq_en    //= s.xcel.req.en
+    m.xcelreq_rdy   //= s.xcel.req.rdy
+    m.xcelresp_en   //= s.xcelresp_q.deq.en
+    m.xcelresp_rdy  //= s.xcelresp_q.deq.rdy
 
-      # commit inst for counting
-      commit_inst = s.commit_inst
-    )
+    # proc2mngr and mngr2proc
+    m.proc2mngr_en  //= s.proc2mngr.en
+    m.proc2mngr_rdy //= s.proc2mngr.rdy
+    m.mngr2proc_en  //= s.mngr2proc_q.deq.en
+    m.mngr2proc_rdy //= s.mngr2proc_q.deq.rdy
+
+    # commit inst for counting
+    m.commit_inst //= s.commit_inst
 
     # Dpath
 
-    s.dpath = ProcDpath()(
+    s.dpath = m = ProcDpath()
 
-      # imem ports
-      imemreq_addr  = s.imemreq_q.enq.msg.addr,
-      imemresp_data = s.imemresp_drop.out.ret,
+    # imem ports
+    m.imemreq_addr  //= s.imemreq_q.enq.msg.addr
+    m.imemresp_data //= s.imemresp_drop.out.ret
 
-      # dmem ports
-      dmemreq_addr  = s.dmem.req.msg.addr,
-      dmemreq_data  = s.dmem.req.msg.data,
-      dmemresp_data = s.dmemresp_q.deq.ret.data,
+    # dmem ports
+    m.dmemreq_addr  //= s.dmem.req.msg.addr
+    m.dmemreq_data  //= s.dmem.req.msg.data
+    m.dmemresp_data //= s.dmemresp_q.deq.ret.data
 
-      # xcel ports
-      xcelresp_data = s.xcelresp_q.deq.ret.data,
+    # xcel ports
+    m.xcelreq_addr  //= s.xcel.req.msg.addr
+    m.xcelreq_data  //= s.xcel.req.msg.data
+    m.xcelresp_data //= s.xcelresp_q.deq.ret.data
 
-      # mngr
-      mngr2proc_data = s.mngr2proc_q.deq.ret,
-      proc2mngr_data = s.proc2mngr.msg,
-
-    )
-    @s.update
-    def up_xcelreq():
-      s.xcel.req.msg = xreq_class(
-        s.ctrl.xcelreq_type,
-        s.dpath.xcelreq_addr,
-        s.dpath.xcelreq_data,
-      )
+    # mngr
+    m.mngr2proc_data //= s.mngr2proc_q.deq.ret
+    m.proc2mngr_data //= s.proc2mngr.msg
 
     # Ctrl <-> Dpath
 
-    connect_pairs(
-      s.ctrl.reg_en_F       , s.dpath.reg_en_F,
-      s.ctrl.pc_sel_F       , s.dpath.pc_sel_F,
+    s.ctrl.reg_en_F        //= s.dpath.reg_en_F
+    s.ctrl.pc_sel_F        //= s.dpath.pc_sel_F
 
-      s.ctrl.reg_en_D       , s.dpath.reg_en_D,
-      s.ctrl.op1_byp_sel_D  , s.dpath.op1_byp_sel_D,
-      s.ctrl.op2_byp_sel_D  , s.dpath.op2_byp_sel_D,
-      s.ctrl.op2_sel_D      , s.dpath.op2_sel_D,
-      s.ctrl.imm_type_D     , s.dpath.imm_type_D,
+    s.ctrl.reg_en_D        //= s.dpath.reg_en_D
+    s.ctrl.op1_byp_sel_D   //= s.dpath.op1_byp_sel_D
+    s.ctrl.op2_byp_sel_D   //= s.dpath.op2_byp_sel_D
+    s.ctrl.op2_sel_D       //= s.dpath.op2_sel_D
+    s.ctrl.imm_type_D      //= s.dpath.imm_type_D
 
-      s.ctrl.reg_en_X       , s.dpath.reg_en_X,
-      s.ctrl.alu_fn_X       , s.dpath.alu_fn_X,
+    s.ctrl.reg_en_X        //= s.dpath.reg_en_X
+    s.ctrl.alu_fn_X        //= s.dpath.alu_fn_X
 
-      s.ctrl.reg_en_M       , s.dpath.reg_en_M,
-      s.ctrl.wb_result_sel_M, s.dpath.wb_result_sel_M,
+    s.ctrl.reg_en_M        //= s.dpath.reg_en_M
+    s.ctrl.wb_result_sel_M //= s.dpath.wb_result_sel_M
 
-      s.ctrl.reg_en_W       , s.dpath.reg_en_W,
-      s.ctrl.rf_waddr_W     , s.dpath.rf_waddr_W,
-      s.ctrl.rf_wen_W       , s.dpath.rf_wen_W,
+    s.ctrl.reg_en_W        //= s.dpath.reg_en_W
+    s.ctrl.rf_waddr_W      //= s.dpath.rf_waddr_W
+    s.ctrl.rf_wen_W        //= s.dpath.rf_wen_W
 
-      s.dpath.inst_D        , s.ctrl.inst_D,
-      s.dpath.ne_X          , s.ctrl.ne_X,
-    )
+    s.dpath.inst_D         //= s.ctrl.inst_D
+    s.dpath.ne_X           //= s.ctrl.ne_X
 
   #-----------------------------------------------------------------------
   # Line tracing

--- a/examples/ex03_proc/TinyRV0InstRTL.py
+++ b/examples/ex03_proc/TinyRV0InstRTL.py
@@ -112,7 +112,7 @@ class DecodeInstType( Component ):
     s.in_ = InPort ( Bits32 )
     s.out = OutPort( Bits8 )
 
-    @s.update
+    @update
     def comb_logic():
 
       s.out = b8( ZERO )

--- a/examples/ex04_xcel/ChecksumXcelCL.py
+++ b/examples/ex04_xcel/ChecksumXcelCL.py
@@ -54,7 +54,7 @@ class ChecksumXcelCL( Component ):
     connect( s.checksum_unit.send, s.out_q.enq )
     connect( s.xcel.req, s.in_q.enq )
 
-    @s.update
+    @update
     def up_tick():
       if s.state == s.XCFG:
         # Dequeue a request message from input queue and send response.

--- a/examples/ex04_xcel/ChecksumXcelFL.py
+++ b/examples/ex04_xcel/ChecksumXcelFL.py
@@ -22,14 +22,14 @@ class ChecksumXcelFL( Component ):
 
     ReqType, RespType = mk_xcel_msg( 5, 32 )
 
-    s.xcel = XcelMinionIfcFL( read=s.read, write=s.write)
+    s.xcel = XcelMinionIfcFL( read=s.read, write=s.write )
 
     # Components
 
     s.reg_file = [ b32(0) for _ in range(6) ]
 
     s.trace = "            "
-    @s.update
+    @update
     def up_clear_trace():
       s.trace = "            "
 

--- a/examples/ex04_xcel/ProcXcel.py
+++ b/examples/ex04_xcel/ProcXcel.py
@@ -26,8 +26,11 @@ class ProcXcel( Component ):
 
     # Instruction Memory Request/Response Interface
 
-    s.proc = ProcClass()( commit_inst = s.commit_inst )
-    s.xcel = XcelClass()( xcel = s.proc.xcel )
+    s.proc = ProcClass()
+    s.proc.commit_inst //= s.commit_inst
+
+    s.xcel = XcelClass()
+    s.xcel.xcel //= s.proc.xcel
 
     if   isinstance( s.proc.imem, MemMasterIfcRTL ): # RTL proc
       s.mngr2proc = RecvIfcRTL( Bits32 )
@@ -47,12 +50,11 @@ class ProcXcel( Component ):
       s.imem = MemMasterIfcFL()
       s.dmem = MemMasterIfcFL()
 
-    connect_pairs(
-      s.mngr2proc, s.proc.mngr2proc,
-      s.proc2mngr, s.proc.proc2mngr,
-      s.imem,      s.proc.imem,
-      s.dmem,      s.proc.dmem,
-    )
+
+    s.mngr2proc //= s.proc.mngr2proc
+    s.proc2mngr //= s.proc.proc2mngr
+    s.imem      //= s.proc.imem
+    s.dmem      //= s.proc.dmem
 
   def line_trace( s ):
     return "{}|{}".format( s.proc.line_trace(), s.xcel.line_trace() )

--- a/examples/ex04_xcel/proc-xcel-sim
+++ b/examples/ex04_xcel/proc-xcel-sim
@@ -115,15 +115,13 @@ class TestHarness(Component):
     s.sink = TestSinkCL( Bits32, [], sink_delay, sink_delay )
     s.mem  = MemoryCL  ( 2, latency = mem_latency )
 
-    s.dut  = ProcXcel  ( ProcClass, XcelClass )(
-      mngr2proc = s.src.send,
-      proc2mngr = s.sink.recv,
-      imem      = s.mem.ifc[0],
-      dmem      = s.mem.ifc[1],
+    s.dut = m = ProcXcel( ProcClass, XcelClass )
+    m.mngr2proc //= s.src.send
+    m.proc2mngr //= s.sink.recv
+    m.imem      //= s.mem.ifc[0]
+    m.dmem      //= s.mem.ifc[1]
 
-      commit_inst = s.commit_inst,
-    )
-
+    m.commit_inst //= s.commit_inst
 
   #-----------------------------------------------------------------------
   # load

--- a/pymtl3/__init__.py
+++ b/pymtl3/__init__.py
@@ -1,6 +1,8 @@
 from .datatypes import *
 from .datatypes import _bitwidths
 from .dsl.Component import Component
+from .dsl.ComponentLevel1 import update
+from .dsl.ComponentLevel2 import update_ff
 from .dsl.ComponentLevel3 import connect
 from .dsl.ComponentLevel5 import method_port
 from .dsl.ComponentLevel6 import non_blocking
@@ -30,7 +32,7 @@ __version__ = "0.5.5"
 __all__ = [
   'U','M','RD','WR',
   'Wire', 'InPort', 'OutPort', 'Interface', 'CallerPort', 'CalleePort',
-  'connect', 'method_port',
+  'update', 'update_ff', 'connect', 'method_port',
   'CalleeIfcRTL', 'CallerIfcRTL',
   'non_blocking', 'CalleeIfcCL', 'CallerIfcCL',
   'blocking', 'CalleeIfcFL', 'CallerIfcFL',

--- a/pymtl3/datatypes/test/bitstructs_test.py
+++ b/pymtl3/datatypes/test/bitstructs_test.py
@@ -11,7 +11,7 @@ from copy import deepcopy
 
 import pytest
 
-from pymtl3.dsl import Component, InPort, OutPort
+from pymtl3.dsl import Component, InPort, OutPort, update
 from pymtl3.dsl.test.sim_utils import simple_sim_pass
 
 from ..bits_import import *
@@ -265,7 +265,7 @@ def test_component():
       s.out    = OutPort( NestedSimple )
       s.out_pt = OutPort( StaticPoint  )
 
-      @s.update
+      @update
       def up_bitstruct():
         # TODO:We have to use deepcopy here as a temporary workaround
         # to prevent s.in_ being mutated by the following operations.

--- a/pymtl3/dsl/Component.py
+++ b/pymtl3/dsl/Component.py
@@ -54,9 +54,6 @@ class Component( ComponentLevel7 ):
         parent._connect_signal_signal( s.clk, parent.clk )
         parent._connect_signal_signal( s.reset, parent.reset )
 
-      if s._dsl.call_kwargs is not None: # s.a = A()( b = s.b )
-        s._continue_call_connect()
-
       s._dsl.constructed = True
 
   # This function deduplicates those checks in each API
@@ -105,7 +102,7 @@ class Component( ComponentLevel7 ):
     except AttributeError:
       raise NotElaboratedError()
 
-    top._dsl.elaborate_stack = [ parent ]
+    NamedObject._elaborate_stack = [ parent ]
 
     # Check if we are adding obj to a list of to a component
     if not indices:
@@ -163,13 +160,13 @@ class Component( ComponentLevel7 ):
       obj._dsl._my_indices  = indices
 
       obj._dsl.elaborate_top = top
-      top._dsl.elaborate_stack.append( obj )
+      NamedObject._elaborate_stack.append( obj )
 
       NamedObject.__setattr__ = NamedObject.__setattr_for_elaborate__
       obj._construct()
       del NamedObject.__setattr__
 
-      top._dsl.elaborate_stack.pop()
+      NamedObject._elaborate_stack.pop()
 
     added_components = obj._collect_all_single( lambda x: isinstance( x, Component ) )
 
@@ -229,7 +226,7 @@ class Component( ComponentLevel7 ):
     for func, obj_name in provided_func_calls:
       parent._dsl.func_calls[func].add( eval(obj_name) )
 
-    del top._dsl.elaborate_stack
+    del NamedObject._elaborate_stack
 
   def _delete_component( top, obj ):
 

--- a/pymtl3/dsl/ComponentLevel1.py
+++ b/pymtl3/dsl/ComponentLevel1.py
@@ -24,6 +24,10 @@ from .Placeholder import Placeholder
 
 p = re.compile('( *((@|def).*))')
 
+def update( blk ):
+  NamedObject._elaborate_stack[-1]._update( blk )
+  return blk
+
 class ComponentLevel1( NamedObject ):
 
   #-----------------------------------------------------------------------
@@ -64,7 +68,7 @@ class ComponentLevel1( NamedObject ):
   # Construction-time APIs
   #-----------------------------------------------------------------------
 
-  def update( s, blk ):
+  def _update( s, blk ):
     if isinstance( s, Placeholder ):
       raise InvalidPlaceholderError( "Cannot define update block <{}> "
               "in a placeholder component.".format( blk.__name__ ) )
@@ -75,7 +79,6 @@ class ComponentLevel1( NamedObject ):
     s._dsl.name_upblk[ name ] = blk
     s._dsl.upblks.add( blk )
     s._dsl.upblk_order.append( blk )
-    return blk
 
   def get_update_block( s, name ):
     return s._dsl.name_upblk[ name ]

--- a/pymtl3/dsl/ComponentLevel2.py
+++ b/pymtl3/dsl/ComponentLevel2.py
@@ -43,6 +43,10 @@ from .Placeholder import Placeholder
 
 compiled_re = re.compile('( *(@|def))')
 
+def update_ff( blk ):
+  NamedObject._elaborate_stack[-1]._update_ff( blk )
+  return blk
+
 class ComponentLevel2( ComponentLevel1 ):
 
   #-----------------------------------------------------------------------
@@ -474,22 +478,20 @@ class ComponentLevel2( ComponentLevel1 ):
     return func
 
   # Override
-  def update( s, blk ):
-    super().update( blk )
+  def _update( s, blk ):
+    super()._update( blk )
 
     s._cache_func_meta( blk, is_update_ff=False ) # add caching of src/ast
-    return blk
 
   def update_on_edge( s, blk ):
     raise PyMTLDeprecationError("\ns.update_on_edge decorator has been deprecated! "
-                                "\n- Please use @s.update_ff instead.")
+                                "\n- Please use @update_ff instead.")
 
-  def update_ff( s, blk ):
-    super().update( blk )
+  def _update_ff( s, blk ):
+    super()._update( blk )
 
     s._dsl.update_ff.add( blk )
     s._cache_func_meta( blk, is_update_ff=True ) # add caching of src/ast
-    return blk
 
   # Override
   def add_constraints( s, *args ): # add RD-U/WR-U constraints

--- a/pymtl3/dsl/ComponentLevel3.py
+++ b/pymtl3/dsl/ComponentLevel3.py
@@ -212,7 +212,7 @@ class ComponentLevel3( ComponentLevel2 ):
     new_src = "def {}():\n {}\n".format( blk_name, src.replace("//=", "=") )
     linecache.cache[ blk_name ] = (len(new_src), None, new_src.splitlines(), blk_name)
 
-    ComponentLevel1.update( s, blk )
+    ComponentLevel1._update( s, blk )
 
     # This caching here does no caching because the block name contains
     # the signal name intentionally to avoid conflicts. With //= it is

--- a/pymtl3/dsl/ComponentLevel3.py
+++ b/pymtl3/dsl/ComponentLevel3.py
@@ -57,7 +57,6 @@ class ComponentLevel3( ComponentLevel2 ):
 
   def __new__( cls, *args, **kwargs ):
     inst = super().__new__( cls, *args, **kwargs )
-    inst._dsl.call_kwargs   = None
     inst._dsl.adjacency     = defaultdict(set)
     inst._dsl.connect_order = []
     inst._dsl.consts        = set()
@@ -95,9 +94,6 @@ class ComponentLevel3( ComponentLevel2 ):
           kwargs.update( more_args )
 
       s.construct( *s._dsl.args, **kwargs )
-
-      if s._dsl.call_kwargs is not None: # s.a = A()( b = s.b )
-        s._continue_call_connect()
 
       s._dsl.constructed = True
 
@@ -279,7 +275,9 @@ class ComponentLevel3( ComponentLevel2 ):
 
   def _connect_signal_signal( s, o1, o2 ):
     if not (o1._dsl.Type is o2._dsl.Type):
-      raise InvalidConnectionError( f"Type mismatch {o1._dsl.Type} != {o2._dsl.Type} during {o1}<->{o2}." )
+      raise InvalidConnectionError( f"Bitwidth mismatch {o1._dsl.Type.__name__} != {o2._dsl.Type.__name__}\n"
+                                    f"- In class {type(s)}\n- When connecting {o1} <-> {o2}\n"
+                                    f"Suggestion: make sure both sides of connection have matching bitwidth")
 
     if o1 not in s._dsl.adjacency[o2]:
       assert o2 not in s._dsl.adjacency[o1]
@@ -365,58 +363,6 @@ class ComponentLevel3( ComponentLevel2 ):
       assert isinstance( o1, Signal ), f"Cannot connect {o1!r} to {o2!r}."
 
       s._connect_signal_const( o1, o2 )
-
-  def _continue_call_connect( s ):
-    """ Here we continue to establish the connections from signals of the
-    parent object, to signals in the current object. Since it is the
-    parent that connects a constant integer to a signal, we should point
-    the Const object back to the parent object by setting _parent_obj to
-    s._parent_obj."""
-
-    parent = s._dsl.parent_obj
-
-    top = s._dsl.elaborate_top
-
-    # _continue_call_connect is actually connecting stuff at parent level,
-    # but it currently happens before before we pop the child component.
-    # To make minimal modification, I temporarily pop it from
-    # elaborate_stack and append it back at the end of this method
-
-    tmp = top._dsl.elaborate_stack.pop()
-
-    try: # Catch AssertionError from _connect
-
-      # Process saved __call__ kwargs
-      for (kw, target) in s._dsl.call_kwargs.items():
-        try:
-          obj = getattr( s, kw )
-        except AttributeError:
-          raise InvalidConnectionError( "{} is not a member of class {}".format(kw, s.__class__) )
-
-        # Obj is a list of signals
-        # We assume the a dict of { index: obj } is provided.
-        if   isinstance( obj, list ):
-          # Make sure the connection target is a dictionary {idx: obj}
-          if not isinstance( target, dict ):
-            raise InvalidConnectionError( "We only support a dictionary when '{}' is an array.".format( kw ) )
-          for idx, item in target.items():
-            parent._connect( obj[idx], item, internal=False )
-
-        # Obj is a single signal
-        # If the target is a list, it's fanout connection
-        elif isinstance( target, (tuple, list) ):
-          for item in target:
-            parent._connect( obj, item, internal=False )
-
-        # Target is a single object
-        else:
-          parent._connect( obj, target, internal=False )
-
-    except AssertionError as e:
-      raise InvalidConnectionError( "Invalid connection for {}:\n{}".format( kw, e ) )
-
-    # Append tmp back to elaborate_stack
-    top._dsl.elaborate_stack.append(tmp)
 
   @staticmethod
   def _floodfill_nets( signal_list, adjacency ):
@@ -829,13 +775,9 @@ class ComponentLevel3( ComponentLevel2 ):
       >>> s.x = SomeReg(Bits1)( in_ = s.in_ )
     It connects s.in_ to s.x.in_ in the same line as model construction.
     """
-    assert args == ()
-    if s._dsl.constructed:
-      raise InvalidConnectionError("Connection using __call__, "
-                                   "i.e. s.x( a = s.a ), is illegal "
-                                   "after constructing s.x")
-    s._dsl.call_kwargs = kwargs
-    return s
+    raise PyMTLDeprecationError("\n__call__ connection has been deprecated! "
+                                "\n- Please use free function connect(s.x,s.y) or "
+                                "syntactic sugar s.x//=s.y instead.")
 
   def connect( s, *args, **kwargs ):
     raise PyMTLDeprecationError("\ns.connect method has been deprecated! "

--- a/pymtl3/dsl/ComponentLevel5.py
+++ b/pymtl3/dsl/ComponentLevel5.py
@@ -60,9 +60,6 @@ class ComponentLevel5( ComponentLevel4 ):
       # Same as parent class _construct
       s.construct( *s._dsl.args, **kwargs )
 
-      if s._dsl.call_kwargs is not None: # s.a = A()( b = s.b )
-        s._continue_call_connect()
-
       s._dsl.constructed = True
 
   def _connect_method_ports( s, o1, o2 ):

--- a/pymtl3/dsl/Connectable.py
+++ b/pymtl3/dsl/Connectable.py
@@ -10,7 +10,7 @@ Date   : Apr 16, 2018
 import types
 from collections import deque
 
-from pymtl3.datatypes import Bits, Bits1, mk_bits, is_bitstruct_class
+from pymtl3.datatypes import Bits, Bits1, is_bitstruct_class, mk_bits
 
 from .errors import InvalidConnectionError
 from .NamedObject import DSLMetadata, NamedObject
@@ -142,8 +142,13 @@ class Const( Connectable ):
 class Signal( NamedObject, Connectable ):
 
   def __init__( s, Type=Bits1 ):
-    assert isinstance( Type, type ) and ( issubclass( Type, Bits ) or is_bitstruct_class(Type) ), \
-            f"RTL signal can only be of Bits type or bitstruct type, not {Type}"
+    if isinstance( Type, int ):
+      Type = mk_bits(Type)
+    else:
+      assert isinstance( Type, type ) and ( issubclass( Type, Bits ) or is_bitstruct_class(Type) ), \
+              f"RTL signal can only be of Bits type or bitstruct type, not {Type}.\n" \
+              f"Note: an integer is also accepted: Wire(32) is equivalent to Wire(Bits32))"
+
     s._dsl.Type = Type
     s._dsl.type_instance = None
 

--- a/pymtl3/dsl/Connectable.py
+++ b/pymtl3/dsl/Connectable.py
@@ -10,7 +10,7 @@ Date   : Apr 16, 2018
 import types
 from collections import deque
 
-from pymtl3.datatypes import Bits, Bits1, mk_bits
+from pymtl3.datatypes import Bits, Bits1, mk_bits, is_bitstruct_class
 
 from .errors import InvalidConnectionError
 from .NamedObject import DSLMetadata, NamedObject
@@ -63,7 +63,6 @@ def _connect_check( o1, o2, internal ):
 
   o1_connectable = False
   o2_connectable = False
-  top = None
 
   # Get access to the top level component by identifying a connectable
 
@@ -81,14 +80,12 @@ def _connect_check( o1, o2, internal ):
   if not o1_connectable and not o2_connectable:
     if internal:  return None, False, False
 
-    raise InvalidConnectionError("class {} and class {} are both not connectable.\n"
-                                  "  (when connecting {} to {})" \
-        .format( type(o1), type(o2), repr(o1), repr(o2)) )
+    raise InvalidConnectionError(f"class {type(o1)} and class {type(o2)} are both not connectable.\n"
+                                 f"  (when connecting {o1!r} to {o2!r})")
 
   # Get the component from elaborate_stack
-
   try:
-    host = top._dsl.elaborate_stack[-1]
+    host = NamedObject._elaborate_stack[-1]
   except AttributeError:
     raise InvalidConnectionError("Cannot call connect after elaboration.\n"
                                  "- Please use top.add_connection(...) API.")
@@ -145,7 +142,8 @@ class Const( Connectable ):
 class Signal( NamedObject, Connectable ):
 
   def __init__( s, Type=Bits1 ):
-    assert isinstance( Type, type ), "Use actual type instead of instance!"
+    assert isinstance( Type, type ) and ( issubclass( Type, Bits ) or is_bitstruct_class(Type) ), \
+            f"RTL signal can only be of Bits type or bitstruct type, not {Type}"
     s._dsl.Type = Type
     s._dsl.type_instance = None
 

--- a/pymtl3/dsl/NamedObject.py
+++ b/pymtl3/dsl/NamedObject.py
@@ -181,9 +181,9 @@ class NamedObject:
         top = sd.elaborate_top
         ud.elaborate_top = top
 
-        top._dsl.elaborate_stack.append( obj )
+        NamedObject._elaborate_stack.append( obj )
         obj._construct()
-        top._dsl.elaborate_stack.pop()
+        NamedObject._elaborate_stack.pop()
 
       # ONLY LIST IS SUPPORTED, SORRY.
       # I don't want to support any iterable object because later "Wire"
@@ -231,9 +231,9 @@ class NamedObject:
             top = sd.elaborate_top
             ud.elaborate_top = top
 
-            top._dsl.elaborate_stack.append( u )
+            NamedObject._elaborate_stack.append( u )
             u._construct()
-            top._dsl.elaborate_stack.pop()
+            NamedObject._elaborate_stack.pop()
 
           elif isinstance( u, list ):
             Q.extend( (v, indices+(i,)) for i, v in enumerate(u) )
@@ -356,23 +356,24 @@ class NamedObject:
     s._dsl.full_name     = "s"
     s._dsl.elaborate_top = s
 
-    s._dsl.elaborate_stack = [ s ]
 
     # Secret source for letting the child know the field name of itself
     # -- override setattr for elaboration, and remove it afterwards
 
     NamedObject.__setattr__ = NamedObject.__setattr_for_elaborate__
+    NamedObject._elaborate_stack = [ s ]
 
     try:
       s._construct()
     except Exception:
       # re-raise here after deleting __setattr__
       del NamedObject.__setattr__ # not harming the rest of execution
+      del NamedObject._elaborate_stack
       raise
 
     del NamedObject.__setattr__
 
-    del s._dsl.elaborate_stack
+    del NamedObject._elaborate_stack
 
   def _elaborate_collect_all_named_objects( s ):
     s._dsl.all_named_objects = s._collect_all_single()

--- a/pymtl3/dsl/NamedObject.py
+++ b/pymtl3/dsl/NamedObject.py
@@ -356,9 +356,9 @@ class NamedObject:
     s._dsl.full_name     = "s"
     s._dsl.elaborate_top = s
 
-
-    # Secret source for letting the child know the field name of itself
+    # Secret sauce for letting the child know the field name of itself
     # -- override setattr for elaboration, and remove it afterwards
+    # -- and the global elaborate to enable free function as decorator
 
     NamedObject.__setattr__ = NamedObject.__setattr_for_elaborate__
     NamedObject._elaborate_stack = [ s ]
@@ -372,7 +372,6 @@ class NamedObject:
       raise
 
     del NamedObject.__setattr__
-
     del NamedObject._elaborate_stack
 
   def _elaborate_collect_all_named_objects( s ):

--- a/pymtl3/dsl/__init__.py
+++ b/pymtl3/dsl/__init__.py
@@ -3,6 +3,8 @@ These objects are only for developers to use. Other objects are exposed
 to users in pymtl/__init__.py
 """
 from .Component import Component
+from .ComponentLevel1 import update
+from .ComponentLevel2 import update_ff
 from .ComponentLevel3 import connect
 from .ComponentLevel5 import method_port
 from .ComponentLevel6 import non_blocking

--- a/pymtl3/dsl/test/ComponentAPI_test.py
+++ b/pymtl3/dsl/test/ComponentAPI_test.py
@@ -9,7 +9,16 @@ Date   : June 2, 2019
 import random
 
 from pymtl3.datatypes import *
-from pymtl3.dsl import Component, InPort, OutPort, Placeholder, Wire, connect
+from pymtl3.dsl import (
+    Component,
+    InPort,
+    OutPort,
+    Placeholder,
+    Wire,
+    connect,
+    update,
+    update_ff,
+)
 from pymtl3.dsl.errors import InvalidAPICallError
 
 from .sim_utils import simple_sim_pass
@@ -19,17 +28,19 @@ def test_api_not_elaborated():
 
   class X( Component ):
     def construct( s, nbits=0 ):
-      s.in_ = InPort ( mk_bits(nbits) )
-      s.out = OutPort( mk_bits(nbits) )
-      @s.update
+      s.in_ = InPort ( nbits )
+      s.out = OutPort( nbits )
+      @update
       def up_x():
         s.out = s.in_ + 1
 
   class Y( Component ):
     def construct( s, nbits=0 ):
-      s.in_ = InPort ( mk_bits(nbits) )
-      s.out = OutPort( mk_bits(nbits) )
-      s.x = X()( in_ = s.in_, out = s.out )
+      s.in_ = InPort ( nbits )
+      s.out = OutPort( nbits )
+      s.x = X()
+      s.x.in_ //= s.in_
+      s.x.out //= s.out
 
   a = Y()
   a.elaborate()
@@ -56,7 +67,7 @@ class Real_shamt( Component ):
   def construct( s, shamt=1 ):
     s.in_ = InPort ( Bits32 )
     s.out = OutPort( Bits32 )
-    @s.update
+    @update
     def up_real():
       s.out = s.in_ << shamt
 
@@ -67,7 +78,7 @@ class Real_shamt2( Component ):
   def construct( s, shamt=1 ):
     s.in_ = InPort ( Bits32 )
     s.out = OutPort( Bits32 )
-    @s.update
+    @update
     def up_real():
       s.out = s.in_ + shamt
 
@@ -76,10 +87,13 @@ class Real_shamt2( Component ):
 
 class Foo_shamt_list_wrap( Component ):
   def construct( s, nbits=0 ):
-    s.in_ = InPort ( mk_bits(nbits) )
-    s.out = [ OutPort( mk_bits(nbits) ) for i in range(5) ]
+    s.in_ = InPort ( nbits )
+    s.out = [ OutPort( nbits ) for _ in range(5) ]
 
-    s.inner = [ Foo_shamt( i )( in_ = s.in_, out = s.out[i] ) for i in range(5) ]
+    s.inner = [ Foo_shamt( i ) for i in range(5) ]
+    for i in range(5):
+      s.inner[i].in_ //= s.in_
+      s.inner[i].out //= s.out[i]
 
   def line_trace( s ):
     return "|".join( [ x.line_trace() for x in s.inner ] )
@@ -88,12 +102,14 @@ def test_real_replaced_by_real2():
 
   class Real_wrap( Component ):
     def construct( s, nbits=0 ):
-      s.in_ = InPort ( mk_bits(nbits) )
-      s.out = OutPort( mk_bits(nbits) )
-      s.w   = Wire( mk_bits(nbits) )
+      s.in_ = InPort ( nbits )
+      s.out = OutPort( nbits )
+      s.w   = Wire( nbits )
       connect( s.w, s.out )
 
-      s.inner = Real_shamt( 5 )( in_ = s.in_, out = s.w )
+      s.inner = Real_shamt( 5 )
+      s.inner.in_ //= s.in_
+      s.inner.out //= s.w
 
     def line_trace( s ):
       return s.inner.line_trace()
@@ -170,7 +186,8 @@ def test_replace_deep_list_of_foo_by_real():
   class TopWrap( Component ):
     def construct( s ):
       s.in_    = InPort( Bits32 )
-      s.foobar = Foo_shamt_list_wrap( 32 )( in_ = s.in_ )
+      s.foobar = Foo_shamt_list_wrap( 32 )
+      s.foobar.in_ //= s.in_
 
   foo_wrap = TopWrap()
 
@@ -198,16 +215,16 @@ def test_replace_component_upblk_rw_port():
 
   class Real_wrap( Component ):
     def construct( s, nbits=0 ):
-      s.in_ = InPort ( mk_bits(nbits) )
-      s.out = OutPort( mk_bits(nbits) )
-      s.w   = Wire( mk_bits(nbits) )
+      s.in_ = InPort ( nbits )
+      s.out = OutPort( nbits )
+      s.w   = Wire( nbits )
       connect( s.w, s.out )
 
-      @s.update
+      @update
       def up_in():
         s.inner.in_ = s.in_
 
-      @s.update
+      @update
       def up_out():
         s.w = s.inner.out
 
@@ -242,16 +259,16 @@ def test_replace_component_func_rw_port():
 
   class Real_wrap( Component ):
     def construct( s, nbits=0 ):
-      s.in_ = InPort ( mk_bits(nbits) )
-      s.out = OutPort( mk_bits(nbits) )
-      s.w   = Wire( mk_bits(nbits) )
+      s.in_ = InPort ( nbits )
+      s.out = OutPort( nbits )
+      s.w   = Wire( nbits )
       connect( s.w, s.out )
 
       @s.func
       def assign_in( x ):
         s.inner.in_ = x
 
-      @s.update
+      @update
       def up_in():
         assign_in( s.in_ )
 
@@ -259,7 +276,7 @@ def test_replace_component_func_rw_port():
       def read_out():
         s.w = s.inner.out
 
-      @s.update
+      @update
       def up_out():
         read_out()
 
@@ -296,7 +313,7 @@ def test_ctrl_dpath_connected_replaced_both():
 
       connect( s.in_, s.wire )
 
-      @s.update
+      @update
       def out():
         s.out = s.wire + 10
 
@@ -308,7 +325,7 @@ def test_ctrl_dpath_connected_replaced_both():
 
       connect( s.in_, s.wire )
 
-      @s.update
+      @update
       def out():
         s.out = s.wire + 444
 
@@ -338,8 +355,8 @@ def test_ctrl_dpath_connected_replaced_both():
   a = Top()
 
   a.elaborate()
-  a.replace_component( a.inner.m1, Module2() )
-  a.replace_component( a.inner.m2, Module2() )
+  a.replace_component_with_obj( a.inner.m1, Module2() )
+  a.replace_component_with_obj( a.inner.m2, Module2() )
 
   simple_sim_pass( a )
 
@@ -356,16 +373,16 @@ def test_connect_upblk_orders():
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
       s.out2 = OutPort( Bits32 )
-      @s.update
+      @update
       def up_out():
         s.out = Bits32(0)
 
       s.wire = Wire(Bits32)
-      @s.update_ff
+      @update_ff
       def up_ff():
         s.wire <<= s.wire + 1
 
-      @s.update
+      @update
       def up_out2():
         s.out2 = Bits32(0)
 
@@ -393,9 +410,9 @@ def test_connect_upblk_orders():
   # class X( Component ):
     # def construct( s, nbits=0 ):
       # s.leak = bytearray(1<<30)
-      # s.in_ = InPort ( mk_bits(nbits) )
-      # s.out = OutPort( mk_bits(nbits) )
-      # @s.update
+      # s.in_ = InPort ( nbits )
+      # s.out = OutPort( nbits )
+      # @update
       # def up_x():
         # s.out = s.in_ + 1
   # for i in range(100):

--- a/pymtl3/dsl/test/ComponentLevel1_test.py
+++ b/pymtl3/dsl/test/ComponentLevel1_test.py
@@ -8,7 +8,7 @@ Date   : Dec 23, 2017
 """
 from collections import deque
 
-from pymtl3.dsl.ComponentLevel1 import ComponentLevel1
+from pymtl3.dsl.ComponentLevel1 import ComponentLevel1, update
 from pymtl3.dsl.ConstraintTypes import U
 from pymtl3.dsl.errors import UpblkCyclicError, UpblkFuncSameNameError
 
@@ -32,7 +32,7 @@ class TestSource( ComponentLevel1 ):
     s.input_ = deque( input_ ) # deque.popleft() is faster
     s.out = 0
 
-    @s.update
+    @update
     def up_src():
       if not s.input_:
         s.out = 0
@@ -53,7 +53,7 @@ class TestSink( ComponentLevel1 ):
     s.answer = deque( answer )
     s.in_ = 0
 
-    @s.update
+    @update
     def up_sink():
       if not s.answer:
         assert False, "Simulation has ended"
@@ -75,11 +75,11 @@ def test_cyclic_dependency():
 
     def construct( s ):
 
-      @s.update
+      @update
       def upA():
         pass
 
-      @s.update
+      @update
       def upB():
         pass
 
@@ -101,11 +101,11 @@ def test_upblock_same_name():
 
     def construct( s ):
 
-      @s.update
+      @update
       def upA():
         pass
 
-      @s.update
+      @update
       def upA():
         pass
 
@@ -128,7 +128,7 @@ def test_register_behavior():
       s.wire0 = 0
       s.wire1 = 0
 
-      @s.update
+      @update
       def up_from_src():
         s.wire0 = s.src.out
 
@@ -138,11 +138,11 @@ def test_register_behavior():
         U(up_src) < U(up_from_src),
       )
 
-      @s.update
+      @update
       def up_reg():
         s.wire1 = s.wire0
 
-      @s.update
+      @update
       def up_to_sink():
         s.sink.in_ = s.wire1
 
@@ -179,7 +179,7 @@ def test_add_loopback():
       s.wire0 = 0
       s.wire1 = 0
 
-      @s.update
+      @update
       def up_from_src():
         s.wire0 = s.src.out + 1
 
@@ -191,11 +191,11 @@ def test_add_loopback():
 
       s.reg0 = 0
 
-      @s.update
+      @update
       def upA():
         s.reg0 = s.wire0 + s.wire1
 
-      @s.update
+      @update
       def up_to_sink_and_loop_back():
         s.sink.in_ = s.reg0
         s.wire1 = s.reg0
@@ -233,7 +233,7 @@ def test_lots_of_fan():
 
       s.wire0 = 0
 
-      @s.update
+      @update
       def up_from_src():
         s.wire0 = s.src.out + 1
 
@@ -245,13 +245,13 @@ def test_lots_of_fan():
 
       s.reg = 0
 
-      @s.update
+      @update
       def up_reg():
         s.reg = s.wire0
 
       s.wire1 = s.wire2 = 0
 
-      @s.update
+      @update
       def upA():
         s.wire1 = s.reg
         s.wire2 = s.reg + 1
@@ -263,14 +263,14 @@ def test_lots_of_fan():
 
       s.wire3 = s.wire4 = 0
 
-      @s.update
+      @update
       def upB():
         s.wire3 = s.wire1
         s.wire4 = s.wire1 + 1
 
       s.wire5 = s.wire6 = 0
 
-      @s.update
+      @update
       def upC():
         s.wire5 = s.wire2
         s.wire6 = s.wire2 + 1
@@ -281,7 +281,7 @@ def test_lots_of_fan():
       )
       s.wire7 = s.wire8 = 0
 
-      @s.update
+      @update
       def upD():
         s.wire7 = s.wire3 + s.wire6
         s.wire8 = s.wire4 + s.wire5
@@ -291,7 +291,7 @@ def test_lots_of_fan():
         U(upC) < U(upD),
       )
 
-      @s.update
+      @update
       def up_to_sink():
         s.sink.in_ = s.wire7 + s.wire8
 
@@ -324,7 +324,7 @@ def test_2d_array_vars():
 
       s.wire = [ [0 for _ in range(2)] for _ in range(2) ]
 
-      @s.update
+      @update
       def up_from_src():
         s.wire[0][0] = s.src.out
         s.wire[0][1] = s.src.out + 1
@@ -337,11 +337,11 @@ def test_2d_array_vars():
 
       s.reg = 0
 
-      @s.update
+      @update
       def up_reg():
         s.reg = s.wire[0][0] + s.wire[0][1]
 
-      @s.update
+      @update
       def upA():
         s.wire[1][0] = s.reg
         s.wire[1][1] = s.reg + 1
@@ -350,7 +350,7 @@ def test_2d_array_vars():
         U(up_reg) < U(upA),
         U(up_reg) < U(up_from_src),
       )
-      @s.update
+      @update
       def up_to_sink():
         s.sink.in_ = s.wire[1][0] + s.wire[1][1]
 

--- a/pymtl3/dsl/test/ComponentLevel2_test.py
+++ b/pymtl3/dsl/test/ComponentLevel2_test.py
@@ -84,11 +84,11 @@ class TestSink( ComponentLevel2 ):
   def line_trace( s ):
     return "%s" % s.in_
 
-def test_signal_require_type():
+def test_signal_require_type_or_int():
 
   class Top(ComponentLevel2):
     def construct( s ):
-      s.a = Wire(1)
+      s.a = Wire('a')
 
   a = Top()
   try:
@@ -101,8 +101,7 @@ def test_ast_caching_closure():
 
   class Parametrized(ComponentLevel2):
     def construct( s, nbits ):
-      nbitsX2 = nbits*2
-      s.x = Wire( mk_bits(nbits*2) )
+      s.x = Wire( nbits*2 )
       @update
       def upA():
         print(s.x[nbits])

--- a/pymtl3/dsl/test/ComponentLevel3_test.py
+++ b/pymtl3/dsl/test/ComponentLevel3_test.py
@@ -8,7 +8,8 @@ Date   : Dec 25, 2017
 """
 from collections import deque
 
-from pymtl3.datatypes import Bits8, Bits10, Bits32, bitstruct
+from pymtl3.datatypes import Bits1, Bits8, Bits10, Bits32, bitstruct, mk_bits, clog2
+from pymtl3.dsl.ComponentLevel1 import update
 from pymtl3.dsl.ComponentLevel3 import ComponentLevel3, connect
 from pymtl3.dsl.Connectable import InPort, OutPort, Wire
 from pymtl3.dsl.ConstraintTypes import WR, U
@@ -26,6 +27,7 @@ def _test_model( cls ):
   A = cls()
   A.elaborate()
   simple_sim_pass( A, 0x123 )
+  A.tick()
 
   T, time = 0, 20
   while not A.done() and T < time:
@@ -44,7 +46,7 @@ class TestSource( ComponentLevel3 ):
 
     s.out = OutPort(Type)
 
-    @s.update
+    @update
     def up_src():
       if not s.input_:
         s.out = Type()
@@ -65,7 +67,7 @@ class TestSink( ComponentLevel3 ):
     s.answer = deque( [ x if x == "*" else Type(x) for x in answer ] )
     s.in_ = InPort(Type)
 
-    @s.update
+    @update
     def up_sink():
       if not s.answer:
         assert False, "Simulation has ended"
@@ -85,10 +87,10 @@ class Mux( ComponentLevel3 ):
 
   def construct( s, Type, ninputs ):
     s.in_ = [ InPort( Type ) for _ in range(ninputs) ]
-    s.sel = InPort( int if Type is int else mk_bits( clog2(ninputs) ) )
+    s.sel = InPort( mk_bits( clog2(ninputs) ) )
     s.out = OutPort( Type )
 
-    @s.update
+    @update
     def up_mux():
       s.out = s.in_[ s.sel ]
 
@@ -100,12 +102,12 @@ def test_connect_list_const_idx():
 
     def construct( s ):
 
-      s.src_in0 = TestSource( int, [4,3,2,1] )
-      s.src_in1 = TestSource( int, [8,7,6,5] )
-      s.src_sel = TestSource( int, [1,0,1,0] )
-      s.sink    = TestSink  ( int, [8,3,6,1] )
+      s.src_in0 = TestSource( Bits32, [4,3,2,1] )
+      s.src_in1 = TestSource( Bits32, [8,7,6,5] )
+      s.src_sel = TestSource( Bits1,  [1,0,1,0] )
+      s.sink    = TestSink  ( Bits32, [8,3,6,1] )
 
-      s.mux = Mux(int, 2)
+      s.mux = Mux(Bits32, 2)
 
       connect( s.mux.in_[MUX_SEL_0], s.src_in0.out )
       connect( s.mux.in_[MUX_SEL_1], s.src_in1.out )
@@ -126,12 +128,12 @@ def test_connect_list_const_idx_ifloordiv_sugar():
 
     def construct( s ):
 
-      s.src_in0 = TestSource( int, [4,3,2,1] )
-      s.src_in1 = TestSource( int, [8,7,6,5] )
-      s.src_sel = TestSource( int, [1,0,1,0] )
-      s.sink    = TestSink  ( int, [8,3,6,1] )
+      s.src_in0 = TestSource( Bits32, [4,3,2,1] )
+      s.src_in1 = TestSource( Bits32, [8,7,6,5] )
+      s.src_sel = TestSource( Bits1,  [1,0,1,0] )
+      s.sink    = TestSink  ( Bits32, [8,3,6,1] )
 
-      s.mux = Mux(int, 2)
+      s.mux = Mux(Bits32, 2)
 
       s.mux.in_[MUX_SEL_0] //= s.src_in0.out
       s.mux.in_[MUX_SEL_1] //= s.src_in1.out
@@ -145,18 +147,19 @@ def test_connect_list_const_idx_ifloordiv_sugar():
       return " >>> " + s.sink.line_trace()
 
   _test_model( Top )
+
 def test_connect_list_idx_call():
 
   class Top(ComponentLevel3):
 
     def construct( s ):
 
-      s.src_in0 = TestSource( int, [4,3,2,1] )
-      s.src_in1 = TestSource( int, [8,7,6,5] )
-      s.src_sel = TestSource( int, [1,0,1,0] )
-      s.sink    = TestSink  ( int, [8,3,6,1] )
+      s.src_in0 = TestSource( Bits32, [4,3,2,1] )
+      s.src_in1 = TestSource( Bits32, [8,7,6,5] )
+      s.src_sel = TestSource( Bits1,  [1,0,1,0] )
+      s.sink    = TestSink  ( Bits32, [8,3,6,1] )
 
-      s.mux = Mux(int, 2)(
+      s.mux = Mux(Bits32, 2)(
         out = s.sink.in_,
         in_ = { MUX_SEL_0: s.src_in0.out, MUX_SEL_1: s.src_in1.out },
         sel = s.src_sel.out,
@@ -194,11 +197,11 @@ def test_connect_deep():
       s.src_sel = TestSource( int, [1,0,1,0] )
       s.sink    = TestSink  ( int, [8,3,6,1] )
 
-      s.mux_wrap = MuxWrap()(
-        out = s.sink.in_,
-        in_ = { 0: s.src_in0.out, 1: s.src_in1.out },
-        sel = s.src_sel.out,
-      )
+      s.mux_wrap = m = MuxWrap()
+      m.out    //= s.sink.in_
+      m.in_[0] //= s.src_in0.out
+      m.in_[1] //= s.src_in1.out
+      m.sel    //= s.src_sel.out
 
     def done( s ):
       return s.src_in0.done() and s.sink.done()
@@ -267,22 +270,22 @@ def test_2d_array_vars_connect_impl():
       s.wire = [ [ Wire(Bits32) for _ in range(2)] for _ in range(2) ]
       connect( s.wire[0][0], s.src.out )
 
-      @s.update
+      @update
       def up_from_src():
         s.wire[0][1] = s.src.out + 1
 
       s.reg = Wire(Bits32)
       connect( s.wire[1][0], s.reg )
 
-      @s.update_ff
+      @update_ff
       def up_reg():
         s.reg <<= s.wire[0][0] + s.wire[0][1]
 
-      @s.update
+      @update
       def upA():
         s.wire[1][1] = s.reg + 1
 
-      @s.update
+      @update
       def up_to_sink():
         s.sink.in_ = s.wire[1][0] + s.wire[1][1]
 
@@ -308,13 +311,13 @@ def test_lots_of_fan_connect():
 
       s.wire0 = Wire(Bits32)
 
-      @s.update
+      @update
       def up_from_src():
         s.wire0 = s.src.out + 1
 
       s.reg = Wire(Bits32)
 
-      @s.update_ff
+      @update_ff
       def up_reg():
         s.reg <<= s.wire0
 
@@ -323,7 +326,7 @@ def test_lots_of_fan_connect():
 
       connect( s.wire1, s.reg )
 
-      @s.update
+      @update
       def upA():
         s.wire2 = s.reg + 1
 
@@ -342,12 +345,12 @@ def test_lots_of_fan_connect():
       s.wire7 = Wire(Bits32)
       s.wire8 = Wire(Bits32)
 
-      @s.update
+      @update
       def upD():
         s.wire7 = s.wire3 + s.wire6
         s.wire8 = s.wire4 + s.wire5
 
-      @s.update
+      @update
       def up_to_sink():
         s.sink.in_ = s.wire7 + s.wire8
 
@@ -372,7 +375,7 @@ def test_connect_plain():
 
       s.wire0 = Wire(int)
 
-      @s.update
+      @update
       def up_from_src():
         s.wire0 = s.src.out + 1
 
@@ -401,14 +404,14 @@ def test_2d_array_vars_connect():
       s.wire = [ [ Wire(int) for _ in range(2)] for _ in range(2) ]
       connect( s.wire[0][0], s.src.out )
 
-      @s.update
+      @update
       def up_from_src():
         s.wire[0][1] = s.src.out + 1
 
       s.reg = Wire(int)
       connect( s.wire[1][0], s.reg )
 
-      @s.update
+      @update
       def up_reg():
         s.reg = s.wire[0][0] + s.wire[0][1]
 
@@ -417,11 +420,11 @@ def test_2d_array_vars_connect():
           U(up_reg) < WR(s.wire[0][i]), # up_reg reads  s.wire[0][i]
         )
 
-      @s.update
+      @update
       def upA():
         s.wire[1][1] = s.reg + 1
 
-      @s.update
+      @update
       def up_to_sink():
         s.sink.in_ = s.wire[1][0] + s.wire[1][1]
 
@@ -444,7 +447,7 @@ def test_connect_const_same_level():
       s.a = Wire(int)
       connect( s.a, 0 )
 
-      @s.update
+      @update
       def up_printa():
         print(s.a)
 
@@ -465,11 +468,11 @@ def test_connect_const_two_writer():
       s.a = Wire(int)
       connect( s.a, 0 )
 
-      @s.update
+      @update
       def up_printa():
         print(s.a)
 
-      @s.update
+      @update
       def up_writea():
         s.a = 123
 
@@ -485,31 +488,6 @@ def test_connect_const_two_writer():
     print("{} is thrown\n{}".format( e.__class__.__name__, e ))
     return
   raise Exception("Should've thrown MultiWriterError.")
-
-def test_connect_list_idx_call():
-
-  class Top(ComponentLevel3):
-
-    def construct( s ):
-
-      s.src_in0 = TestSource( int, [4,3,2,1] )
-      s.src_sel = TestSource( int, [1,0,1,0] )
-      s.sink    = TestSink  ( int, [12,3,12,1] )
-
-      s.mux = Mux(int, 2)(
-        out = s.sink.in_,
-        in_ = { MUX_SEL_0: s.src_in0.out },
-        sel = s.src_sel.out,
-      )
-      connect( s.mux.in_[MUX_SEL_1], 12 )
-
-    def done( s ):
-      return s.src_in0.done() and s.sink.done()
-
-    def line_trace( s ):
-      return " >>> " + s.sink.line_trace()
-
-  _test_model( Top )
 
 def test_connect_list_idx_const_in_call():
 
@@ -545,7 +523,7 @@ def test_top_level_inport():
       s.b = Wire(Bits32)
       connect( s.a, s.b[0:10] )
 
-      @s.update
+      @update
       def up():
         print(s.b[10:32])
 
@@ -567,7 +545,7 @@ def test_top_level_outport():
       s.b = Wire(Bits32)
       connect( s.a, s.b[9:19] )
 
-      @s.update
+      @update
       def up():
         s.b[0:10] = 1023
 
@@ -656,7 +634,7 @@ def test_multiple_fields_are_assigned():
 
       # connect( s.in_.a, s.out1.c )
       # connect( s.in_.b[0:8], s.out2.c )
-      @s.update
+      @update
       def up_pass():
         s.out1.c = s.in_.a
         s.out2.c = s.in_.b[0:8]
@@ -930,7 +908,7 @@ def test_lambda_name_conflict():
       # the implicit name of a lambda function conflicts
       # with the explicit name of an update block
 
-      @s.update
+      @update
       def _lambda__s_out():
         s.out2 = Bits32(2)
 
@@ -993,7 +971,7 @@ def test_connect_slice_int():
       s.x = Wire( Bits32 )
 
       s.y //= s.x[0:8]
-      @s.update
+      @update
       def sx():
         s.x = 10 # Except
 

--- a/pymtl3/dsl/test/ComponentLevel4_test.py
+++ b/pymtl3/dsl/test/ComponentLevel4_test.py
@@ -8,6 +8,8 @@ Date   : Dec 25, 2017
 """
 from collections import deque
 
+from pymtl3.datatypes import Bits32
+from pymtl3.dsl.ComponentLevel1 import update
 from pymtl3.dsl.ComponentLevel4 import ComponentLevel4
 from pymtl3.dsl.Connectable import CalleePort, Wire
 from pymtl3.dsl.ConstraintTypes import M
@@ -113,26 +115,26 @@ def test_2regs():
   class Top( ComponentLevel4 ):
 
     def construct( s ):
-      s.in_ = Wire(int)
+      s.in_ = Wire(Bits32)
 
-      @s.update
+      @update
       def up_src():
         s.in_ += 1
 
       s.reg0 = SimpleReg()
 
-      @s.update
+      @update
       def up_plus_one_to_reg0():
         s.reg0.write( s.in_ + 1 )
 
       s.reg1 = SimpleReg()
 
-      @s.update
+      @update
       def up_reg0_to_reg1():
         s.reg1.write( s.reg0.read() + 1)
 
-      s.out = Wire(int)
-      @s.update
+      s.out = Wire(Bits32)
+      @update
       def up_sink():
         s.out = s.reg1.read()
 
@@ -154,19 +156,19 @@ def test_bypass_queue():
     def construct( s ):
       s.in_ = 0
 
-      @s.update
+      @update
       def up_src():
         s.in_ += 1
 
       s.q = BypassQueue( 1 )
 
-      @s.update
+      @update
       def up_plus_one_to_q():
         if s.q.enq_rdy():
           s.q.enq( s.in_ + 1 )
 
       s.out = 0
-      @s.update
+      @update
       def up_sink():
         s.out = 'X'
         #  if s.in_ % 3 == 0:
@@ -190,19 +192,19 @@ def test_pipe_queue():
     def construct( s ):
       s.in_ = 0
 
-      @s.update
+      @update
       def up_src():
         s.in_ += 1
 
       s.q = PipeQueue( 1 )
 
-      @s.update
+      @update
       def up_plus_one_to_q():
         if s.q.enq_rdy():
           s.q.enq( s.in_ + 1 )
 
       s.out = 0
-      @s.update
+      @update
       def up_sink():
         s.out = 'X'
         #  if s.in_ % 3 == 0:

--- a/pymtl3/dsl/test/ComponentLevel5_test.py
+++ b/pymtl3/dsl/test/ComponentLevel5_test.py
@@ -8,6 +8,7 @@ Date   : Jan 4, 2019
 """
 from collections import deque
 
+from pymtl3.dsl.ComponentLevel1 import update
 from pymtl3.dsl.ComponentLevel3 import connect
 from pymtl3.dsl.ComponentLevel5 import ComponentLevel5, method_port
 from pymtl3.dsl.Connectable import CalleePort, CallerPort, Interface
@@ -38,7 +39,7 @@ class SimpleTestSource( ComponentLevel5 ):
     s.req_rdy = CallerPort()
 
     s.v = 0
-    @s.update
+    @update
     def up_src():
       s.v = None
       if s.req_rdy() and s.msgs:
@@ -124,7 +125,7 @@ class TestSinkUp( ComponentLevel5 ):
 
     s.v = None
 
-    @s.update
+    @update
     def up_sink():
       s.v = None
 
@@ -211,9 +212,13 @@ def test_constraint_equal_pass_through():
 
     def construct( s ):
       s.src  = SimpleTestSource( [1,2,3,4] )
-      s.mid  = PassThrough()( req = s.src.req, req_rdy = s.src.req_rdy )
-      s.sink = TestSinkUp( [1,2,3,4] )( resp = s.mid.resp,
-                                        resp_rdy = s.mid.resp_rdy )
+      s.mid  = PassThrough()
+      s.sink = TestSinkUp( [1,2,3,4] )
+
+      s.mid.req       //= s.src.req
+      s.mid.req_rdy   //= s.src.req_rdy
+      s.sink.resp     //= s.mid.resp
+      s.sink.resp_rdy //= s.mid.resp_rdy
 
     def done( s ):
       return s.src.done() and s.sink.done()
@@ -288,7 +293,7 @@ def test_method_interface():
       s.req = SendIfcCL()
 
       s.v = 0
-      @s.update
+      @update
       def up_src():
         s.v = None
         if s.req.rdy() and s.msgs:

--- a/pymtl3/dsl/test/ComponentLevel6_test.py
+++ b/pymtl3/dsl/test/ComponentLevel6_test.py
@@ -10,6 +10,7 @@ Author : Yanghui Ou
 from collections import deque
 
 from pymtl3.datatypes import Bits16
+from pymtl3.dsl.ComponentLevel1 import update
 from pymtl3.dsl.ComponentLevel3 import connect
 from pymtl3.dsl.ComponentLevel6 import ComponentLevel6, non_blocking
 from pymtl3.dsl.Connectable import CalleeIfcCL, CallerIfcCL
@@ -31,7 +32,7 @@ class TestSrc( ComponentLevel6 ):
     s.head = None
     s.trace_len = len( str( s.msgs[0] ) )
 
-    @s.update
+    @update
     def send_msg():
       s.head = None
       if s.send.rdy() and s.msgs:
@@ -94,7 +95,7 @@ class TestHarness( ComponentLevel6 ):
 
     s.src     = TestSrc ( src_msgs  )
     s.sink    = TestSink( sink_msgs )
-    s.dut     = DUT()
+    s.dut     = DUT
 
     # Connections
     connect( s.src.send, s.dut.recv  )
@@ -204,7 +205,7 @@ class QueueIncr( ComponentLevel6 ):
     connect( s.recv, s.queue.enq )
 
     s.v = None
-    @s.update
+    @update
     def deq_incr():
       s.v = None
       if s.queue.deq.rdy() and s.send.rdy():

--- a/pymtl3/dsl/test/DataStruct_test.py
+++ b/pymtl3/dsl/test/DataStruct_test.py
@@ -7,6 +7,8 @@ Author : Shunning Jiang
 Date   : Apr 16, 2018
 """
 from pymtl3.datatypes import Bits16, Bits32, bitstruct
+from pymtl3.dsl.ComponentLevel1 import update
+from pymtl3.dsl.ComponentLevel2 import update_ff
 from pymtl3.dsl.ComponentLevel3 import ComponentLevel3, connect
 from pymtl3.dsl.Connectable import InPort, OutPort, Wire
 from pymtl3.dsl.errors import InvalidFFAssignError, MultiWriterError, NoWriterError
@@ -82,11 +84,11 @@ def test_rd_A_b_wr_A_impl():
     def construct( s ):
       s.A  = Wire( SomeMsg )
 
-      @s.update
+      @update
       def up_wr_A():
         s.A = SomeMsg( 12, 123 )
 
-      @s.update
+      @update
       def up_rd_A_b():
         assert s.A.a == 12 and s.A.b == 123
 
@@ -99,11 +101,11 @@ def test_wr_A_b_wr_A_conflict():
     def construct( s ):
       s.A  = Wire( SomeMsg )
 
-      @s.update
+      @update
       def up_wr_A_b():
         s.A.b = Bits32( 123 )
 
-      @s.update
+      @update
       def up_wr_A():
         s.A = SomeMsg( 12, 123 )
 
@@ -121,11 +123,11 @@ def test_wr_A_b_rd_A_impl():
     def construct( s ):
       s.A  = Wire( SomeMsg )
 
-      @s.update
+      @update
       def up_wr_A_b():
         s.A.b = 123
 
-      @s.update
+      @update
       def up_rd_A():
         z = s.A
 
@@ -138,15 +140,15 @@ def test_wr_A_b_rd_A_rd_A_b_can_schedule():
     def construct( s ):
       s.A  = Wire( SomeMsg )
 
-      @s.update
+      @update
       def up_wr_A_b():
         s.A.b = Bits32( 123 )
 
-      @s.update
+      @update
       def up_rd_A():
         z = s.A
 
-      @s.update
+      @update
       def up_rd_A_b():
         assert s.A.b == 123
 
@@ -159,15 +161,15 @@ def test_wr_A_rd_fields_can_schedule():
     def construct( s ):
       s.A  = Wire( SomeMsg )
 
-      @s.update
+      @update
       def up_wr_A():
         s.A = SomeMsg( 12, 123 )
 
-      @s.update
+      @update
       def up_rd_A_a():
         assert s.A.a == 12
 
-      @s.update
+      @update
       def up_rd_A_b():
         assert s.A.b == 123
 
@@ -180,15 +182,15 @@ def test_wr_A_b_rd_A_rd_A_a_cannot_schedule():
     def construct( s ):
       s.A  = Wire( SomeMsg )
 
-      @s.update
+      @update
       def up_wr_A_b():
         s.A.b = Bits32( 123 )
 
-      @s.update
+      @update
       def up_rd_A():
         z = s.A
 
-      @s.update
+      @update
       def up_rd_A_a():
         assert s.A.a == 12
 
@@ -213,11 +215,11 @@ def test_connect_rd_A_b_wr_x_conn_A_impl():
 
       connect( s.x, s.A )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = SomeMsg( 12, 123 )
 
-      @s.update
+      @update
       def up_rd_A_b():
         assert s.A.b == 123
 
@@ -234,7 +236,7 @@ def test_connect_wr_A_b_rd_x_conn_A_mark_writer():
 
       connect( s.x, s.A )
 
-      @s.update
+      @update
       def up_wr_A_b():
         s.A.b = Bits32( 123 )
 
@@ -252,11 +254,11 @@ def test_connect_wr_A_b_rd_x_conn_A_mark_writer():
 
       # s.x |= s.A
 
-      # @s.update
+      # @update
       # def up_wr_A_b():
         # s.A.b = Bits32( 123 )
 
-      # @s.update
+      # @update
       # def up_wr_x_b():
         # s.x.a = 12
 
@@ -273,11 +275,11 @@ def test_connect_wr_A_b_wr_x_conn_A_conflict():
 
       connect( s.x, s.A )
 
-      @s.update
+      @update
       def up_wr_A_b():
         s.A.b = Bits32( 123 )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = SomeMsg( 12, 123 )
 
@@ -299,11 +301,11 @@ def test_connect_wr_x_conn_A_b_rd_A_impl():
 
       connect( s.A.b, s.x )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits32( 123 )
 
-      @s.update
+      @update
       def up_rd_A():
         z = s.A
 
@@ -320,11 +322,11 @@ def test_connect_wr_x_conn_A_b_wr_A_conflict():
 
       connect( s.A.b, s.x )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits32( 123 )
 
-      @s.update
+      @update
       def up_wr_A():
         s.A = SomeMsg( 12, 123 )
 
@@ -346,11 +348,11 @@ def test_connect_rd_x_conn_A_b_wr_A_mark_writer():
 
       connect( s.A.b, s.x )
 
-      @s.update
+      @update
       def up_wr_A():
         s.A = SomeMsg( 12, 123 )
 
-      @s.update
+      @update
       def up_rd_x():
         z = s.x
 
@@ -369,11 +371,11 @@ def test_connect_wr_x_conn_A_b_wr_y_conn_A_conflict():
       connect( s.A.b, s.x )
       connect( s.A,   s.y )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits32( 123 )
 
-      @s.update
+      @update
       def up_wr_y():
         s.y = SomeMsg( 12, 123 )
 
@@ -397,11 +399,11 @@ def test_connect_wr_x_conn_A_b_rd_y_conn_A_mark_writer():
       connect( s.A.b, s.x )
       connect( s.A,   s.y )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits32( 123 )
 
-      @s.update
+      @update
       def up_rd_y():
         z = s.y
 
@@ -420,11 +422,11 @@ def test_connect_rd_x_conn_A_b_wr_y_conn_A_mark_writer():
       connect( s.A.b, s.x )
       connect( s.A,   s.y )
 
-      @s.update
+      @update
       def up_rd_x():
         z = s.x
 
-      @s.update
+      @update
       def up_wr_y():
         s.y = SomeMsg( 12, 123 )
 
@@ -444,7 +446,7 @@ def test_iterative_find_nets():
       connect( s.x.a, s.y.a ) # net2
       connect( s.y, s.z ) # net3
 
-      @s.update
+      @update
       def up_wr_s_w():
         s.w = SomeMsg( 12, 123 )
 
@@ -452,21 +454,21 @@ def test_iterative_find_nets():
 
 def test_deep_connections():
 
+  @bitstruct
   class Msg1:
-    def __init__( s, a=0, b=0 ):
-      s.a = int( a )
-      s.b = Bits32( b )
+    a: Bits16
+    b: Bits32
 
+  @bitstruct
   class Msg2:
-    def __init__( s, a=Msg1(), b=Msg1() ):
-      s.p = a
-      s.q = b
+    p: Msg1
+    q: Msg1
 
+  @bitstruct
   class Msg3:
-    def __init__( s, a=Msg1(), b=Msg2(), c=0 ):
-      s.x = a
-      s.y = b
-      s.z = int( c )
+    x: Msg1
+    y: Msg2
+    z: Bits16
 
   class Top( ComponentLevel3 ):
     def construct( s ):
@@ -476,21 +478,21 @@ def test_deep_connections():
       s.y  = Wire( Msg2 )
       s.z  = Wire( Msg3 )
 
-      s.w  = Wire( int )
+      s.w  = Wire( 16 )
 
       connect( s.A.y.p, s.x )
       connect( s.A.z,   s.w )
       connect( s.A,     s.z )
 
-      @s.update
+      @update
       def up_z():
         yy = s.z
 
-      @s.update
+      @update
       def up_rd_x():
         zz = s.x
 
-      @s.update
+      @update
       def up_wr_y():
         s.w = Msg2( 12, 123 )
 
@@ -503,9 +505,10 @@ def test_deep_connections():
 
 def test_struct_with_list_of_bits():
 
+
+  @bitstruct
   class B:
-    def __init__( s, foo=42 ):
-      s.foo = [ Bits32( foo ) for _ in range(5) ]
+    foo: [ Bits32 ] * 5
 
   class A( ComponentLevel3 ):
     def construct( s ):
@@ -537,7 +540,7 @@ def test_nested_struct_2d_array_index():
       connect( s.struct.bar[1][4].bar, s.out2 )
 
       s.wire = Wire( B )
-      @s.update_ff
+      @update_ff
       def ffs():
         s.wire.bar <<= 1
 
@@ -564,7 +567,7 @@ def test_ff_cannot_write_to_struct_field():
   class A( ComponentLevel3 ):
     def construct( s ):
       s.wire = Wire( B )
-      @s.update_ff
+      @update_ff
       def ffs():
         s.wire.bar <<= 1
 

--- a/pymtl3/dsl/test/Placeholder_test.py
+++ b/pymtl3/dsl/test/Placeholder_test.py
@@ -24,6 +24,7 @@ from pymtl3.dsl import (
     connect,
     method_port,
     non_blocking,
+    update,
 )
 from pymtl3.dsl.errors import InvalidPlaceholderError, LeftoverPlaceholderError
 
@@ -34,9 +35,9 @@ def test_placeholder_no_upblk():
 
   class Wrong( Placeholder, Component ):
     def construct( s, nbits=0 ):
-      s.in_ = InPort ( mk_bits(nbits) )
-      s.out = OutPort( mk_bits(nbits) )
-      @s.update
+      s.in_ = InPort ( nbits )
+      s.out = OutPort( nbits )
+      @update
       def up_x():
         s.out = s.in_ + 1
   try:
@@ -51,8 +52,8 @@ def test_placeholder_no_constraints():
 
   class Wrong( Placeholder, Component ):
     def construct( s, nbits=0 ):
-      s.in_ = InPort ( mk_bits(nbits) )
-      s.out = OutPort( mk_bits(nbits) )
+      s.in_ = InPort ( nbits )
+      s.out = OutPort( nbits )
       s.add_constraints( U(s.out) < WR(s.out) ) # this is obvious wrong
 
   try:
@@ -65,22 +66,22 @@ def test_placeholder_no_constraints():
 
 class Foo( Placeholder, Component ):
   def construct( s, nbits=0 ):
-    s.in_ = InPort ( mk_bits(nbits) )
-    s.out = OutPort( mk_bits(nbits) )
+    s.in_ = InPort ( nbits )
+    s.out = OutPort( nbits )
 
     # Nothing here
 
   def line_trace( s ):
     return "{}>{}".format( s.in_, s.out )
 
+@bitstruct
 class SomeMsg:
-  def __init__( s, a=0, b=0 ):
-    s.a = Bits16(a)
-    s.b = Bits32(b)
+  a: Bits16
+  b: Bits32
 
 class FooStruct( Placeholder, Component ):
   def construct( s, nbits=0 ):
-    s.in_ = InPort ( mk_bits(nbits) )
+    s.in_ = InPort ( nbits )
     s.out = OutPort( SomeMsg )
 
     # Nothing here
@@ -90,9 +91,9 @@ class FooStruct( Placeholder, Component ):
 
 class Real( Component ):
   def construct( s, nbits=0 ):
-    s.in_ = InPort ( mk_bits(nbits) )
-    s.out = OutPort( mk_bits(nbits) )
-    @s.update
+    s.in_ = InPort ( nbits )
+    s.out = OutPort( nbits )
+    @update
     def up_x2():
       s.out = s.in_ << 1
 
@@ -101,12 +102,14 @@ class Real( Component ):
 
 class Foo_wrap( Component ):
   def construct( s, nbits=0 ):
-    s.in_ = InPort ( mk_bits(nbits) )
-    s.out = OutPort( mk_bits(nbits) )
-    s.w   = Wire( mk_bits(nbits) )
+    s.in_ = InPort ( nbits )
+    s.out = OutPort( nbits )
+    s.w   = Wire( nbits )
     connect( s.w, s.out )
 
-    s.inner = Foo( 32 )( in_ = s.in_, out = s.w )
+    s.inner = Foo( 32 )
+    s.inner.in_ //= s.in_
+    s.inner.out //= s.w
 
   def line_trace( s ):
     return s.inner.line_trace()
@@ -145,7 +148,8 @@ def test_foo_field_as_writer():
       s.in_ = InPort ( Bits16 )
       s.out = OutPort( Bits32 )
 
-      s.inner = FooStruct( 16 )( in_ = s.in_ )
+      s.inner = FooStruct( 16 )
+      s.inner.in_ //= s.in_
       connect( s.inner.out.b, s.out )
 
     def line_trace( s ):
@@ -191,19 +195,21 @@ def test_cl_methodport_placeholder():
     def construct( s ):
       s.enq = CalleePort()
       s.deq = CalleePort()
-      s.foo = FooCL()( enq = s.enq, deq = s.deq )
+      s.foo = FooCL()
+      s.foo.enq //= s.enq
+      s.foo.deq //= s.deq
 
   class FooCL_top( Component ):
     def construct( s ):
       s.x = FooCL_wrap()
 
       s.counter = 0
-      @s.update
+      @update
       def up_enq():
         s.x.enq(s.counter + 1)
         s.counter += 1
 
-      @s.update
+      @update
       def up_recv():
         print(s.x.deq())
 
@@ -240,7 +246,9 @@ def test_cl_interface_placeholder():
     def construct( s ):
       s.enq = CalleeIfcCL()
       s.deq = CalleeIfcCL()
-      s.foo = FooCL()( enq = s.enq, deq = s.deq )
+      s.foo = FooCL()
+      s.foo.enq //= s.enq
+      s.foo.deq //= s.deq
 
   class FooCL_top( Component ):
     def construct( s ):
@@ -248,7 +256,7 @@ def test_cl_interface_placeholder():
 
       s.received = None
       s.counter = 0
-      @s.update
+      @update
       def up_enq():
         if s.x.enq.rdy():
           s.x.enq(s.counter + 1)
@@ -256,7 +264,7 @@ def test_cl_interface_placeholder():
         else:
           print("enq not rdy")
 
-      @s.update
+      @update
       def up_recv():
         if s.x.deq.rdy():
           s.received = s.x.deq()

--- a/pymtl3/dsl/test/PortCheck_test.py
+++ b/pymtl3/dsl/test/PortCheck_test.py
@@ -7,6 +7,7 @@ Author : Shunning Jiang
 Date   : Dec 25, 2017
 """
 from pymtl3.datatypes import Bits32
+from pymtl3.dsl.ComponentLevel1 import update
 from pymtl3.dsl.ComponentLevel3 import ComponentLevel3, connect
 from pymtl3.dsl.Connectable import InPort, OutPort, Wire
 from pymtl3.dsl.errors import InvalidConnectionError, SignalTypeError
@@ -28,7 +29,7 @@ def test_illegal_inport_write():
     def construct( s ):
       s.in_ = InPort( Bits32 )
 
-      @s.update
+      @update
       def up_B_write():
         s.in_[1:10] = 10
 
@@ -49,7 +50,7 @@ def test_illegal_inport_deep_write():
     def construct( s ):
       s.in_ = InPort( Bits32 )
 
-      @s.update
+      @update
       def up_B_print():
         print(s.in_)
 
@@ -61,7 +62,7 @@ def test_illegal_inport_deep_write():
     def construct( s ):
       s.b = BWrap()
 
-      @s.update
+      @update
       def up_write_b_in():
         s.b.b.in_[1:10] = 10
 
@@ -78,7 +79,7 @@ def test_legal_inport_write():
     def construct( s ):
       s.in_ = InPort( Bits32 )
 
-      @s.update
+      @update
       def up_B_print():
         print(s.in_)
 
@@ -86,7 +87,7 @@ def test_legal_inport_write():
     def construct( s ):
       s.b = B()
 
-      @s.update
+      @update
       def up_write_b_in():
         s.b.in_[1:10] = 10
 
@@ -98,7 +99,7 @@ def test_illegal_outport_write():
     def construct( s ):
       s.out = OutPort( Bits32 )
 
-      @s.update
+      @update
       def up_A_read():
         print(s.out)
 
@@ -106,7 +107,7 @@ def test_illegal_outport_write():
     def construct( s ):
       s.a = A()
 
-      @s.update
+      @update
       def up_write_a_out():
         s.a.out[1:10] = 10
 
@@ -123,7 +124,7 @@ def test_illegal_outport_deep_write():
     def construct( s ):
       s.out = OutPort( Bits32 )
 
-      @s.update
+      @update
       def up_A_read():
         print(s.out)
 
@@ -135,7 +136,7 @@ def test_illegal_outport_deep_write():
     def construct( s ):
       s.a = AWrap()
 
-      @s.update
+      @update
       def up_write_a_out():
         s.a.a.out[1:10] = 10
 
@@ -152,7 +153,7 @@ def test_legal_outport_write():
     def construct( s ):
       s.out = OutPort( Bits32 )
 
-      @s.update
+      @update
       def up_A_write():
         s.out[0:2] = 2
 
@@ -160,7 +161,7 @@ def test_legal_outport_write():
     def construct( s ):
       s.a = A()
 
-      @s.update
+      @update
       def up_read_a_out():
         print(s.a.out)
 
@@ -176,7 +177,7 @@ def test_illegal_wire_write():
     def construct( s ):
       s.a = A()
 
-      @s.update
+      @update
       def up_write_a_out():
         s.a.wire[1:10] = 10
 
@@ -192,7 +193,7 @@ def test_illegal_wire_read():
   class A( ComponentLevel3 ):
     def construct( s ):
       s.wire = Wire( Bits32 )
-      @s.update
+      @update
       def up_write_wire():
         s.wire[1:10] = 10
 
@@ -200,7 +201,7 @@ def test_illegal_wire_read():
     def construct( s ):
       s.a = A()
 
-      @s.update
+      @update
       def up_read_a_out():
         print(s.a.wire[1:10])
 
@@ -215,35 +216,37 @@ def test_legal_port_connect():
 
   class A( ComponentLevel3 ):
     def construct( s ):
-      s.out = OutPort(int)
+      s.out = OutPort(32)
 
-      @s.update
+      @update
       def up_A_write():
         s.out = 123
 
   class B( ComponentLevel3 ):
     def construct( s ):
-      s.in_ = InPort(int)
+      s.in_ = InPort(32)
 
-      @s.update
+      @update
       def up_B_read():
         print(s.in_)
 
   class OutWrap(ComponentLevel3):
     def construct( s ):
-      s.out = OutPort(int)
-      s.a = A()( out = s.out )
+      s.out = OutPort(32)
+      s.a = A()
+      s.a.out //= s.out
 
-      @s.update
+      @update
       def up_out_read():
         print(s.out)
 
   class InWrap(ComponentLevel3):
     def construct( s ):
-      s.in_ = InPort(int)
-      s.b = B()( in_ = s.in_ )
+      s.in_ = InPort(32)
+      s.b = B()
+      s.b.in_ //= s.in_
 
-      @s.update
+      @update
       def up_in_read():
         print(s.in_)
 
@@ -259,17 +262,18 @@ def test_illegal_same_host():
 
   class A( ComponentLevel3 ):
     def construct( s ):
-      s.out = OutPort(int)
-      @s.update
+      s.out = OutPort(32)
+      @update
       def up_A_write():
         s.out = 123
 
   class AWrap(ComponentLevel3):
     def construct( s ):
-      s.out = OutPort(int) # Wire is the same
-      s.a = A()( out = s.out )
+      s.out = OutPort(32) # Wire is the same
+      s.a = A()
+      s.a.out //= s.out
 
-      s.in_ = InPort(int)
+      s.in_ = InPort(32)
 
       connect( s.out, s.in_ )
 
@@ -288,15 +292,16 @@ def test_illegal_rdhost_is_wrhost_parent():
 
   class A( ComponentLevel3 ):
     def construct( s ):
-      s.out = OutPort(int)
-      @s.update
+      s.out = OutPort(32)
+      @update
       def up_A_write():
         s.out = 123
 
   class AWrap(ComponentLevel3):
     def construct( s ):
-      s.out = InPort(int) # Should be OutPort
-      s.a   = A()( out = s.out )
+      s.out = InPort(32) # Should be OutPort
+      s.a   = A()
+      s.a.out //= s.out
 
   class Top( ComponentLevel3 ):
     def construct( s ):
@@ -313,22 +318,23 @@ def test_illegal_wrhost_is_rdhost_parent():
 
   class A( ComponentLevel3 ):
     def construct( s ):
-      s.out = OutPort(int)
-      @s.update
+      s.out = OutPort(32)
+      @update
       def up_A_write():
         s.out = 123
 
   class B( ComponentLevel3 ):
     def construct( s ):
-      s.in_ = OutPort(int) # Should be InPort
-      @s.update
+      s.in_ = OutPort(32) # Should be InPort
+      @update
       def up_B_read():
         print(s.in_)
 
   class BWrap(ComponentLevel3):
     def construct( s ):
-      s.in_ = InPort(int)
-      s.b   = B()( in_ = s.in_ )
+      s.in_ = InPort(32)
+      s.b   = B()
+      s.b.in_ //= s.in_
 
   class Top( ComponentLevel3 ):
     def construct( s ):
@@ -347,22 +353,23 @@ def test_illegal_hosts_same_parent():
 
   class A( ComponentLevel3 ):
     def construct( s ):
-      s.out = OutPort(int)
-      @s.update
+      s.out = OutPort(32)
+      @update
       def up_A_write():
         s.out = 123
 
   class B( ComponentLevel3 ):
     def construct( s ):
-      s.in_ = InPort(int)
-      @s.update
+      s.in_ = InPort(32)
+      @update
       def up_B_read():
         print(s.in_)
 
   class BWrap(ComponentLevel3):
     def construct( s ):
-      s.in_ = OutPort(int) # Should be InPort
-      s.b   = B()( in_ = s.in_ )
+      s.in_ = OutPort(32) # Should be InPort
+      s.b   = B()
+      s.b.in_ //= s.in_
 
   class Top( ComponentLevel3 ):
     def construct( s ):
@@ -381,19 +388,20 @@ def test_illegal_hosts_too_far():
 
   class A( ComponentLevel3 ):
     def construct( s ):
-      s.out = OutPort(int)
-      @s.update
+      s.out = OutPort(32)
+      @update
       def up_A_write():
         s.out = 123
 
   class AWrap( ComponentLevel3 ):
     def construct( s ):
-      s.out = OutPort(int)
-      s.A = A()( out = s.out )
+      s.out = OutPort(32)
+      s.A = A()
+      s.A.out //= s.out
 
   class Top( ComponentLevel3 ):
     def construct( s ):
-      s.wire = Wire(int)
+      s.wire = Wire(32)
       s.A = AWrap()
 
       connect( s.wire, s.A.A.out )

--- a/pymtl3/dsl/test/Slicing_test.py
+++ b/pymtl3/dsl/test/Slicing_test.py
@@ -7,6 +7,7 @@ Author : Shunning Jiang
 Date   : Aug 23, 2018
 """
 from pymtl3.datatypes import Bits2, Bits4, Bits14, Bits16, Bits24, Bits32
+from pymtl3.dsl.ComponentLevel1 import update
 from pymtl3.dsl.ComponentLevel3 import ComponentLevel3, connect
 from pymtl3.dsl.Connectable import Wire
 from pymtl3.dsl.errors import MultiWriterError, NoWriterError
@@ -29,15 +30,15 @@ def test_write_two_disjoint_slices():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_0_16():
         s.A[0:16] = Bits16( 0xff )
 
-      @s.update
+      @update
       def up_wr_16_30():
         s.A[16:30] = Bits14( 0xff )
 
-      @s.update
+      @update
       def up_rd_12_30():
         assert s.A[12:30] == 0xff0
 
@@ -50,15 +51,15 @@ def test_write_two_disjoint_slices_no_reader():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_0_16():
         s.A[0:16] = Bits16( 0xff )
 
-      @s.update
+      @update
       def up_wr_16_30():
         s.A[16:30] = Bits14( 0xff )
 
-      @s.update
+      @update
       def up_rd_17_30():
         assert s.A[16:30] == 0xff
 
@@ -80,15 +81,15 @@ def test_write_two_overlapping_slices():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_0_24():
         s.A[0:24] = Bits24( 0xff )
 
-      @s.update
+      @update
       def up_wr_8_32():
         s.A[8:32] = Bits24( 0xff )
 
-      @s.update
+      @update
       def up_rd_A():
         x = s.A
 
@@ -106,19 +107,19 @@ def test_write_two_slices_and_bit():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_0_16():
         s.A[0:16] = Bits16( 0xff )
 
-      @s.update
+      @update
       def up_wr_16_30():
         s.A[16:30] = Bits14( 0xff )
 
-      @s.update
+      @update
       def up_wr_30_31():
         s.A[30] = Bits1( 1 )
 
-      @s.update
+      @update
       def up_rd_A():
         print(s.A[0:17])
 
@@ -141,15 +142,15 @@ def test_write_slices_and_bit_overlapped():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_0_16():
         s.A[0:16] = Bits16( 0xff )
 
-      @s.update
+      @update
       def up_wr_15():
         s.A[15] = Bits1( 1 )
 
-      @s.update
+      @update
       def up_rd_A():
         print(s.A[0:17])
 
@@ -167,15 +168,15 @@ def test_multiple_readers():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_8_24():
         s.A[8:24] = Bits16( 0x1234 )
 
-      @s.update
+      @update
       def up_rd_0_12():
         assert s.A[0:12] == 0x400
 
-      @s.update
+      @update
       def up_rd_bunch():
         assert s.A[23] == 0
         assert s.A[22] == 0
@@ -251,11 +252,11 @@ def test_rd_As_wr_A_impl():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_A():
         s.A = Bits32( 123 )
 
-      @s.update
+      @update
       def up_rd_As():
         assert s.A[0:16] == 123
 
@@ -268,11 +269,11 @@ def test_rd_As_wr_At_impl_intersect():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_At():
         s.A[8:24] = Bits16( 0xff )
 
-      @s.update
+      @update
       def up_rd_As():
         assert s.A[0:16] == 0xff00
 
@@ -285,11 +286,11 @@ def test_rd_As_wr_At_impl_disjoint():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_At():
         s.A[16:32] = Bits16( 0xff )
 
-      @s.update
+      @update
       def up_rd_As():
         assert s.A[0:16] == 0
 
@@ -306,11 +307,11 @@ def test_wr_As_wr_A_conflict():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[1:3] = Bits2( 2 )
 
-      @s.update
+      @update
       def up_wr_A():
         s.A = Bits32( 123 )
 
@@ -328,15 +329,15 @@ def test_wr_As_wr_At_intersect():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[1:3] = Bits2( 2 )
 
-      @s.update
+      @update
       def up_wr_At():
         s.A[2:4] = Bits2( 2 )
 
-      @s.update
+      @update
       def up_rd_A():
         z = s.A
 
@@ -354,15 +355,15 @@ def test_wr_As_wr_At_disjoint():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[1:3] = Bits2( 2 )
 
-      @s.update
+      @update
       def up_wr_At():
         s.A[5:7] = Bits2( 2 )
 
-      @s.update
+      @update
       def up_rd_A():
         z = s.A
 
@@ -375,11 +376,11 @@ def test_wr_As_rd_A_impl():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[1:3] = Bits2( 2 )
 
-      @s.update
+      @update
       def up_rd_A():
         z = s.A
 
@@ -392,15 +393,15 @@ def test_wr_As_rd_A_rd_At_can_schedule():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[1:3] = Bits2( 2 )
 
-      @s.update
+      @update
       def up_rd_A():
         z = s.A
 
-      @s.update
+      @update
       def up_rd_As():
         assert s.A[2:4] == 1
 
@@ -413,15 +414,15 @@ def test_wr_As_rd_A_rd_At_cannot_schedule():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[1:3] = Bits2( 2 )
 
-      @s.update
+      @update
       def up_rd_A():
         z = s.A
 
-      @s.update
+      @update
       def up_rd_At():
         assert s.A[3:5] == 0
 
@@ -442,15 +443,15 @@ def test_wr_A_rd_slices_can_schedule():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_A():
         s.A = Bits32( 0x12345678 )
 
-      @s.update
+      @update
       def up_rd_As():
         assert s.A[0:16] == 0x5678
 
-      @s.update
+      @update
       def up_rd_At():
         assert s.A[8:24] == 0x3456
 
@@ -463,15 +464,15 @@ def test_wr_As_rd_A_rd_At_bit_cannot_schedule():
     def construct( s ):
       s.A  = Wire( Bits32 )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[0:16] = Bits16( 0x1234 )
 
-      @s.update
+      @update
       def up_rd_A():
         z = s.A
 
-      @s.update
+      @update
       def up_rd_At():
         assert s.A[16] == 0
 
@@ -496,11 +497,11 @@ def test_connect_rd_As_wr_x_conn_A_impl():
 
       connect( s.A, s.x )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits32( 123 )
 
-      @s.update
+      @update
       def up_rd_As():
         assert s.A[0:16] == 123
 
@@ -517,11 +518,11 @@ def test_connect_rd_As_wr_x_conn_At_impl():
 
       connect( s.A[0:24], s.x )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits24( 0x123456 )
 
-      @s.update
+      @update
       def up_rd_As():
         assert s.A[0:16] == 0x3456
 
@@ -538,11 +539,11 @@ def test_connect_rd_As_wr_x_conn_At_disjoint():
 
       connect( s.A[0:24], s.x )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits24( 0x123456 )
 
-      @s.update
+      @update
       def up_rd_As():
         assert s.A[24:32] == 0
 
@@ -567,7 +568,7 @@ def test_connect_wr_As_rd_x_conn_A_mark_writer():
 
       connect( s.x, s.A )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[0:24] = Bits24( 0x123456 )
 
@@ -584,11 +585,11 @@ def test_connect_wr_As_wr_x_conn_A_conflict():
 
       connect( s.x, s.A )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[0:24] = Bits24( 0x123456 )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits32( 0x87654321 )
 
@@ -610,7 +611,7 @@ def test_connect_wr_As_rd_x_conn_At_mark_writer():
 
       connect( s.x, s.A[8:32] )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[0:24] = Bits24( 0x123456 )
 
@@ -627,7 +628,7 @@ def test_connect_wr_As_rd_x_conn_At_no_driver():
 
       connect( s.x, s.A[8:32] )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[0:4] = Bits4( 0xf )
 
@@ -649,11 +650,11 @@ def test_connect_wr_As_wr_x_conn_At_conflict():
 
       connect( s.x, s.A[8:32] )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[0:24] = Bits24( 0x123456 )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits24( 0x654321 )
 
@@ -675,15 +676,15 @@ def test_connect_wr_As_wr_x_conn_At_disjoint():
 
       connect( s.x, s.A[8:32] )
 
-      @s.update
+      @update
       def up_wr_As():
         s.A[0:4] = Bits4( 0xf )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits24( 0x654321 )
 
-      @s.update
+      @update
       def up_rd_A():
         assert s.A == 0x6543210f
 
@@ -700,11 +701,11 @@ def test_connect_wr_x_conn_As_rd_A_impl():
 
       connect( s.A[8:32], s.x )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits24( 0x123456 )
 
-      @s.update
+      @update
       def up_rd_A():
         assert s.A == 0x12345600
 
@@ -723,11 +724,11 @@ def test_connect_wr_x_conn_As_wr_A_conflict():
       connect( s.A[8:32], s.x )
       connect( s.x, s.y )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits24( 0x123456 )
 
-      @s.update
+      @update
       def up_wr_A():
         s.A = Bits32( 0x12345678 )
 
@@ -749,11 +750,11 @@ def test_connect_rd_x_conn_As_wr_A_mark_writer():
 
       connect( s.A[8:32], s.x )
 
-      @s.update
+      @update
       def up_wr_A():
         s.A = Bits32( 0x12345678 )
 
-      @s.update
+      @update
       def up_rd_x():
         assert s.x == 0x123456
 
@@ -772,11 +773,11 @@ def test_connect_wr_x_conn_As_wr_y_conn_A_conflict():
       connect( s.A[8:32], s.x )
       connect( s.A      , s.y )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits24( 0x123456 )
 
-      @s.update
+      @update
       def up_wr_y():
         s.y = Bits32( 0x12345678 )
 
@@ -800,11 +801,11 @@ def test_connect_wr_x_conn_As_wr_y_conn_At_conflict():
       connect( s.A[8:32], s.x )
       connect( s.A[0:16], s.y )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits24( 0x123456 )
 
-      @s.update
+      @update
       def up_wr_y():
         s.y = Bits16( 0x1234 )
 
@@ -828,15 +829,15 @@ def test_connect_wr_x_conn_As_wr_y_conn_At_disjoint():
       connect( s.A[8:32], s.x )
       connect( s.A[0:4],  s.y )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits24( 0x123456 )
 
-      @s.update
+      @update
       def up_wr_y():
         s.y = Bits4( 0xf )
 
-      @s.update
+      @update
       def up_rd_A():
         assert s.A == 0x1234560f
 
@@ -855,11 +856,11 @@ def test_connect_wr_x_conn_As_rd_y_conn_A_mark_writer():
       connect( s.A[8:32], s.x )
       connect( s.A,       s.y )
 
-      @s.update
+      @update
       def up_wr_x():
         s.x = Bits24( 0x123456 )
 
-      @s.update
+      @update
       def up_rd_y():
         assert s.y == 0x12345600
 
@@ -878,11 +879,11 @@ def test_connect_rd_x_conn_As_wr_y_conn_A_mark_writer():
       connect( s.A[8:32], s.x )
       connect( s.A,       s.y )
 
-      @s.update
+      @update
       def up_rd_x():
         assert s.x == 0x123456
 
-      @s.update
+      @update
       def up_wr_y():
         s.y = Bits32( 0x12345678 )
 
@@ -901,11 +902,11 @@ def test_connect_rd_x_conn_As_wr_y_conn_At_mark_writer():
       connect( s.A[8:32], s.x )
       connect( s.A[0:16], s.y )
 
-      @s.update
+      @update
       def up_rd_x():
         assert s.x == 0x12
 
-      @s.update
+      @update
       def up_wr_y():
         s.y = Bits16( 0x1234 )
 
@@ -924,11 +925,11 @@ def test_connect_rd_x_conn_As_wr_y_conn_no_driver():
       connect( s.A[8:32], s.x )
       connect( s.A[0:4 ], s.y )
 
-      @s.update
+      @update
       def up_rd_x():
         assert s.x == 0
 
-      @s.update
+      @update
       def up_wr_y():
         s.y = Bits4( 0xf )
 
@@ -953,7 +954,7 @@ def test_iterative_find_nets():
       connect( s.x[16:32], s.y[0:16] ) # net2
       connect( s.y[8:24],  s.z[0:16] ) # net3
 
-      @s.update
+      @update
       def up_wr_s_w():
         s.w = Bits32( 0x12345678 )
 
@@ -975,7 +976,7 @@ def test_multiple_sibling_slices():
 
       connect( s.A[16:32], s.z ) # net3
 
-      @s.update
+      @update
       def up_wr_s_w():
         s.x = Bits16( 0x1234 )
 
@@ -994,7 +995,7 @@ def test_multiple_write_same_slice():
       s.wire = Wire( Bits32 )
       connect( s.out, s.wire[0:32] )
 
-      @s.update
+      @update
       def comb_upblk():
         s.wire[0:16]  = 0
         s.wire[16:32] = 1
@@ -1013,7 +1014,7 @@ def test_multiple_write_same_slice_with_overlap():
       s.wire2 = Wire( Bits24 )
       connect( s.wire2[0:24], s.wire[8:32] )
 
-      @s.update
+      @update
       def comb_upblk():
         s.wire[0:16]  = 0
         s.wire2[0:24] = 1

--- a/pymtl3/dsl/test/set_param_test.py
+++ b/pymtl3/dsl/test/set_param_test.py
@@ -8,6 +8,7 @@ Date   : May 28, 2019
 """
 from pymtl3.datatypes.bits_import import Bits4, Bits8
 from pymtl3.dsl.Component import Component
+from pymtl3.dsl.ComponentLevel1 import update
 from pymtl3.dsl.ComponentLevel3 import connect
 from pymtl3.dsl.Connectable import InPort, OutPort
 from pymtl3.dsl.NamedObject import NamedObject
@@ -141,7 +142,7 @@ def test_component():
 
       s.incr_value = DataType( incr_value )
 
-      @s.update
+      @update
       def up_incr():
         s.out = s.in_ + s.incr_value
 

--- a/pymtl3/passes/autotick/test/OpenLoopCLPass_test.py
+++ b/pymtl3/passes/autotick/test/OpenLoopCLPass_test.py
@@ -27,15 +27,15 @@ def test_top_level_method_tracing():
 
       s.value = Wire(Bits32)
 
-      @s.update_ff
+      @update_ff
       def up_incr():
         s.count <<= s.count + 1
 
-      @s.update
+      @update
       def up_amp():
         s.amp = s.count * 100
 
-      @s.update
+      @update
       def up_compose_in():
         if s.element:
           s.value = s.amp + s.element
@@ -101,15 +101,15 @@ class TestModuleNonBlockingIfc(Component):
 
     s.value = Wire(Bits32)
 
-    @s.update_ff
+    @update_ff
     def up_incr():
       s.count <<= s.count + 1
 
-    @s.update
+    @update
     def up_amp():
       s.amp = s.count * 100
 
-    @s.update
+    @update
     def up_compose_in():
       if s.element:
         s.value = s.amp + s.element
@@ -211,7 +211,10 @@ def test_top_level_non_blocking_ifc_in_deep_net():
     def construct( s ):
       s.push = CalleeIfcCL()
       s.pull = CalleeIfcCL()
-      s.inner = Top_less_less_inner()( push = s.push, pull = s.pull )
+      s.inner = Top_less_less_inner()
+      s.inner.push //= s.push
+      s.inner.pull //= s.pull
+
     def line_trace( s ):
       return s.inner.line_trace()
 
@@ -222,7 +225,9 @@ def test_top_level_non_blocking_ifc_in_deep_net():
     def construct( s ):
       s.push = CalleeIfcCL()
       s.pull = CalleeIfcCL()
-      s.inner = Top_less_inner()( push = s.push, pull = s.pull )
+      s.inner = Top_less_inner()
+      s.inner.push //= s.push
+      s.inner.pull //= s.pull
     def line_trace( s ):
       return s.inner.line_trace()
 
@@ -233,7 +238,9 @@ def test_top_level_non_blocking_ifc_in_deep_net():
     def construct( s ):
       s.push = CalleeIfcCL()
       s.pull = CalleeIfcCL()
-      s.inner = TestModuleNonBlockingIfc()( push = s.push, pull = s.pull )
+      s.inner = TestModuleNonBlockingIfc()
+      s.inner.push //= s.push
+      s.inner.pull //= s.pull
 
     def line_trace( s ):
       return s.inner.line_trace()
@@ -264,8 +271,11 @@ def test_pass_through_equal_m_constraint():
     def construct( s ):
       s.push = CalleeIfcCL()
       s.pull = CalleeIfcCL()
-      s.pass1 = PassThroughPlus100()( push = s.push )
-      s.inner = TestModuleNonBlockingIfc()( push = s.pass1.real_push, pull = s.pull )
+      s.pass1 = PassThroughPlus100()
+      s.pass1.push //= s.push
+      s.inner = TestModuleNonBlockingIfc()
+      s.inner.push //= s.pass1.real_push
+      s.inner.pull //= s.pull
 
     def line_trace( s ):
       return s.inner.line_trace()
@@ -286,13 +296,11 @@ def test_deep_pass_through_equal_m_constraint():
       s.through = [ PassThroughPlus100() for _ in range(10) ]
       for i in range(10):
         connect( s.through[i].push, s.push if i == 0 else \
-                                      s.through[i-1].real_push,
-        )
+                                      s.through[i-1].real_push )
 
-      s.inner = TestModuleNonBlockingIfc()(
-        push = s.through[-1].real_push,
-        pull = s.pull,
-      )
+      s.inner = TestModuleNonBlockingIfc()
+      s.inner.push //= s.through[-1].real_push
+      s.inner.pull //= s.pull
 
     def line_trace( s ):
       return "push's line trace:" + str(s.push)

--- a/pymtl3/passes/backends/sverilog/import_/verilator_wrapper.py.template
+++ b/pymtl3/passes/backends/sverilog/import_/verilator_wrapper.py.template
@@ -12,7 +12,7 @@ import os
 from cffi  import FFI
 
 from pymtl3.datatypes import *
-from pymtl3.dsl import Component, connect, InPort, OutPort, Wire, M, U, RD, WR
+from pymtl3.dsl import Component, connect, InPort, OutPort, Wire, update, update_ff
 
 def full_vector( wire, signal ):
 
@@ -130,7 +130,7 @@ class {component_name}( Component ):
     # declare the port interface
 {port_defs}
 
-    @s.update
+    @update
     def comb_upblk():
       # Set inputs
 {set_comb_input}
@@ -141,7 +141,7 @@ class {component_name}( Component ):
 {set_comb_output}
 
     if {has_clk}:
-      @s.update_ff
+      @update_ff
       def seq_upblk():
         # Advance the clock
         _ffi_m.{clk}[0] = 0

--- a/pymtl3/passes/backends/sverilog/test/TranslationImport_closed_loop_component_input_test.py
+++ b/pymtl3/passes/backends/sverilog/test/TranslationImport_closed_loop_component_input_test.py
@@ -10,7 +10,7 @@ from random import randint, seed
 import pytest
 
 from pymtl3.datatypes import Bits1, Bits16, Bits32, clog2, mk_bits
-from pymtl3.dsl import Component, InPort, Interface, OutPort
+from pymtl3.dsl import Component, InPort, Interface, OutPort, update, update_ff
 from pymtl3.passes.rtlir.util.test_utility import do_test
 
 from ..util.test_utility import closed_loop_component_input_test
@@ -32,7 +32,7 @@ def test_adder( do_test, Type ):
       s.in_1 = InPort( Type )
       s.in_2 = InPort( Type )
       s.out = OutPort( Type )
-      @s.update
+      @update
       def add_upblk():
         s.out = s.in_1 + s.in_2
     def line_trace( s ): return "sum = " + str( s.out )
@@ -55,7 +55,7 @@ def test_mux( do_test, Type, n_ports ):
       s.in_ = [ InPort( Type ) for _ in range(n_ports) ]
       s.sel = InPort( mk_bits( clog2(n_ports) ) )
       s.out = OutPort( Type )
-      @s.update
+      @update
       def add_upblk():
         s.out = s.in_[ s.sel ]
     def line_trace( s ): return "out = " + str( s.out )

--- a/pymtl3/passes/backends/sverilog/test/TranslationImport_closed_loop_component_test.py
+++ b/pymtl3/passes/backends/sverilog/test/TranslationImport_closed_loop_component_test.py
@@ -10,7 +10,7 @@ import pytest
 from hypothesis import HealthCheck, given, reproduce_failure, settings
 
 from pymtl3.datatypes import Bits1, Bits16, Bits32, bitstruct, clog2, mk_bits
-from pymtl3.dsl import Component, InPort, Interface, OutPort, Wire, connect
+from pymtl3.dsl import Component, InPort, Interface, OutPort, Wire, connect, update, update_ff
 from pymtl3.passes.rtlir.util.test_utility import do_test
 
 from ..util.test_utility import closed_loop_component_test
@@ -34,7 +34,7 @@ def test_adder( do_test, Type, data ):
       s.in_1 = InPort( Type )
       s.in_2 = InPort( Type )
       s.out = OutPort( Type )
-      @s.update
+      @update
       def add_upblk():
         s.out = s.in_1 + s.in_2
     def line_trace( s ): return "sum = " + str( s.out )
@@ -53,7 +53,7 @@ def test_mux( do_test, Type, n_ports, data ):
       s.in_ = [ InPort( Type ) for _ in range(n_ports) ]
       s.sel = InPort( mk_bits( clog2(n_ports) ) )
       s.out = OutPort( Type )
-      @s.update
+      @update
       def add_upblk():
         s.out = s.in_[ s.sel ]
     def line_trace( s ): return "out = " + str( s.out )
@@ -95,7 +95,7 @@ def test_nested_struct( do_test, data ):
       s.out_bar = OutPort( Bits32 )
       s.out_sum = OutPort( Bits16 )
       s.sum = [ Wire( Bits16 ) for _ in range(3) ]
-      @s.update
+      @update
       def upblk():
         for i in range(3):
           s.sum[i] = s.in_.packed_array[i][0] + s.in_.packed_array[i][1]
@@ -130,7 +130,7 @@ def test_subcomp( do_test, data ):
       s.out_bar = OutPort( Bits32 )
       s.out_sum = OutPort( Bits16 )
       s.sum = [ Wire( Bits16 ) for _ in range(3) ]
-      @s.update
+      @update
       def upblk():
         for i in range(3):
           s.sum[i] = s.in_.packed_array[i][0] + s.in_.packed_array[i][1]
@@ -151,7 +151,7 @@ def test_index_static( do_test, Type, data ):
     def construct( s, Type ):
       s.in_ = [InPort ( Type ) for _ in range(2)]
       s.out = [OutPort( Type ) for _ in range(2)]
-      @s.update
+      @update
       def index_upblk():
         if s.in_[0] > s.in_[1]:
           s.out[0] = Type(1)

--- a/pymtl3/passes/backends/sverilog/test/TranslationImport_closed_loop_component_test.py
+++ b/pymtl3/passes/backends/sverilog/test/TranslationImport_closed_loop_component_test.py
@@ -10,7 +10,16 @@ import pytest
 from hypothesis import HealthCheck, given, reproduce_failure, settings
 
 from pymtl3.datatypes import Bits1, Bits16, Bits32, bitstruct, clog2, mk_bits
-from pymtl3.dsl import Component, InPort, Interface, OutPort, Wire, connect, update, update_ff
+from pymtl3.dsl import (
+    Component,
+    InPort,
+    Interface,
+    OutPort,
+    Wire,
+    connect,
+    update,
+    update_ff,
+)
 from pymtl3.passes.rtlir.util.test_utility import do_test
 
 from ..util.test_utility import closed_loop_component_test

--- a/pymtl3/passes/backends/sverilog/test/TranslationImport_dynlib_close_test.py
+++ b/pymtl3/passes/backends/sverilog/test/TranslationImport_dynlib_close_test.py
@@ -36,7 +36,7 @@ def test_dynlib_close():
       def construct( s ):
         s.in_ = InPort( Bits32 )
         s.out = OutPort( Bits32 )
-        @s.update
+        @update
         def upblk():
           s.out = s.in_
   class Seq:
@@ -44,7 +44,7 @@ def test_dynlib_close():
       def construct( s ):
         s.in_ = InPort( Bits32 )
         s.out = OutPort( Bits32 )
-        @s.update_ff
+        @update_ff
         def upblk():
           s.out <<= s.in_
 

--- a/pymtl3/passes/mamba/test/HeuTopoUnrollSim_test.py
+++ b/pymtl3/passes/mamba/test/HeuTopoUnrollSim_test.py
@@ -11,7 +11,7 @@ def test_very_deep_dag():
       s.in_ = InPort(Bits32)
       s.out = OutPort(Bits32)
 
-      @s.update
+      @update
       def up():
         s.out = s.in_ + 1
 
@@ -28,7 +28,7 @@ def test_very_deep_dag():
         s.inners[i].out //= s.inners[i+1].in_
 
       s.out = OutPort(Bits32)
-      @s.update_ff
+      @update_ff
       def ff():
         if s.reset:
           s.out <<= 0

--- a/pymtl3/passes/mamba/test/TraceBreakingSim_test.py
+++ b/pymtl3/passes/mamba/test/TraceBreakingSim_test.py
@@ -11,7 +11,7 @@ def test_very_deep_dag():
       s.in_ = InPort(Bits32)
       s.out = OutPort(Bits32)
 
-      @s.update
+      @update
       def up():
         s.out = s.in_ + 1
 
@@ -28,7 +28,7 @@ def test_very_deep_dag():
         s.inners[i].out //= s.inners[i+1].in_
 
       s.out = OutPort(Bits32)
-      @s.update_ff
+      @update_ff
       def ff():
         if s.reset:
           s.out <<= 0

--- a/pymtl3/passes/mamba/test/UnrollSim_test.py
+++ b/pymtl3/passes/mamba/test/UnrollSim_test.py
@@ -11,7 +11,7 @@ def test_very_deep_dag():
       s.in_ = InPort(Bits32)
       s.out = OutPort(Bits32)
 
-      @s.update
+      @update
       def up():
         s.out = s.in_ + 1
 
@@ -28,7 +28,7 @@ def test_very_deep_dag():
         s.inners[i].out //= s.inners[i+1].in_
 
       s.out = OutPort(Bits32)
-      @s.update_ff
+      @update_ff
       def ff():
         if s.reset:
           s.out <<= 0

--- a/pymtl3/passes/sim/test/DynamicSchedulePass_test.py
+++ b/pymtl3/passes/sim/test/DynamicSchedulePass_test.py
@@ -36,47 +36,47 @@ def test_false_cyclic_dependency():
   class Top(Component):
 
     def construct( s ):
-      s.a = Wire(int)
-      s.b = Wire(int)
-      s.c = Wire(int)
-      s.d = Wire(int)
-      s.e = Wire(int)
-      s.f = Wire(int)
-      s.g = Wire(int)
-      s.h = Wire(int)
-      s.i = Wire(int)
-      s.j = Wire(int)
+      s.a = Wire(32)
+      s.b = Wire(32)
+      s.c = Wire(32)
+      s.d = Wire(32)
+      s.e = Wire(32)
+      s.f = Wire(32)
+      s.g = Wire(32)
+      s.h = Wire(32)
+      s.i = Wire(32)
+      s.j = Wire(32)
 
-      @s.update
+      @update
       def up1():
         s.a = 10 + s.i
         s.b = s.d + 1
 
-      @s.update
+      @update
       def up2():
         s.c = s.a + 1
         s.e = s.d + 1
 
-      @s.update
+      @update
       def up3():
         s.d = s.c + 1
         print("up3 prints out d =", s.d)
 
-      @s.update
+      @update
       def up4():
         s.f = s.d + 1
 
-      @s.update
+      @update
       def up5():
         s.g = s.c + 1
         s.h = s.j + 1
         print("up5 prints out h =", s.h)
 
-      @s.update
+      @update
       def up6():
         s.i = s.i + 1
 
-      @s.update
+      @update
       def up7():
         s.j = s.g + 1
 
@@ -94,20 +94,20 @@ def test_combinational_loop():
   class Top(Component):
 
     def construct( s ):
-      s.a = Wire(int)
-      s.b = Wire(int)
-      s.c = Wire(int)
-      s.d = Wire(int)
+      s.a = Wire(32)
+      s.b = Wire(32)
+      s.c = Wire(32)
+      s.d = Wire(32)
 
-      @s.update
+      @update
       def up1():
         s.b = s.d + 1
 
-      @s.update
+      @update
       def up2():
         s.c = s.b + 1
 
-      @s.update
+      @update
       def up3():
         s.d = s.c + 1
         print("up3 prints out d =", s.d)
@@ -130,10 +130,10 @@ def test_very_deep_dag():
 
   class Inner(Component):
     def construct( s ):
-      s.in_ = InPort(int)
-      s.out = OutPort(int)
+      s.in_ = InPort(32)
+      s.out = OutPort(32)
 
-      @s.update
+      @update
       def up():
         s.out = s.in_ + 1
 
@@ -164,11 +164,11 @@ def test_sequential_break_loop():
       s.b = Wire( Bits32 )
       s.c = Wire( Bits32 )
 
-      @s.update
+      @update
       def up1():
         s.b = s.c + 1
 
-      @s.update_ff
+      @update_ff
       def up2():
         if s.reset:
           s.c <<= 0
@@ -189,12 +189,11 @@ def test_connect_slice_int():
 
   class Top( Component ):
     def construct( s ):
-      from pymtl3.datatypes import Bits8, Bits32
       s.y = OutPort( Bits8 )
       s.x = Wire( Bits32 )
 
       s.y //= s.x[0:8]
-      @s.update
+      @update
       def sx():
         s.x = 10 # Except
 

--- a/pymtl3/passes/sim/test/SimpleSchedulePass_test.py
+++ b/pymtl3/passes/sim/test/SimpleSchedulePass_test.py
@@ -51,36 +51,36 @@ def _test_false_cyclic_dependency():
       s.i = Wire(int)
       s.j = Wire(int)
 
-      @s.update
+      @update
       def up1():
         s.a = 10 + s.i
         s.b = s.d + 1
 
-      @s.update
+      @update
       def up2():
         s.c = s.a + 1
         s.e = s.d + 1
 
-      @s.update
+      @update
       def up3():
         s.d = s.c + 1
         print("up3 prints out d =", s.d)
 
-      @s.update
+      @update
       def up4():
         s.f = s.d + 1
 
-      @s.update
+      @update
       def up5():
         s.g = s.c + 1
         s.h = s.j + 1
         print("up5 prints out h =", s.h)
 
-      @s.update
+      @update
       def up6():
         s.i = s.i + 1
 
-      @s.update
+      @update
       def up7():
         s.j = s.g + 1
 
@@ -108,15 +108,15 @@ def _test_combinational_loop():
       s.c = Wire(int)
       s.d = Wire(int)
 
-      @s.update
+      @update
       def up1():
         s.b = s.d + 1
 
-      @s.update
+      @update
       def up2():
         s.c = s.b + 1
 
-      @s.update
+      @update
       def up3():
         s.d = s.c + 1
         print("up3 prints out d =", s.d)
@@ -139,10 +139,10 @@ def test_very_deep_dag():
 
   class Inner(Component):
     def construct( s ):
-      s.in_ = InPort(int)
-      s.out = OutPort(int)
+      s.in_ = InPort(32)
+      s.out = OutPort(32)
 
-      @s.update
+      @update
       def up():
         s.out = s.in_ + 1
 
@@ -173,11 +173,11 @@ def test_sequential_break_loop():
       s.b = Wire( Bits32 )
       s.c = Wire( Bits32 )
 
-      @s.update
+      @update
       def up1():
         s.b = s.c + 1
 
-      @s.update_ff
+      @update_ff
       def up2():
         if s.reset:
           s.c <<= 0
@@ -203,7 +203,7 @@ def test_connect_slice_int():
       s.x = Wire( Bits32 )
 
       s.y //= s.x[0:8]
-      @s.update
+      @update
       def sx():
         s.x = 10 # Except
 

--- a/pymtl3/passes/testcases/test_cases.py
+++ b/pymtl3/passes/testcases/test_cases.py
@@ -174,7 +174,7 @@ class Bits16InOutPassThroughComp( Component ):
   def construct( s ):
     s.in_ = InPort( Bits16 )
     s.out = OutPort( Bits16 )
-    @s.update
+    @update
     def pass_through():
       s.out = s.in_
 
@@ -198,7 +198,7 @@ class WrappedBits32OutComp( Component ):
 class Bits32OutTmpDrivenComp( Component ):
   def construct( s ):
     s.out = OutPort( Bits32 )
-    @s.update
+    @update
     def upblk():
       u = Bits32(0)
       s.out = u
@@ -206,7 +206,7 @@ class Bits32OutTmpDrivenComp( Component ):
 class Bits32OutFreeVarDrivenComp( Component ):
   def construct( s ):
     s.out = OutPort( Bits32 )
-    @s.update
+    @update
     def upblk():
       if 1:
         s.out = Bits32(STATE_IDLE)
@@ -297,7 +297,7 @@ class CaseBits32ClosureConstruct:
       foo = Bits32( 42 )
       s.fvar_ref = foo
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = foo
 
@@ -306,7 +306,7 @@ class CaseBits32ArrayClosureConstruct:
     def construct( s ):
       foo = [ Bits32(42) for _ in range(5) ]
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = foo[2]
 
@@ -314,7 +314,7 @@ class CaseBits32ClosureGlobal:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = pymtl_Bits_global_freevar
 
@@ -324,7 +324,7 @@ class CaseStructClosureGlobal:
       foo = InPort( Bits32Foo )
       s._foo = foo
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = foo.foo
 
@@ -335,7 +335,7 @@ class CaseReducesInx3OutComp:
       s.in_2 = InPort( Bits32 )
       s.in_3 = InPort( Bits32 )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def v_reduce():
         s.out = reduce_and( s.in_1 ) & reduce_or( s.in_2 ) | reduce_xor( s.in_3 )
   TV_IN = \
@@ -359,7 +359,7 @@ class CaseBits16IndexBasicComp:
     def construct( s ):
       s.in_ = [ InPort( Bits16 ) for _ in range( 4 ) ]
       s.out = [ OutPort( Bits16 ) for _ in range( 2 ) ]
-      @s.update
+      @update
       def index_basic():
         s.out[ 0 ] = s.in_[ 0 ] + s.in_[ 1 ]
         s.out[ 1 ] = s.in_[ 2 ] + s.in_[ 3 ]
@@ -369,7 +369,7 @@ class CaseBits8Bits16MismatchAssignComp:
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = OutPort( Bits8 )
-      @s.update
+      @update
       def mismatch_width_assign():
         s.out = s.in_
 
@@ -378,7 +378,7 @@ class CaseBits32Bits64SlicingBasicComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits64 )
-      @s.update
+      @update
       def slicing_basic():
         s.out[ 0:16 ] = s.in_[ 16:32 ]
         s.out[ 16:32 ] = s.in_[ 0:16 ]
@@ -388,7 +388,7 @@ class CaseBits16ConstAddComp:
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = OutPort( Bits16 )
-      @s.update
+      @update
       def bits_basic():
         s.out = s.in_ + Bits16( 10 )
 
@@ -397,7 +397,7 @@ class CaseSlicingOverIndexComp:
     def construct( s ):
       s.in_ = [ InPort( Bits16 ) for _ in range( 10 ) ]
       s.out = [ OutPort( Bits16 ) for _ in range( 5 ) ]
-      @s.update
+      @update
       def index_bits_slicing():
         s.out[0][0:8] = s.in_[1][8:16] + s.in_[2][0:8] + Bits8( 10 )
         s.out[1] = s.in_[3][0:16] + s.in_[4] + Bits16( 1 )
@@ -410,7 +410,7 @@ class CaseSubCompAddComp:
       s.b = Bits16InOutPassThroughComp()
       # There should be a way to check module connections?
       connect( s.in_, s.b.in_ )
-      @s.update
+      @update
       def multi_components_A():
         s.out = s.in_ + s.b.out
 
@@ -419,7 +419,7 @@ class CaseIfBasicComp:
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = OutPort( Bits8 )
-      @s.update
+      @update
       def if_basic():
         if s.in_[ 0:8 ] == Bits8( 255 ):
           s.out = s.in_[ 8:16 ]
@@ -445,7 +445,7 @@ class CaseIfDanglingElseInnerComp:
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         if Bits1(1):
           if Bits1(0):
@@ -474,7 +474,7 @@ class CaseIfDanglingElseOutterComp:
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         if Bits1(1):
           if Bits1(0):
@@ -504,7 +504,7 @@ class CaseElifBranchComp:
       s.in_2 = InPort( Bits32 )
       s.in_3 = InPort( Bits32 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         if Bits1(1):
           s.out = s.in_1
@@ -536,7 +536,7 @@ class CaseNestedIfComp:
       s.in_2 = InPort( Bits32 )
       s.in_3 = InPort( Bits32 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         if Bits1(1):
           if Bits1(0):
@@ -575,7 +575,7 @@ class CaseForBasicComp:
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = OutPort( Bits8 )
-      @s.update
+      @update
       def for_basic():
         for i in range( 8 ):
           s.out[ 2*i:2*i+1 ] = s.in_[ 2*i:2*i+1 ] + s.in_[ 2*i+1:(2*i+1)+1 ]
@@ -585,7 +585,7 @@ class CaseForRangeLowerUpperStepPassThroughComp:
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
-      @s.update
+      @update
       def upblk():
         for i in range(0, 5, 2):
           s.out[i] = s.in_[i]
@@ -621,7 +621,7 @@ class CaseIfExpInForStmtComp:
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
-      @s.update
+      @update
       def upblk():
         for i in range(5):
           s.out[i] = s.in_[i] if i == 1 else s.in_[0]
@@ -655,7 +655,7 @@ class CaseIfExpUnaryOpInForStmtComp:
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
-      @s.update
+      @update
       def upblk():
         for i in range(5):
           s.out[i] = (~s.in_[i]) if i == 1 else s.in_[0]
@@ -689,7 +689,7 @@ class CaseIfBoolOpInForStmtComp:
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
-      @s.update
+      @update
       def upblk():
         for i in range(5):
           if ( s.in_[i] != Bits32(0) ) and ( ( s.in_[i+1] != Bits32(0) ) if i<4 else ( s.in_[4] != Bits32(0) )):
@@ -726,7 +726,7 @@ class CaseIfTmpVarInForStmtComp:
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(5) ]
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
-      @s.update
+      @update
       def upblk():
         for i in range(5):
           if ( s.in_[i]  != Bits32(0) ) and ( ( s.in_[i+1] != Bits32(0) ) if i<4 else ( s.in_[4] != Bits32(0) ) ):
@@ -764,7 +764,7 @@ class CaseFixedSizeSliceComp:
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = [ OutPort( Bits8 ) for _ in range(2) ]
-      @s.update
+      @update
       def upblk():
         for i in range(2):
           s.out[i] = s.in_[i*8 : i*8 + 8]
@@ -790,10 +790,10 @@ class CaseTwoUpblksSliceComp:
     def construct( s ):
       s.in_ = InPort( Bits4 )
       s.out = OutPort( Bits8 )
-      @s.update
+      @update
       def multi_upblks_1():
         s.out[ 0:4 ] = s.in_
-      @s.update
+      @update
       def multi_upblks_2():
         s.out[ 4:8 ] = s.in_
 
@@ -803,10 +803,10 @@ class CaseTwoUpblksFreevarsComp:
       STATE_IDLE = Bits2(0)
       STATE_WORK = Bits2(1)
       s.out = [ OutPort( Bits2 ) for _ in range(2) ]
-      @s.update
+      @update
       def multi_upblks_1():
         s.out[0] = STATE_IDLE
-      @s.update
+      @update
       def multi_upblks_2():
         s.out[1] = STATE_WORK
 
@@ -817,11 +817,11 @@ class CaseTwoUpblksStructTmpWireComp:
       s.in_bar = InPort( Bits32Bar )
       s.out_foo = OutPort( Bits32 )
       s.out_bar = OutPort( Bits32 )
-      @s.update
+      @update
       def multi_upblks_1():
         u = s.in_foo
         s.out_foo = u.foo
-      @s.update
+      @update
       def multi_upblks_2():
         u = s.in_bar
         s.out_bar = u.bar
@@ -832,7 +832,7 @@ class CaseFlipFlopAdder:
       s.in0 = InPort( Bits32 )
       s.in1 = InPort( Bits32 )
       s.out0 = OutPort( Bits32 )
-      @s.update_ff
+      @update_ff
       def update_ff_upblk():
         s.out0 <<= s.in0 + s.in1
 
@@ -841,7 +841,7 @@ class CaseConstSizeSlicingComp:
     def construct( s ):
       s.in_ = InPort( Bits16 )
       s.out = [ OutPort( Bits8 ) for _ in range(2) ]
-      @s.update
+      @update
       def upblk():
         for i in range(2):
           s.out[i] = s.in_[i*8 : i*8 + 8]
@@ -851,7 +851,7 @@ class CaseBits32TmpWireComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         u = s.in_ + Bits32(42)
         s.out = u
@@ -861,7 +861,7 @@ class CaseBits32MultiTmpWireComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         u = s.in_ + Bits32(42)
         v = s.in_ + Bits32(40)
@@ -873,7 +873,7 @@ class CaseBits32FreeVarToTmpVarComp:
     def construct( s ):
       # STATE_IDLE = Bits32(0)
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         u = STATE_IDLE
         s.out = u
@@ -882,7 +882,7 @@ class CaseBits32ConstBitsToTmpVarComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         u = Bits32(0)
         s.out = u
@@ -891,7 +891,7 @@ class CaseBits32ConstIntToTmpVarComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         u = 1
         s.out = u
@@ -901,11 +901,11 @@ class CaseBits32TmpWireAliasComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = [ OutPort( Bits32 ) for _ in range(5) ]
-      @s.update
+      @update
       def multi_upblks_1():
         u = s.in_ + Bits32(42)
         s.out[0] = u
-      @s.update
+      @update
       def multi_upblks_2():
         u = s.in_ + Bits32(42)
         s.out[1] = u
@@ -915,7 +915,7 @@ class CaseStructTmpWireComp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         u = s.in_
         s.out = u.foo
@@ -926,7 +926,7 @@ class CaseTmpWireOverwriteConflictComp:
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits16 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         u = s.in_1 + Bits32(42)
         u = s.in_2 + Bits16(1)
@@ -938,7 +938,7 @@ class CaseScopeTmpWireOverwriteConflictComp:
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits16 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         if 1:
           u = s.in_1 + Bits32(42)
@@ -956,7 +956,7 @@ class CaseSizeCastPaddingStructPort:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits64 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits64( s.in_ )
   TV_IN = \
@@ -978,7 +978,7 @@ class CaseBits32x2ConcatComp:
       s.in_1 = InPort( Bits32 )
       s.in_2 = InPort( Bits32 )
       s.out = OutPort( Bits64 )
-      @s.update
+      @update
       def upblk():
         s.out = concat( s.in_1, s.in_2 )
   TV_IN = \
@@ -1000,7 +1000,7 @@ class CaseBits32x2ConcatConstComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits64 )
-      @s.update
+      @update
       def upblk():
         s.out = concat( Bits32(42), Bits32(0) )
   TV_IN = \
@@ -1017,7 +1017,7 @@ class CaseBits32x2ConcatMixedComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits64 )
-      @s.update
+      @update
       def upblk():
         s.out = concat( s.in_, Bits32(0) )
   TV_IN = \
@@ -1037,7 +1037,7 @@ class CaseBits32x2ConcatFreeVarComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits64 )
-      @s.update
+      @update
       def upblk():
         s.out = concat( s.in_, STATE_IDLE )
   TV_IN = \
@@ -1057,7 +1057,7 @@ class CaseBits32x2ConcatUnpackedSignalComp:
     def construct( s ):
       s.in_ = [ InPort( Bits32 ) for _ in range(2) ]
       s.out = OutPort( Bits64 )
-      @s.update
+      @update
       def upblk():
         s.out = concat( s.in_[0], s.in_[1] )
   TV_IN = \
@@ -1080,7 +1080,7 @@ class CaseBits64SextInComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits64 )
-      @s.update
+      @update
       def upblk():
         s.out = sext( s.in_, 64 )
   TV_IN = \
@@ -1100,7 +1100,7 @@ class CaseBits64ZextInComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits64 )
-      @s.update
+      @update
       def upblk():
         s.out = zext( s.in_, 64 )
   TV_IN = \
@@ -1120,7 +1120,7 @@ class CaseBits32BitSelUpblkComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[1]
   TV_IN = \
@@ -1140,7 +1140,7 @@ class CaseBits64PartSelUpblkComp:
     def construct( s ):
       s.in_ = InPort( Bits64 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[4:36]
   TV_IN = \
@@ -1163,7 +1163,7 @@ class CasePassThroughComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_
   TV_IN = \
@@ -1184,7 +1184,7 @@ class CaseSequentialPassThroughComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
-      @s.update_ff
+      @update_ff
       def upblk():
         s.out <<= s.in_
   TV_IN = \
@@ -1267,7 +1267,7 @@ class CaseBits32FooInBits32OutComp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_.foo
   TV_IN = \
@@ -1288,7 +1288,7 @@ class CaseBits32FooKwargComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits32Foo( foo = Bits32( 42 ) )
 
@@ -1296,7 +1296,7 @@ class CaseBits32FooInstantiationComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32Foo )
-      @s.update
+      @update
       def upblk():
         s.out = Bits32Foo( Bits32( 42 ) )
 
@@ -1305,7 +1305,7 @@ class CaseConstStructInstComp:
     def construct( s ):
       s.in_ = Bits32Foo()
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_.foo
   TV_IN = \
@@ -1322,7 +1322,7 @@ class CaseStructPackedArrayUpblkComp:
     def construct( s ):
       s.in_ = InPort( Bits32x5Foo )
       s.out = OutPort( Bits96 )
-      @s.update
+      @update
       def upblk():
         s.out = concat( s.in_.foo[0], s.in_.foo[1], s.in_.foo[2] )
   TV_IN = \
@@ -1357,7 +1357,7 @@ class CaseNestedStructPackedArrayUpblkComp:
     def construct( s ):
       s.in_ = InPort( NestedStructPackedPlusScalar )
       s.out = OutPort( Bits96 )
-      @s.update
+      @update
       def upblk():
         s.out = concat( s.in_.bar[0], s.in_.woo.foo, s.in_.foo )
   TV_IN = \
@@ -1399,7 +1399,7 @@ class CaseInterfaceAttributeComp:
     def construct( s ):
       s.in_ = Bits32OutIfc()
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_.foo
 
@@ -1408,7 +1408,7 @@ class CaseArrayInterfacesComp:
     def construct( s ):
       s.in_ = [ Bits32OutIfc() for _ in range(4) ]
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[2].foo
 
@@ -1417,7 +1417,7 @@ class CaseBits32SubCompPassThroughComp:
     def construct( s ):
       s.comp = Bits32OutComp()
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.comp.out
 
@@ -1426,7 +1426,7 @@ class CaseArrayBits32SubCompPassThroughComp:
     def construct( s ):
       s.comp = [ Bits32OutComp() for _ in range(4) ]
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.comp[2].out
 
@@ -1435,7 +1435,7 @@ class CaseSubCompTmpDrivenComp:
     def construct( s ):
       s.subcomp = Bits32OutTmpDrivenComp()
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         u = s.subcomp.out
         s.out = u
@@ -1445,7 +1445,7 @@ class CaseSubCompFreeVarDrivenComp:
     def construct( s ):
       s.subcomp = Bits32OutFreeVarDrivenComp()
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         if 1:
           s.out = s.subcomp.out
@@ -1507,7 +1507,7 @@ class CaseWiresDrivenComp:
     def construct( s ):
       s.foo = Wire( Bits32 )
       s.bar = Wire( Bits4 )
-      @s.update
+      @update
       def upblk():
         s.foo = Bits32(42)
         s.bar = Bits4(0)
@@ -1516,7 +1516,7 @@ class CaseBits32Wirex5DrivenComp:
   class DUT( Component ):
     def construct( s ):
       s.foo = [ Wire( Bits32 ) for _ in range(5) ]
-      @s.update
+      @update
       def upblk():
         for i in range(5):
           s.foo[i] = Bits32(0)
@@ -1525,7 +1525,7 @@ class CaseStructWireDrivenComp:
   class DUT( Component ):
     def construct( s ):
       s.foo = Wire( Bits32Foo )
-      @s.update
+      @update
       def upblk():
         s.foo.foo = Bits32(42)
 
@@ -1667,7 +1667,7 @@ class CaseArrayBits32IfcInUpblkComp:
     def construct( s ):
       s.in_ = [ Bits32InIfc() for _ in range(5) ]
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[1].foo
   TV_IN = \
@@ -1720,7 +1720,7 @@ class CaseConnectValRdyIfcUpblkComp:
     def construct( s ):
       s.in_ = Bits32InValRdyIfc()
       s.out = Bits32OutValRdyIfc()
-      @s.update
+      @update
       def upblk():
         s.out.val = s.in_.val
         s.out.msg = s.in_.msg
@@ -1765,7 +1765,7 @@ class CaseConnectArrayBits32FooIfcComp:
   )
   TEST_VECTOR = \
   [
-      [ 1,      0,    1,      0, ], 
+      [ 1,      0,    1,      0, ],
       [ 0,     42,    0,     42, ],
       [ 1,     42,    1,     42, ],
       [ 1,     -1,    1,     -1, ],
@@ -1803,7 +1803,7 @@ class CaseConnectArrayNestedIfcComp:
   )
   TEST_VECTOR = \
   [
-      [ 1,  1,      0,    0,    1,  1,      0,    0,  1,  1,      0,    0,    1,  1,      0,    0, ], 
+      [ 1,  1,      0,    0,    1,  1,      0,    0,  1,  1,      0,    0,    1,  1,      0,    0, ],
       [ 1,  0,     42,    1,    1,  0,     42,    1,  1,  0,     42,    1,    1,  0,     42,    1, ],
       [ 1,  1,     42,    0,    1,  1,     42,    0,  1,  1,     42,    0,    1,  1,     42,    0, ],
       [ 1,  1,     -1,    1,    1,  1,     -1,    1,  1,  1,     -1,    1,    1,  1,     -1,    1, ],
@@ -1815,7 +1815,7 @@ class CaseBits32IfcTmpVarOutComp:
     def construct( s ):
       s.out = OutPort( Bits32 )
       s.ifc = Bits32OutIfc()
-      @s.update
+      @update
       def upblk():
         u = s.ifc.foo
         s.out = u
@@ -1825,7 +1825,7 @@ class CaseStructIfcTmpVarOutComp:
     def construct( s ):
       s.out = OutPort( Bits32 )
       s.ifc = Bits32FooInIfc()
-      @s.update
+      @update
       def upblk():
         u = s.ifc.foo
         s.out = u.foo
@@ -1847,7 +1847,7 @@ class CaseBits32SubCompAttrUpblkComp:
     def construct( s ):
       s.b = Bits32OutDrivenComp()
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.b.out
   TV_IN = \
@@ -1916,7 +1916,7 @@ class CaseBits32ArraySubCompAttrUpblkComp:
     def construct( s ):
       s.b = [ Bits32OutDrivenComp() for _ in range(5) ]
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.b[1].out
   TV_IN = \
@@ -1984,7 +1984,7 @@ class CaseSVerilogReservedComp:
     def construct( s ):
       s.buf = InPort( Bits32 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.buf
 
@@ -1993,7 +1993,7 @@ class CaseInterfaceArrayNonStaticIndexComp:
     def construct( s ):
       s.in_ = [ Bits32InIfc() for _ in range(2) ]
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[s.in_[0].foo].foo
   TV_IN = \
@@ -2021,7 +2021,7 @@ class CaseStructBitsUnagreeableComp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits16 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_
 
@@ -2030,7 +2030,7 @@ class CaseConcatComponentComp:
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
-      @s.update
+      @update
       def upblk():
         s.out = concat( s, s.in_ )
 
@@ -2039,7 +2039,7 @@ class CaseZextVaribleNbitsComp:
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
-      @s.update
+      @update
       def upblk():
         s.out = zext( s.in_, s.in_ )
 
@@ -2048,7 +2048,7 @@ class CaseZextSmallNbitsComp:
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
-      @s.update
+      @update
       def upblk():
         s.out = zext( s.in_, 4 )
 
@@ -2057,7 +2057,7 @@ class CaseSextVaribleNbitsComp:
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
-      @s.update
+      @update
       def upblk():
         s.out = sext( s.in_, s.in_ )
 
@@ -2066,7 +2066,7 @@ class CaseSextSmallNbitsComp:
     def construct( s ):
       s.in_ = InPort( Bits8 )
       s.out = OutPort( Bits16 )
-      @s.update
+      @update
       def upblk():
         s.out = sext( s.in_, 4 )
 
@@ -2076,7 +2076,7 @@ class CaseDroppedAttributeComp:
       # s.in_ is not recognized by RTLIR and will be dropped
       s.in_ = 'string'
       s.out = OutPort( Bits16 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_
 
@@ -2086,7 +2086,7 @@ class CaseL1UnsupportedSubCompAttrComp:
       s.in_ = InPort( Bits4 )
       s.out = [ OutPort( Bits1 ) for _ in range(5) ]
       s.comp_array = [ Bits1OutComp() for _ in range(5) ]
-      @s.update
+      @update
       def upblk():
         s.out = s.comp_array[ 0 ].out
 
@@ -2095,7 +2095,7 @@ class CaseIndexOutOfRangeComp:
     def construct( s ):
       s.in_ = [ InPort( Bits1 ) for _ in range(4) ]
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[4]
 
@@ -2104,7 +2104,7 @@ class CaseBitSelOutOfRangeComp:
     def construct( s ):
       s.in_ = InPort( Bits4 )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[4]
 
@@ -2113,7 +2113,7 @@ class CaseIndexOnStructComp:
     def construct( s ):
       s.in_ = InPort( Bits32x5Foo )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[16]
 
@@ -2122,7 +2122,7 @@ class CaseSliceOnStructComp:
     def construct( s ):
       s.in_ = InPort( Bits32x5Foo )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[0:16]
 
@@ -2131,7 +2131,7 @@ class CaseSliceBoundLowerComp:
     def construct( s ):
       s.in_ = InPort( Bits4 )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[4:0]
 
@@ -2142,7 +2142,7 @@ class CaseSliceVariableBoundComp:
       s.slice_l = InPort( Bits2 )
       s.slice_r = InPort( Bits2 )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[s.slice_l:s.slice_r]
 
@@ -2151,7 +2151,7 @@ class CaseSliceOutOfRangeComp:
     def construct( s ):
       s.in_ = InPort( Bits4 )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[0:5]
 
@@ -2159,7 +2159,7 @@ class CaseLHSConstComp:
   class DUT( Component ):
     def construct( s ):
       u, s.v = 42, 42
-      @s.update
+      @update
       def upblk():
         s.v = u
 
@@ -2167,7 +2167,7 @@ class CaseLHSComponentComp:
   class DUT( Component ):
     def construct( s ):
       s.u = Bits16InOutPassThroughComp()
-      @s.update
+      @update
       def upblk():
         s.u = 42
 
@@ -2175,7 +2175,7 @@ class CaseRHSComponentComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s
 
@@ -2183,7 +2183,7 @@ class CaseZextOnComponentComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = zext( s, 1 )
 
@@ -2191,7 +2191,7 @@ class CaseSextOnComponentComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = sext( s, 1 )
 
@@ -2199,7 +2199,7 @@ class CaseSizeCastComponentComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits32( s )
 
@@ -2208,7 +2208,7 @@ class CaseAttributeSignalComp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_.foo
 
@@ -2217,7 +2217,7 @@ class CaseComponentInIndexComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[ s ]
 
@@ -2225,7 +2225,7 @@ class CaseComponentBaseIndexComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s[ 1 ]
 
@@ -2235,7 +2235,7 @@ class CaseComponentLowerSliceComp:
       s.in_ = InPort( Bits32 )
       s.idx = Bits16InOutPassThroughComp()
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[ s.idx:4 ]
 
@@ -2245,7 +2245,7 @@ class CaseComponentHigherSliceComp:
       s.in_ = InPort( Bits32 )
       s.idx = Bits16InOutPassThroughComp()
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_[ 0:s.idx ]
 
@@ -2253,35 +2253,35 @@ class CaseSliceOnComponentComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s[ 0:4 ]
 
 class CaseUpblkArgComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk( number ):
         u = number
 
 class CaseAssignMultiTargetComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         u = v = x = y
 
 class CaseCopyArgsComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         u = copy(42, 10)
 
 class CaseDeepcopyArgsComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         u = deepcopy(42, 10)
 
@@ -2289,7 +2289,7 @@ class CaseSliceWithStepsComp:
   class DUT( Component ):
     def construct( s ):
       v = 42
-      @s.update
+      @update
       def upblk():
         u = v[ 0:16:4 ]
 
@@ -2297,7 +2297,7 @@ class CaseExtendedSubscriptComp:
   class DUT( Component ):
     def construct( s ):
       v = 42
-      @s.update
+      @update
       def upblk():
         u = v[ 0:8, 16:24 ]
 
@@ -2305,28 +2305,28 @@ class CaseTmpComponentComp:
   class DUT( Component ):
     def construct( s ):
       v = Bits16InOutPassThroughComp()
-      @s.update
+      @update
       def upblk():
         u = v
 
 class CaseUntypedTmpComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         u = 42
 
 class CaseStarArgsComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         x = x(*x)
 
 class CaseDoubleStarArgsComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         x = x(**x)
 
@@ -2334,49 +2334,49 @@ class CaseKwArgsComp:
   class DUT( Component ):
     def construct( s ):
       xx = 42
-      @s.update
+      @update
       def upblk():
         x = x(x=x)
 
 class CaseNonNameCalledComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         x = copy.copy( x )
 
 class CaseFuncNotFoundComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         t = undefined_func(u)
 
 class CaseBitsArgsComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         x = Bits32( 42, 42 )
 
 class CaseConcatNoArgsComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         x = concat()
 
 class CaseZextTwoArgsComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         x = zext( s )
 
 class CaseSextTwoArgsComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         x = sext( s )
 
@@ -2384,14 +2384,14 @@ class CaseUnrecognizedFuncComp:
   class DUT( Component ):
     def construct( s ):
       def foo(): pass
-      @s.update
+      @update
       def upblk():
         x = foo()
 
 class CaseStandaloneExprComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         42
 
@@ -2399,7 +2399,7 @@ class CaseLambdaFuncComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = lambda: 42
 
@@ -2407,7 +2407,7 @@ class CaseDictComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = { 1:42 }
 
@@ -2415,7 +2415,7 @@ class CaseSetComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = { 42 }
 
@@ -2423,7 +2423,7 @@ class CaseListComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = [ 42 ]
 
@@ -2431,7 +2431,7 @@ class CaseTupleComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = ( 42, )
 
@@ -2439,7 +2439,7 @@ class CaseListComprehensionComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = [ 42 for _ in range(1) ]
 
@@ -2447,7 +2447,7 @@ class CaseSetComprehensionComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = { 42 for _ in range(1) }
 
@@ -2455,7 +2455,7 @@ class CaseDictComprehensionComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = { 1:42 for _ in range(1) }
 
@@ -2463,7 +2463,7 @@ class CaseGeneratorExprComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = ( 42 for _ in range(1) )
 
@@ -2471,7 +2471,7 @@ class CaseYieldComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = yield
 
@@ -2479,7 +2479,7 @@ class CaseReprComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         # Python 2 only: s.out = `42`
         s.out = repr(42)
@@ -2488,42 +2488,42 @@ class CaseStrComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = '42'
 
 class CaseClassdefComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         class c: pass
 
 class CaseDeleteComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         del u
 
 class CaseWithComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         with u: 42
 
 class CaseRaiseComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         raise 42
 
 class CaseTryExceptComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         try: 42
         except: 42
@@ -2531,7 +2531,7 @@ class CaseTryExceptComp:
 class CaseTryFinallyComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         try: 42
         finally: 42
@@ -2540,7 +2540,7 @@ class CaseImportComp:
   class DUT( Component ):
     def construct( s ):
       x = 42
-      @s.update
+      @update
       def upblk():
         import x
 
@@ -2548,14 +2548,14 @@ class CaseImportFromComp:
   class DUT( Component ):
     def construct( s ):
       x = 42
-      @s.update
+      @update
       def upblk():
         from x import x
 
 class CaseExecComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         # Python 2 only: exec 42
         exec(42)
@@ -2564,28 +2564,28 @@ class CaseGlobalComp:
   class DUT( Component ):
     def construct( s ):
       u = 42
-      @s.update
+      @update
       def upblk():
         global u
 
 class CasePassComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         pass
 
 class CaseWhileComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         while 42: 42
 
 class CaseExtSliceComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         42[ 1:2:3, 2:4:6 ]
 
@@ -2593,7 +2593,7 @@ class CaseAddComponentComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1( 1 ) + s
 
@@ -2601,7 +2601,7 @@ class CaseInvComponentComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = ~s
 
@@ -2609,7 +2609,7 @@ class CaseComponentStartRangeComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         for i in range( s, 8, 1 ):
           s.out = ~Bits1( 1 )
@@ -2618,7 +2618,7 @@ class CaseComponentEndRangeComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         for i in range( 0, s, 1 ):
           s.out = ~Bits1( 1 )
@@ -2627,7 +2627,7 @@ class CaseComponentStepRangeComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         for i in range( 0, 8, s ):
           s.out = ~Bits1( 1 )
@@ -2636,7 +2636,7 @@ class CaseComponentIfCondComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         if s:
           s.out = Bits1( 1 )
@@ -2647,7 +2647,7 @@ class CaseComponentIfExpCondComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1(1) if s else ~Bits1(1)
 
@@ -2655,7 +2655,7 @@ class CaseComponentIfExpBodyComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s if 1 else ~Bits1(1)
 
@@ -2663,7 +2663,7 @@ class CaseComponentIfExpElseComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1(1) if 1 else s
 
@@ -2672,7 +2672,7 @@ class CaseStructIfCondComp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         if s.in_:
           s.out = Bits1(1)
@@ -2683,7 +2683,7 @@ class CaseZeroStepRangeComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         for i in range( 0, 4, 0 ):
           s.out = Bits1( 1 )
@@ -2693,7 +2693,7 @@ class CaseVariableStepRangeComp:
     def construct( s ):
       s.in_ = InPort( Bits2 )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         for i in range( 0, 4, s.in_ ):
           s.out = Bits1( 1 )
@@ -2703,7 +2703,7 @@ class CaseStructIfExpCondComp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1(1) if s.in_ else ~Bits1(1)
 
@@ -2712,7 +2712,7 @@ class CaseDifferentTypesIfExpComp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1(1) if 1 else s.in_
 
@@ -2721,7 +2721,7 @@ class CaseNotStructComp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = not s.in_
 
@@ -2730,7 +2730,7 @@ class CaseAndStructComp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1( 1 ) and s.in_
 
@@ -2739,7 +2739,7 @@ class CaseAddStructBits1Comp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1( 1 ) + s.in_
 
@@ -2748,7 +2748,7 @@ class CaseExplicitBoolComp:
     def construct( s ):
       Bool = rdt.Bool
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = Bool( Bits1(1) )
 
@@ -2756,7 +2756,7 @@ class CaseTmpVarUsedBeforeAssignmentComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         s.out = u + Bits4( 1 )
 
@@ -2764,7 +2764,7 @@ class CaseForLoopElseComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         for i in range(4):
           s.out = Bits4( 1 )
@@ -2776,7 +2776,7 @@ class CaseSignalAsLoopIndexComp:
     def construct( s ):
       s.in_ = Wire( Bits4 )
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         for s.in_ in range(4):
           s.out = Bits4( 1 )
@@ -2785,7 +2785,7 @@ class CaseRedefLoopIndexComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         for i in range(4):
           for i in range(4):
@@ -2796,7 +2796,7 @@ class CaseSignalAfterInComp:
     def construct( s ):
       s.in_ = InPort( Bits2 )
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         for i in s.in_:
           s.out = Bits4( 1 )
@@ -2806,7 +2806,7 @@ class CaseFuncCallAfterInComp:
     def construct( s ):
       s.out = OutPort( Bits4 )
       def foo(): pass
-      @s.update
+      @update
       def upblk():
         for i in foo():
           s.out = Bits4( 1 )
@@ -2815,7 +2815,7 @@ class CaseNoArgsToRangeComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         for i in range():
           s.out = Bits4( 1 )
@@ -2824,7 +2824,7 @@ class CaseTooManyArgsToRangeComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         for i in range( 0, 4, 1, 1 ):
           s.out = Bits4( 1 )
@@ -2833,7 +2833,7 @@ class CaseInvalidIsComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1( 1 ) is Bits1( 1 )
 
@@ -2841,7 +2841,7 @@ class CaseInvalidIsNotComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1( 1 ) is not Bits1( 1 )
 
@@ -2849,7 +2849,7 @@ class CaseInvalidInComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1( 1 ) in Bits1( 1 )
 
@@ -2857,7 +2857,7 @@ class CaseInvalidNotInComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1( 1 ) not in Bits1( 1 )
 
@@ -2865,7 +2865,7 @@ class CaseInvalidDivComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1( 1 ) // Bits1( 1 )
 
@@ -2873,21 +2873,21 @@ class CaseMultiOpComparisonComp:
   class DUT( Component ):
     def construct( s ):
       s.out = OutPort( Bits4 )
-      @s.update
+      @update
       def upblk():
         s.out = Bits1( 0 ) <= Bits2( 1 ) <= Bits2( 2 )
 
 class CaseInvalidBreakComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         for i in range(42): break
 
 class CaseInvalidContinueComp:
   class DUT( Component ):
     def construct( s ):
-      @s.update
+      @update
       def upblk():
         for i in range(42): continue
 
@@ -2896,7 +2896,7 @@ class CaseBitsAttributeComp:
     def construct( s ):
       s.in_ = InPort( Bits32 )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_.foo
 
@@ -2905,7 +2905,7 @@ class CaseStructMissingAttributeComp:
     def construct( s ):
       s.in_ = InPort( Bits32Foo )
       s.out = OutPort( Bits1 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_.bar
 
@@ -2914,7 +2914,7 @@ class CaseInterfaceMissingAttributeComp:
     def construct( s ):
       s.in_ = Bits32OutIfc()
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.in_.bar
 
@@ -2923,7 +2923,7 @@ class CaseSubCompMissingAttributeComp:
     def construct( s ):
       s.comp = Bits32OutComp()
       s.out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.out = s.comp.bar
 
@@ -2932,7 +2932,7 @@ class CaseCrossHierarchyAccessComp:
     def construct( s ):
       s.comp = WrappedBits32OutComp()
       s.a_out = OutPort( Bits32 )
-      @s.update
+      @update
       def upblk():
         s.a_out = s.comp.comp.out
 

--- a/pymtl3/passes/tracing/test/CollectSignalPass_test.py
+++ b/pymtl3/passes/tracing/test/CollectSignalPass_test.py
@@ -22,7 +22,7 @@ class Toy( Component ):
     s.in1 = InPort( Bits32 )
     s.out = OutPort( Bits32 )
 
-    @s.update
+    @update
     def add_upblk():
       # This update block models the behavior of a 32-bit adder
       s.out = s.in0 + s.in1

--- a/pymtl3/passes/tracing/test/PrintWavePass_test.py
+++ b/pymtl3/passes/tracing/test/PrintWavePass_test.py
@@ -37,7 +37,7 @@ def test_toy():
       s.inlong = InPort( Bits32 )
       s.out = OutPort( Bits32 )
       s.state = Wire(Bits1)
-      @s.update
+      @update
       def add_upblk():
         # This update block models the behavior of a 32-bit adder
         s.out = s.i + s.inlong
@@ -97,7 +97,7 @@ def test_widetoy():
       s.inlong = InPort( Bits128 )
       s.out = OutPort( Bits128 )
       s.state = Wire(Bits1)
-      @s.update
+      @update
       def add_upblk():
         # This update block models the behavior of a 32-bit adder
         s.out = s.i + s.inlong
@@ -165,7 +165,7 @@ def test_bitstruct():
       s.inlong = InPort( Bits16 )
       s.out = OutPort( XX )
       s.state = Wire(Bits1)
-      @s.update
+      @update
       def add_upblk():
         # This update block models the behavior of a 32-bit adder
         s.out.x = s.i.x + s.inlong

--- a/pymtl3/passes/tracing/test/VcdGenerationPass_test.py
+++ b/pymtl3/passes/tracing/test/VcdGenerationPass_test.py
@@ -41,7 +41,7 @@ def test_vector_signals():
       s.in1 = InPort( Bits32 )
       s.out = OutPort( Bits32 )
 
-      @s.update
+      @update
       def add_upblk():
         s.out = s.in0 + s.in1
   def tv_in( m, tv ):
@@ -73,7 +73,7 @@ def test_bitstruct_signals():
       s.in1 = InPort( Bits32 )
       s.out = OutPort( Bits32 )
 
-      @s.update
+      @update
       def add_upblk():
         s.out = s.in0.bar + s.in1
   def tv_in( m, tv ):

--- a/pymtl3/stdlib/cl/DelayPipeCL.py
+++ b/pymtl3/stdlib/cl/DelayPipeCL.py
@@ -47,7 +47,7 @@ class DelayPipeDeqCL( Component ):
     else: # delay >= 1, pipe behavior
       s.pipeline = deque( [None]*(delay+1), maxlen=(delay+1) )
 
-      @s.update
+      @update
       def up_delay():
         if s.pipeline[-1] is None:
           s.pipeline.rotate()
@@ -93,7 +93,7 @@ class DelayPipeSendCL( Component ):
       s.enq = CalleeIfcCL( Type=None, method=s.enq_pipe, rdy=s.enq_rdy_pipe )
       s.pipeline = deque( [None]*delay, maxlen=delay )
 
-      @s.update
+      @update
       def up_delay():
         if s.pipeline[-1] is not None:
           if s.send.rdy():

--- a/pymtl3/stdlib/cl/DelayPipeCL_test.py
+++ b/pymtl3/stdlib/cl/DelayPipeCL_test.py
@@ -8,7 +8,7 @@
 import pytest
 
 from pymtl3 import *
-from pymtl3.stdlib.test import TestSinkCL, TestSrcCL, mk_test_case_table
+from pymtl3.stdlib.test import TestSinkCL, TestSrcCL, mk_test_case_table, run_sim
 
 from .DelayPipeCL import DelayPipeDeqCL, DelayPipeSendCL
 
@@ -47,34 +47,6 @@ class TestHarness( Component ):
   def line_trace(s ):
     return s.src.line_trace() + " >>> " + s.dut.line_trace() + " >>> " + s.sink.line_trace()
 
-
-def run_cl_sim( th, max_cycles=5000 ):
-
-  # Create a simulator
-
-  th.apply( SimulationPass() )
-
-  # Reset model
-
-  th.reset()
-
-  # Run simulation
-
-  ncycles = 0
-  print("{:3}:{}".format( ncycles, th.line_trace() ))
-  while not th.done() and ncycles < max_cycles:
-    th.tick()
-    ncycles += 1
-    print("{:3}:{}".format( ncycles, th.line_trace() ))
-
-  # Force a test failure if we timed out
-
-  assert ncycles < max_cycles
-
-  th.tick()
-  th.tick()
-  th.tick()
-
 #-------------------------------------------------------------------------
 # Test Case Table
 #-------------------------------------------------------------------------
@@ -112,7 +84,7 @@ def basic_msgs():
 ]) )
 def test_delay_pipe_deq( test_params, dump_vcd ):
   msgs = test_params.msg_func()
-  run_cl_sim( TestHarness( DelayPipeDeqCL, msgs[::2], msgs[1::2],
+  run_sim( TestHarness( DelayPipeDeqCL, msgs[::2], msgs[1::2],
                            test_params.lat,
                            test_params.src_lat, test_params.sink_lat ) )
 
@@ -131,6 +103,6 @@ def test_delay_pipe_deq( test_params, dump_vcd ):
 ]) )
 def test_delay_pipe_send( test_params, dump_vcd ):
   msgs = test_params.msg_func()
-  run_cl_sim( TestHarness( DelayPipeSendCL, msgs[::2], msgs[1::2],
+  run_sim( TestHarness( DelayPipeSendCL, msgs[::2], msgs[1::2],
                            test_params.lat,
                            test_params.src_lat, test_params.sink_lat ) )

--- a/pymtl3/stdlib/cl/DelayPipeCL_test.py
+++ b/pymtl3/stdlib/cl/DelayPipeCL_test.py
@@ -33,7 +33,7 @@ class TestHarness( Component ):
     connect( s.src.send,  s.dut.enq )
 
     if   dut_class is DelayPipeDeqCL:
-      @s.update
+      @update
       def up_adapt():
         if s.dut.deq.rdy() and s.sink.recv.rdy():
           s.sink.recv( s.dut.deq() )

--- a/pymtl3/stdlib/cl/MemoryCL.py
+++ b/pymtl3/stdlib/cl/MemoryCL.py
@@ -74,11 +74,17 @@ class MemoryCL( Component ):
     req_latency = min(1, latency)
     resp_latency = latency - req_latency
 
-    s.req_stalls = [ StallCL( stall_prob, i )( recv = s.ifc[i].req ) for i in range(nports) ]
-    s.req_qs  = [ DelayPipeDeqCL( req_latency )( enq = s.req_stalls[i].send ) for i in range(nports) ]
-    s.resp_qs = [ DelayPipeSendCL( resp_latency )( send = s.ifc[i].resp ) for i in range(nports) ]
+    s.req_stalls = [ StallCL( stall_prob, i )     for i in range(nports) ]
+    s.req_qs  = [ DelayPipeDeqCL( req_latency )   for i in range(nports) ]
+    s.resp_qs = [ DelayPipeSendCL( resp_latency ) for i in range(nports) ]
 
-    @s.update
+    for i in range(nports):
+      s.req_stalls[i].recv //= s.ifc[i].req
+      s.resp_qs[i].send    //= s.ifc[i].resp
+
+      s.req_qs[i].enq      //= s.req_stalls[i].send
+
+    @update
     def up_mem():
 
       for i in range(s.nports):

--- a/pymtl3/stdlib/cl/MemoryCL.py
+++ b/pymtl3/stdlib/cl/MemoryCL.py
@@ -8,7 +8,7 @@ the one in pclib because we actually use the memory messages correctly
 in the interface.
 
 Author : Shunning Jiang
-Date   : Mar 12, 2018
+Date   : Feb 6, 2020
 """
 
 from pymtl3 import *
@@ -17,6 +17,7 @@ from pymtl3.stdlib.ifcs import MemMsgType, mk_mem_msg
 from pymtl3.stdlib.ifcs.mem_ifcs import MemMinionIfcCL
 
 from .DelayPipeCL import DelayPipeDeqCL, DelayPipeSendCL
+from .StallCL import StallCL
 
 # BRGTC2 custom MemMsg modified for RISC-V 32
 
@@ -55,7 +56,7 @@ class MemoryCL( Component ):
     return s.mem.write_mem( addr, data )
 
   # Actual stuff
-  def construct( s, nports, mem_ifc_dtypes=[mk_mem_msg(8,32,32), mk_mem_msg(8,32,32)], latency=1, mem_nbytes=2**20 ):
+  def construct( s, nports, mem_ifc_dtypes=[mk_mem_msg(8,32,32), mk_mem_msg(8,32,32)], stall_prob=0, latency=1, mem_nbytes=2**20 ):
 
     # Local constants
 
@@ -73,7 +74,8 @@ class MemoryCL( Component ):
     req_latency = min(1, latency)
     resp_latency = latency - req_latency
 
-    s.req_qs  = [ DelayPipeDeqCL( req_latency )( enq = s.ifc[i].req ) for i in range(nports) ]
+    s.req_stalls = [ StallCL( stall_prob, i )( recv = s.ifc[i].req ) for i in range(nports) ]
+    s.req_qs  = [ DelayPipeDeqCL( req_latency )( enq = s.req_stalls[i].send ) for i in range(nports) ]
     s.resp_qs = [ DelayPipeSendCL( resp_latency )( send = s.ifc[i].resp ) for i in range(nports) ]
 
     @s.update
@@ -111,4 +113,4 @@ class MemoryCL( Component ):
   # TODO: better line trace.
 
   def line_trace( s ):
-    return "|".join( [ x[0].line_trace() + x[1].line_trace() for x in zip(s.req_qs, s.resp_qs) ] )
+    return "|".join( [ x[0].line_trace() + x[1].line_trace() + x[2].line_trace() for x in zip(s.req_stalls, s.req_qs, s.resp_qs) ] )

--- a/pymtl3/stdlib/cl/StallCL.py
+++ b/pymtl3/stdlib/cl/StallCL.py
@@ -8,8 +8,9 @@
  Date   : Feb 6, 2020
 """
 
-from pymtl3 import *
 from random import Random
+
+from pymtl3 import *
 
 # This stall is for testing purpose
 # Recv side has a random stall

--- a/pymtl3/stdlib/cl/StallCL.py
+++ b/pymtl3/stdlib/cl/StallCL.py
@@ -1,0 +1,37 @@
+"""
+=========================================================================
+ StallCL.py
+=========================================================================
+ Models random stall
+
+ Author : Shunning Jiang
+ Date   : Feb 6, 2020
+"""
+
+from pymtl3 import *
+from random import Random
+
+# This stall is for testing purpose
+# Recv side has a random stall
+
+class StallCL( Component ):
+
+  # ready <==> stall_rand > stall_prob
+  @non_blocking( lambda s: s.stall_rgen.random() > s.stall_prob and s.send.rdy() )
+  def recv( s, msg ):
+    s.send( msg )
+
+  def construct( s, stall_prob=0.5, stall_seed=0x1 ):
+
+    s.send = CallerIfcCL()
+
+    s.stall_prob = stall_prob
+    s.stall_rgen = Random( stall_seed ) # Separate randgen for each injector
+
+    s.add_constraints(
+      M(s.recv) == M(s.send),  # pass_through
+    )
+
+
+  def line_trace( s ):
+    return f"{s.recv}"

--- a/pymtl3/stdlib/cl/__init__.py
+++ b/pymtl3/stdlib/cl/__init__.py
@@ -1,2 +1,3 @@
 from .DelayPipeCL import DelayPipeDeqCL as DelayPipeCL
 from .queues import BypassQueueCL, NormalQueueCL, PipeQueueCL
+from .StallCL import StallCL

--- a/pymtl3/stdlib/cl/queues.py
+++ b/pymtl3/stdlib/cl/queues.py
@@ -81,7 +81,7 @@ class NormalQueueCL( Component ):
     s.enq_rdy = False
     s.deq_rdy = False
 
-    @s.update
+    @update
     def up_pulse():
       s.enq_rdy    = len( s.queue ) < s.queue.maxlen
       s.deq_rdy    = len( s.queue ) > 0

--- a/pymtl3/stdlib/cl/queues_test.py
+++ b/pymtl3/stdlib/cl/queues_test.py
@@ -9,8 +9,7 @@ Author: Yanghui Ou
 import pytest
 
 from pymtl3 import *
-from pymtl3.stdlib.test.test_sinks import TestSinkCL
-from pymtl3.stdlib.test.test_srcs import TestSrcCL
+from pymtl3.stdlib.test import TestSinkCL, TestSrcCL, run_sim
 
 from .queues import BypassQueueCL, NormalQueueCL, PipeQueueCL
 
@@ -28,7 +27,7 @@ class TestHarness( Component ):
 
     connect( s.src.send, s.dut.enq )
 
-    @s.update
+    @update
     def up_deq_send():
       if s.dut.deq.rdy() and s.sink.recv.rdy():
         s.sink.recv( s.dut.deq() )
@@ -39,34 +38,6 @@ class TestHarness( Component ):
   def line_trace( s ):
     return "{} ({}) {}".format(
       s.src.line_trace(), s.dut.line_trace(), s.sink.line_trace() )
-
-#-------------------------------------------------------------------------
-# run_sim
-#-------------------------------------------------------------------------
-
-def run_sim( th, max_cycles=100 ):
-
-  # Create a simulator
-
-  th.apply( SimulationPass() )
-
-  # Run simulation
-
-  print("")
-  ncycles = 0
-  print("{:2}:{}".format( ncycles, th.line_trace() ))
-  while not th.done() and ncycles < max_cycles:
-    th.tick()
-    ncycles += 1
-    print("{:2}:{}".format( ncycles, th.line_trace() ))
-
-  # Check timeout
-
-  assert ncycles < max_cycles
-
-  th.tick()
-  th.tick()
-  th.tick()
 
 #-------------------------------------------------------------------------
 # Test cases

--- a/pymtl3/stdlib/fl/MemoryFL.py
+++ b/pymtl3/stdlib/fl/MemoryFL.py
@@ -22,7 +22,7 @@ class MemoryFL( Component ):
     s.ifc = MemMinionIfcFL( s.read, s.write, s.amo )
 
     s.trace = "     "
-    @s.update
+    @update
     def up_clear_trace():
       s.trace = "     "
 

--- a/pymtl3/stdlib/ifcs/GetGiveIfc.py
+++ b/pymtl3/stdlib/ifcs/GetGiveIfc.py
@@ -34,7 +34,7 @@ class And( Component ):
     s.in1 = InPort( Type )
     s.out = OutPort( Type )
 
-    @s.update
+    @update
     def up_and():
       s.out = s.in0 & s.in1
 
@@ -69,7 +69,7 @@ class GiveIfcRTL( CalleeIfcRTL ):
     elif isinstance( other, CalleeIfcCL ):
       if s._dsl.level <= other._dsl.level:
         raise InvalidConnectionError(
-            "CL2RTL connection is not supported between RecvIfcRTL"
+            "CL2RTL connection is not supported between GiveIfcRTL"
             " and CalleeIfcCL.\n"
             "          - level {}: {} (class {})\n"
             "          - level {}: {} (class {})".format(
@@ -134,14 +134,14 @@ class GetRTL2GiveCL( Component ):
 
     s.entry = None
 
-    @s.update
+    @update
     def up_get_rtl():
       if s.entry is None and s.get.rdy:
         s.get.en = b1(1)
       else:
         s.get.en = b1(0)
 
-    @s.update
+    @update
     def up_entry():
       if s.get.en:
         s.entry = deepcopy( s.get.msg )

--- a/pymtl3/stdlib/ifcs/SendRecvIfc.py
+++ b/pymtl3/stdlib/ifcs/SendRecvIfc.py
@@ -167,12 +167,12 @@ class RecvCL2SendRTL( Component ):
 
     s.entry = None
 
-    @s.update
+    @update
     def up_clear():
       if s.send.en: # constraints reverse this
         s.entry = None
 
-    @s.update
+    @update
     def up_send_rtl():
       if s.entry is None:
         s.send.en  = b1( 0 )
@@ -212,12 +212,12 @@ class RecvRTL2SendCL( Component ):
     s.sent_msg = None
     s.send_rdy = False
 
-    @s.update
+    @update
     def up_recv_rtl_rdy():
       s.send_rdy = s.send.rdy() and not s.reset
       s.recv.rdy = b1( 1 ) if s.send.rdy() and not s.reset else b1( 0 )
 
-    @s.update
+    @update
     def up_send_cl():
       s.sent_msg = None
       if s.recv.en:

--- a/pymtl3/stdlib/ifcs/xcel_ifcs.py
+++ b/pymtl3/stdlib/ifcs/xcel_ifcs.py
@@ -194,7 +194,7 @@ class XcelIfcCL2FLAdapter( Component ):
     s.right = XcelMasterIfcFL()
     s.entry = None
 
-    @s.update
+    @update
     def up_xcelifc_cl_fl_blk():
 
       if s.entry is not None and s.left.resp.rdy():
@@ -282,7 +282,7 @@ class XcelIfcRTL2FLAdapter( Component ):
     s.req_q = NormalQueueRTL( ReqType, num_entries=1 )
     connect( s.left.req, s.req_q.enq )
 
-    @s.update
+    @update
     def up_xcelifc_rtl_fl_blk():
 
       if s.req_q.deq.rdy and s.left.resp.rdy:

--- a/pymtl3/stdlib/rtl/Crossbar.py
+++ b/pymtl3/stdlib/rtl/Crossbar.py
@@ -17,7 +17,7 @@ class Crossbar( Component ):
     s.out = [ OutPort ( dtype )     for _ in range( nports ) ]
     s.sel = [ InPort  ( mk_bits( sel_nbits ) ) for _ in range( nports ) ]
 
-    @s.update
+    @update
     def comb_logic():
 
       for i in range( nports ):

--- a/pymtl3/stdlib/rtl/Encoder.py
+++ b/pymtl3/stdlib/rtl/Encoder.py
@@ -28,7 +28,7 @@ class Encoder( Component ):
 
     # Logic
 
-    @s.update
+    @update
     def encode():
       s.out = OutType( 0 )
       for i in range( s.in_nbits ):

--- a/pymtl3/stdlib/rtl/RegisterFile.py
+++ b/pymtl3/stdlib/rtl/RegisterFile.py
@@ -17,19 +17,19 @@ class RegisterFile( Component ):
 
     s.regs = [ Wire( Type ) for i in range(nregs) ]
 
-    @s.update
+    @update
     def up_rf_read():
       for i in range( rd_ports ):
         s.rdata[i] = s.regs[ s.raddr[i] ]
 
     if const_zero:
-      @s.update_ff
+      @update_ff
       def up_rf_write_constzero():
         for i in range( wr_ports ):
           if s.wen[i] & (s.waddr[i] != addr_type(0)):
             s.regs[ s.waddr[i] ] <<= s.wdata[i]
     else:
-      @s.update_ff
+      @update_ff
       def up_rf_write():
         for i in range( wr_ports ):
           if s.wen[i]:

--- a/pymtl3/stdlib/rtl/arbiters.py
+++ b/pymtl3/stdlib/rtl/arbiters.py
@@ -44,7 +44,7 @@ class RoundRobinArbiter( Component ):
     # comb_reqs_int
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_reqs_int():
 
       s.reqs_int [    0:nreqs  ] = s.reqs
@@ -54,7 +54,7 @@ class RoundRobinArbiter( Component ):
     # comb_grants
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_grants():
 
       # Assign the output ports
@@ -65,7 +65,7 @@ class RoundRobinArbiter( Component ):
     # comb_priority_en
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_priority_en():
 
       # Set the priority enable
@@ -75,7 +75,7 @@ class RoundRobinArbiter( Component ):
     # comb_priority_int
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_priority_int():
 
       s.priority_int[    0:nreqs  ] = s.priority_reg.out
@@ -85,7 +85,7 @@ class RoundRobinArbiter( Component ):
     # comb_kills
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_kills():
 
       # Set kill signals
@@ -104,7 +104,7 @@ class RoundRobinArbiter( Component ):
     # comb_grants_int
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_grants_int():
 
       for i in range( nreqsX2 ):
@@ -160,7 +160,7 @@ class RoundRobinArbiterEn( Component ):
     # comb_reqs_int
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_reqs_int():
 
       s.reqs_int [    0:nreqs  ] = s.reqs
@@ -170,7 +170,7 @@ class RoundRobinArbiterEn( Component ):
     # comb_grants
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_grants():
 
       # Assign the output ports
@@ -181,7 +181,7 @@ class RoundRobinArbiterEn( Component ):
     # comb_priority_en
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_priority_en():
 
       # Set the priority enable
@@ -191,7 +191,7 @@ class RoundRobinArbiterEn( Component ):
     # comb_priority_int
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_priority_int():
 
       s.priority_int[    0:nreqs  ] = s.priority_reg.out
@@ -201,7 +201,7 @@ class RoundRobinArbiterEn( Component ):
     # comb_kills
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_kills():
 
       # Set kill signals
@@ -220,7 +220,7 @@ class RoundRobinArbiterEn( Component ):
     # comb_grants_int
     #-------------------------------------------------------------------
 
-    @s.update
+    @update
     def comb_grants_int():
 
       for i in range( nreqsX2 ):

--- a/pymtl3/stdlib/rtl/arithmetics.py
+++ b/pymtl3/stdlib/rtl/arithmetics.py
@@ -9,7 +9,7 @@ class Mux( Component ):
     s.sel = InPort( int if Type is int else mk_bits( clog2(ninputs) ) )
     s.out = OutPort( Type )
 
-    @s.update
+    @update
     def up_mux():
       s.out = s.in_[ s.sel ]
 
@@ -22,7 +22,7 @@ class RightLogicalShifter( Component ):
     s.shamt = InPort( int if Type is int else mk_bits( shamt_nbits ) )
     s.out   = OutPort( Type )
 
-    @s.update
+    @update
     def up_rshifter():
       s.out = s.in_ >> s.shamt
 
@@ -35,7 +35,7 @@ class LeftLogicalShifter( Component ):
     s.shamt = InPort( int if Type is int else mk_bits( shamt_nbits ) )
     s.out   = OutPort( Type )
 
-    @s.update
+    @update
     def up_lshifter():
       s.out = s.in_ << s.shamt
 
@@ -47,7 +47,7 @@ class Incrementer( Component ):
     s.in_ = InPort( Type )
     s.out = OutPort( Type )
 
-    @s.update
+    @update
     def up_incrementer():
       s.out = s.in_ + Type(amount)
 
@@ -60,7 +60,7 @@ class Adder( Component ):
     s.in1 = InPort( Type )
     s.out = OutPort( Type )
 
-    @s.update
+    @update
     def up_adder():
       s.out = s.in0 + s.in1
 
@@ -73,7 +73,7 @@ class And( Component ):
     s.in1 = InPort( Type )
     s.out = OutPort( Type )
 
-    @s.update
+    @update
     def up_and():
       s.out = s.in0 & s.in1
 
@@ -86,7 +86,7 @@ class Subtractor( Component ):
     s.in1 = InPort( Type )
     s.out = OutPort( Type )
 
-    @s.update
+    @update
     def up_subtractor():
       s.out = s.in0 - s.in1
 
@@ -98,7 +98,7 @@ class ZeroComparator( Component ):
     s.in_ = InPort( Type )
     s.out = OutPort( bool if Type is int else Bits1 )
 
-    @s.update
+    @update
     def up_zerocomp():
       # s.out = Bits1( s.in_ == Type(0) )
       s.out = s.in_ == Type(0)
@@ -112,7 +112,7 @@ class LTComparator( Component ):
     s.in1 = InPort( Type )
     s.out = OutPort( bool if Type is int else Bits1 )
 
-    @s.update
+    @update
     def up_ltcomp():
       s.out = Bits1(s.in0 < s.in1)
 
@@ -125,6 +125,6 @@ class LEComparator( Component ):
     s.in1 = InPort( Type )
     s.out = OutPort( bool if Type is int else Bits1 )
 
-    @s.update
+    @update
     def up_lecomp():
       s.out = Bits1(s.in0 <= s.in1)

--- a/pymtl3/stdlib/rtl/enrdy_queues.py
+++ b/pymtl3/stdlib/rtl/enrdy_queues.py
@@ -19,15 +19,19 @@ class PipeQueue1RTL( Component ):
     s.enq = RecvIfcRTL( Type )
     s.deq = SendIfcRTL( Type )
 
-    s.buffer  = RegEn( Type )( en = s.enq.en, in_ = s.enq.msg, out = s.deq.msg )
+    s.buffer = m = RegEn( Type )
+    m.en  //= s.enq.en
+    m.in_ //= s.enq.msg
+    m.out //= s.deq.msg
+
     s.full = Reg( Bits1 )
 
-    @s.update
+    @update
     def up_pipeq_use_deq_rdy():
       s.deq.en  =  s.full.out & s.deq.rdy
       s.enq.rdy = ~s.full.out | s.deq.rdy
 
-    @s.update
+    @update
     def up_pipeq_full():
       s.full.in_ = s.enq.en | (s.full.out & ~s.deq.rdy )
 
@@ -40,22 +44,22 @@ class BypassQueue1RTL( Component ):
     s.enq = RecvIfcRTL( Type )
     s.deq = SendIfcRTL( Type )
 
-    s.buffer  = RegEn( Type )( in_ = s.enq.msg )
+    s.buffer = RegEn( Type )
+    s.buffer.in_ //= s.enq.msg
 
     s.full = RegRst( Bits1, reset_value = 0 )
 
-    s.byp_mux = Mux( Type, 2 )(
-      out = s.deq.msg,
-      in_ = { 0: s.enq.msg,
-              1: s.buffer.out, },
-      sel = s.full.out, # full -- buffer.out, empty -- bypass
-    )
+    s.byp_mux = m = Mux( Type, 2 )
+    m.out    //= s.deq.msg
+    m.in_[0] //= s.enq.msg
+    m.in_[1] //= s.buffer.out
+    m.sel    //= s.full.out # full -- buffer.out, empty -- bypass
 
-    @s.update
+    @update
     def up_bypq_set_enq_rdy():
       s.enq.rdy = ~s.full.out
 
-    @s.update
+    @update
     def up_bypq_use_enq_en():
       s.deq.en   = (s.enq.en | s.full.out) & s.deq.rdy
       s.buffer.en   =  s.enq.en & ~s.deq.en
@@ -70,8 +74,12 @@ class BypassQueue2RTL( Component ):
     assert queue_size == 2
     s.enq = RecvIfcRTL( MsgType )
     s.deq = SendIfcRTL( MsgType )
-    s.q1 = BypassQueue1RTL( MsgType )( enq = s.enq )
-    s.q2 = BypassQueue1RTL( MsgType )( enq = s.q1.deq, deq = s.deq )
+    s.q1 = BypassQueue1RTL( MsgType )
+    s.q2 = BypassQueue1RTL( MsgType )
+
+    s.enq    //= s.q1.enq
+    s.q1.deq //= s.q2.enq
+    s.q2.deq //= s.deq
 
   def line_trace( s ):
     return "{}({}){}".format( s.enq, s.q1.deq, s.deq )
@@ -84,14 +92,17 @@ class NormalQueue1RTL( Component ):
 
     # Now since enq.en depends on enq.rdy, enq.en == 1 actually means
     # we will enq some stuff
-    s.buffer  = RegEn( Type )( en = s.enq.en, in_ = s.enq.msg, out = s.deq.msg )
+    s.buffer = m = RegEn( Type )
+    m.en  //= s.enq.en
+    m.in_ //= s.enq.msg
+    m.out //= s.deq.msg
     s.full = Reg( Bits1 )
 
-    @s.update
+    @update
     def up_normq_set_enq_rdy():
       s.enq.rdy = ~s.full.out
 
-    @s.update
+    @update
     def up_normq_full():
       # When the bufferf is full and deq side is ready, we enable deq
       s.deq.en = s.full.out & s.deq.rdy

--- a/pymtl3/stdlib/rtl/enrdy_queues_test.py
+++ b/pymtl3/stdlib/rtl/enrdy_queues_test.py
@@ -9,7 +9,7 @@ Date   : Mar 9, 2018
 import pytest
 
 from pymtl3 import *
-from pymtl3.stdlib.test import TestSinkCL, TestSrcCL
+from pymtl3.stdlib.test import TestSinkCL, TestSrcCL, run_sim
 
 from .enrdy_queues import *
 
@@ -37,23 +37,6 @@ class TestHarness( Component ):
 
   def line_trace(s ):
     return s.src.line_trace() + " " + s.q.line_trace() + " " + s.sink.line_trace()
-
-def run_sim( model ):
-  model.apply( SimulationPass() )
-
-  print()
-  cycle = 0
-  while not model.done() and cycle < 1000:
-    model.tick()
-    print( "{:3}: {}".format( cycle, model.line_trace() ) )
-    cycle += 1
-
-  assert cycle < 1000
-
-  model.tick()
-  model.tick()
-  model.tick()
-
 
 F = lambda x: Bits32(x)
 

--- a/pymtl3/stdlib/rtl/queues.py
+++ b/pymtl3/stdlib/rtl/queues.py
@@ -33,13 +33,12 @@ class NormalQueueDpathRTL( Component ):
 
     # Component
 
-    s.queue = RegisterFile( EntryType, num_entries )(
-      raddr = { 0: s.raddr   },
-      rdata = { 0: s.deq_ret },
-      wen   = { 0: s.wen     },
-      waddr = { 0: s.waddr   },
-      wdata = { 0: s.enq_msg },
-    )
+    s.queue = m = RegisterFile( EntryType, num_entries )
+    m.raddr[0] //= s.raddr
+    m.rdata[0] //= s.deq_ret
+    m.wen[0]   //= s.wen
+    m.waddr[0] //= s.waddr
+    m.wdata[0] //= s.enq_msg
 
 class NormalQueueCtrlRTL( Component ):
 
@@ -88,7 +87,7 @@ class NormalQueueCtrlRTL( Component ):
     s.enq_xfer //= lambda: s.enq_en & s.enq_rdy
     s.deq_xfer //= lambda: s.deq_en & s.deq_rdy
 
-    @s.update_ff
+    @update_ff
     def up_reg():
 
       if s.reset:
@@ -207,7 +206,7 @@ class PipeQueueCtrlRTL( Component ):
     s.enq_xfer //= lambda: s.enq_en & s.enq_rdy
     s.deq_xfer //= lambda: s.deq_en & s.deq_rdy
 
-    @s.update_ff
+    @update_ff
     def up_reg():
 
       if s.reset:
@@ -295,18 +294,17 @@ class BypassQueueDpathRTL( Component ):
 
     # Component
 
-    s.queue = RegisterFile( EntryType, num_entries )(
-      raddr = { 0: s.raddr   },
-      wen   = { 0: s.wen     },
-      waddr = { 0: s.waddr   },
-      wdata = { 0: s.enq_msg },
-    )
+    s.queue = m = RegisterFile( EntryType, num_entries )
+    m.raddr[0] //= s.raddr
+    m.wen[0]   //= s.wen
+    m.waddr[0] //= s.waddr
+    m.wdata[0] //= s.enq_msg
 
-    s.mux = Mux( EntryType, 2 )(
-      sel = s.mux_sel,
-      in_ = { 0: s.queue.rdata[0], 1: s.enq_msg },
-      out = s.deq_ret,
-    )
+    s.mux = m = Mux( EntryType, 2 )
+    m.sel    //= s.mux_sel
+    m.in_[0] //= s.queue.rdata[0]
+    m.in_[1] //= s.enq_msg
+    m.out    //= s.deq_ret
 
 class BypassQueueCtrlRTL( Component ):
 
@@ -358,7 +356,7 @@ class BypassQueueCtrlRTL( Component ):
     s.enq_xfer //= lambda: s.enq_en & s.enq_rdy
     s.deq_xfer //= lambda: s.deq_en & s.deq_rdy
 
-    @s.update_ff
+    @update_ff
     def up_reg():
 
       if s.reset:
@@ -455,7 +453,7 @@ class NormalQueue1EntryRTL( Component ):
     s.enq.rdy //= lambda: ~s.reset & ~s.full
     s.deq.rdy //= lambda: ~s.reset & s.full
 
-    @s.update_ff
+    @update_ff
     def ff_normal1():
       s.full <<= ~s.reset & ( ~s.deq.en & (s.enq.en | s.full) )
       if s.enq.en:
@@ -492,7 +490,7 @@ class PipeQueue1EntryRTL( Component ):
     s.enq.rdy //= lambda: ~s.reset & ( ~s.full | s.deq.en )
     s.deq.rdy //= lambda: s.full & ~s.reset
 
-    @s.update_ff
+    @update_ff
     def ff_pipe1():
       s.full <<= ~s.reset & ( s.enq.en | s.full & ~s.deq.en )
 
@@ -521,11 +519,11 @@ class BypassQueue1EntryRTL( Component ):
     s.entry = Wire( EntryType )
     s.full  = Wire( Bits1 )
 
-    s.bypass_mux = Mux( EntryType, 2 )(
-      in_ = { 0: s.enq.msg, 1: s.entry },
-      out = s.deq.ret,
-      sel = s.full,
-    )
+    s.bypass_mux = m = Mux( EntryType, 2 )
+    m.in_[0] //= s.enq.msg
+    m.in_[1] //= s.entry
+    m.out    //= s.deq.ret
+    m.sel    //= s.full
 
     # Logic
 
@@ -534,7 +532,7 @@ class BypassQueue1EntryRTL( Component ):
     s.enq.rdy //= lambda: ~s.reset & ~s.full
     s.deq.rdy //= lambda: ~s.reset & ( s.full | s.enq.en )
 
-    @s.update_ff
+    @update_ff
     def ff_bypass1():
       s.full <<= ~s.reset & ( ~s.deq.en & (s.enq.en | s.full) )
 

--- a/pymtl3/stdlib/rtl/queues_test.py
+++ b/pymtl3/stdlib/rtl/queues_test.py
@@ -11,9 +11,7 @@ from itertools import product
 import pytest
 
 from pymtl3 import *
-from pymtl3.stdlib.test import TestVectorSimulator
-from pymtl3.stdlib.test.test_sinks import TestSinkRTL
-from pymtl3.stdlib.test.test_srcs import TestSrcCL
+from pymtl3.stdlib.test import TestSinkCL, TestSrcCL, TestVectorSimulator, run_sim
 
 from .queues import (
     BypassQueue1EntryRTL,
@@ -75,10 +73,18 @@ class TestHarness( Component ):
 
     s.src  = TestSrcCL ( MsgType, src_msgs )
     s.dut  = QType( MsgType )
-    s.sink = TestSinkRTL( MsgType, sink_msgs )
 
-    connect( s.src.send, s.dut.enq   )
-    connect( s.dut.deq,  s.sink.recv )
+    s.sink = TestSinkCL( MsgType, sink_msgs )
+
+    connect( s.src.send, s.dut.enq )
+
+    @update
+    def dut2sink():
+      s.dut.deq.en = b1(0)
+
+      if s.dut.deq.rdy and s.sink.recv.rdy():
+        s.dut.deq.en = b1(1)
+        s.sink.recv( s.dut.deq.ret )
 
   def done( s ):
     return s.src.done() and s.sink.done()
@@ -86,33 +92,6 @@ class TestHarness( Component ):
   def line_trace( s ):
     return "{} ({}) {}".format(
       s.src.line_trace(), s.dut.line_trace(), s.sink.line_trace() )
-
-#-------------------------------------------------------------------------
-# run_sim
-#-------------------------------------------------------------------------
-
-def run_sim( th, max_cycles=100 ):
-
-  # Create a simulator
-
-  th.apply( SimulationPass() )
-  th.sim_reset()
-
-  print("")
-  ncycles = 0
-  print("{:2}:{}".format( ncycles, th.line_trace() ))
-  while not th.done() and ncycles < max_cycles:
-    th.tick()
-    ncycles += 1
-    print("{:2}:{}".format( ncycles, th.line_trace() ))
-
-  # Check timeout
-
-  assert ncycles < max_cycles
-
-  th.tick()
-  th.tick()
-  th.tick()
 
 #-------------------------------------------------------------------------
 # Test cases
@@ -129,49 +108,49 @@ def test_normal1_simple():
   th = TestHarness( Bits16, NormalQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.sink.construct", arrival_time = arrival_normal )
   th.set_param( "top.dut.construct", num_entries = 1 )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )
 
 def test_normal2_simple():
   th = TestHarness( Bits16, NormalQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.sink.construct", arrival_time = arrival_pipe )
   th.set_param( "top.dut.construct", num_entries = 2 )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )
 
 def test_pipe1_simple():
   th = TestHarness( Bits16, PipeQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.sink.construct", arrival_time = arrival_pipe )
   th.set_param( "top.dut.construct", num_entries = 1 )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )
 
 def test_pipe1_backpressure():
   th = TestHarness( Bits16, PipeQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.sink.construct", initial_delay = 20 )
   th.set_param( "top.dut.construct", num_entries = 1 )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )
 
 def test_pipe2_backpressure():
   th = TestHarness( Bits16, PipeQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.sink.construct", initial_delay = 20 )
   th.set_param( "top.dut.construct", num_entries = 2 )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )
 
 def test_bypass1_simple():
   th = TestHarness( Bits16, BypassQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.sink.construct", arrival_time = arrival_bypass )
   th.set_param( "top.dut.construct", num_entries = 1 )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )
 
 def test_bypass1_backpressure():
   th = TestHarness( Bits16, BypassQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.sink.construct", initial_delay = 20 )
   th.set_param( "top.dut.construct", num_entries = 1 )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )
 
 def test_bypass2_sparse():
   th = TestHarness( Bits16, BypassQueueRTL, test_msgs, test_msgs )
   th.set_param( "top.src.construct", interval_delay = 3 )
   th.set_param( "top.dut.construct", num_entries = 2 )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )
 
 @pytest.mark.parametrize(
   'QType, num_entries',
@@ -182,14 +161,14 @@ def test_large_backpressure( QType, num_entries ):
   th = TestHarness( Bits16, QType, msgs, msgs )
   th.set_param( "top.sink.construct", initial_delay = 20 )
   th.set_param( "top.dut.construct", num_entries = 16 )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )
 
 @pytest.mark.parametrize(
   'QType', [ NormalQueue1EntryRTL, PipeQueue1EntryRTL, BypassQueue1EntryRTL ]
 )
 def test_single_simple( QType ):
   th = TestHarness( Bits16, QType, test_msgs, test_msgs )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )
 
 @pytest.mark.parametrize(
   'QType', [ NormalQueue1EntryRTL, PipeQueue1EntryRTL, BypassQueue1EntryRTL ]
@@ -197,4 +176,4 @@ def test_single_simple( QType ):
 def test_single_backpressure( QType ):
   th = TestHarness( Bits16, QType, test_msgs, test_msgs )
   th.set_param( "top.sink.construct", initial_delay = 10, interval_delay=2 )
-  run_sim( th )
+  run_sim( th, max_cycles=500 )

--- a/pymtl3/stdlib/rtl/registers.py
+++ b/pymtl3/stdlib/rtl/registers.py
@@ -7,7 +7,7 @@ class Reg( Component ):
     s.out = OutPort( Type )
     s.in_ = InPort( Type )
 
-    @s.update_ff
+    @update_ff
     def up_reg():
       s.out <<= s.in_
 
@@ -22,7 +22,7 @@ class RegEn( Component ):
 
     s.en  = InPort( int if Type is int else Bits1 )
 
-    @s.update_ff
+    @update_ff
     def up_regen():
       if s.en:
         s.out <<= s.in_
@@ -38,7 +38,7 @@ class RegRst( Component ):
 
     s.reset = InPort( int if Type is int else Bits1 )
 
-    @s.update_ff
+    @update_ff
     def up_regrst():
       if s.reset: s.out <<= Type( reset_value )
       else:       s.out <<= s.in_
@@ -55,7 +55,7 @@ class RegEnRst( Component ):
     s.reset = InPort( int if Type is int else Bits1 )
     s.en    = InPort( int if Type is int else Bits1 )
 
-    @s.update_ff
+    @update_ff
     def up_regenrst():
       if s.reset: s.out <<= Type( reset_value )
       elif s.en:  s.out <<= s.in_

--- a/pymtl3/stdlib/test/test_sinks.py
+++ b/pymtl3/stdlib/test/test_sinks.py
@@ -41,7 +41,7 @@ class TestSinkCL( Component ):
 
     s.recv_called = False
 
-    @s.update
+    @update
     def up_sink_count():
       # Raise exception at the start of next cycle so that the errored
       # line trace gets printed out

--- a/pymtl3/stdlib/test/test_srcs.py
+++ b/pymtl3/stdlib/test/test_srcs.py
@@ -26,7 +26,7 @@ class TestSrcCL( Component ):
     s.count  = initial_delay
     s.delay  = interval_delay
 
-    @s.update
+    @update
     def up_src_send():
       if s.count > 0:
         s.count -= 1


### PR DESCRIPTION
This PR implements four important syntax changes:

- `__call__` connection is deprecated. This is somewhat convenient but the keyword argument approach doesn't work for cases when we need to connect individual ports in the interface.
- Signal now only takes Bits or bitstruct type. We used to allow arbitrary type but throughout the practice we don't find creating Wire(int) very useful.
- Signal now allows taking a single integer N as a shortcut for mk_bits(N). This might avoid a lot of mk_bits calls ... 
- Support `@update` and @update_ff. Dropping @s.update.