### PR TITLE
Verilog translation bug fix

### DIFF
--- a/pymtl3/passes/backends/verilog/errors.py
+++ b/pymtl3/passes/backends/verilog/errors.py
@@ -49,6 +49,12 @@ class VerilogTranslationError( Exception ):
     return super().__init__(
       f"\nIn file {fname}, Line {line}, Col {col}:{code}\n- {msg}" )
 
+class VerilogStructuralTranslationError( Exception ):
+  """SystemVerilog translation error."""
+  def __init__( self, obj, msg ):
+    return super().__init__(
+      f"\nError while performing structural translation on {obj}\n- {msg}" )
+
 class VerilogReservedKeywordError( Exception ):
   """SystemVerilog reserved keyword error."""
   def __init__( self, name, msg ):

--- a/pymtl3/passes/backends/verilog/translation/VTranslator.py
+++ b/pymtl3/passes/backends/verilog/translation/VTranslator.py
@@ -8,8 +8,8 @@
 from collections import deque
 
 from pymtl3.passes.backends.generic import RTLIRTranslator
-from pymtl3.passes.backends.verilog.util.utility import verilog_reserved
 from pymtl3.passes.backends.verilog.errors import VerilogStructuralTranslationError
+from pymtl3.passes.backends.verilog.util.utility import verilog_reserved
 
 from .behavioral import VBehavioralTranslator as V_BTranslator
 from .structural import VStructuralTranslator as V_STranslator

--- a/pymtl3/passes/backends/verilog/translation/VTranslator.py
+++ b/pymtl3/passes/backends/verilog/translation/VTranslator.py
@@ -9,6 +9,7 @@ from collections import deque
 
 from pymtl3.passes.backends.generic import RTLIRTranslator
 from pymtl3.passes.backends.verilog.util.utility import verilog_reserved
+from pymtl3.passes.backends.verilog.errors import VerilogStructuralTranslationError
 
 from .behavioral import VBehavioralTranslator as V_BTranslator
 from .structural import VStructuralTranslator as V_STranslator
@@ -42,6 +43,15 @@ def mk_VTranslator( _RTLIRTranslator, _STranslator, _BTranslator ):
       s._rtlir_tr_unpacked_q = deque()
 
     def rtlir_tr_src_layout( s, hierarchy ):
+      # Sanity check on BitStructs
+      all_structs = list(map(lambda x: x[0], hierarchy.decl_type_struct))
+      all_struct_names = list(map(lambda x: x.cls.__name__, all_structs))
+      for struct in all_structs:
+        for field_name in struct.get_all_properties().keys():
+          if field_name in all_struct_names:
+            raise VerilogStructuralTranslationError(struct,
+              f'field {field_name} has the same name as BitStruct type {field_name}!')
+
       s.set_header()
       name = s._top_module_full_name
       ret = s.header.format( **locals() )

--- a/pymtl3/passes/backends/verilog/translation/behavioral/VBehavioralTranslatorL2.py
+++ b/pymtl3/passes/backends/verilog/translation/behavioral/VBehavioralTranslatorL2.py
@@ -130,11 +130,12 @@ class BehavioralRTLIRToVVisitorL2( BehavioralRTLIRToVVisitorL1 ):
 
     begin    = ' begin' if len( node.body ) > 1 else ''
 
-    cmp_op   = '<' if node.step.value > 0 else '<'
-    inc_op   = '+' if node.step.value > 0 else '-'
+    cmp_op   = '>' if node.step._value[31] else '<'
+    inc_op   = '-' if node.step._value[31] else '+'
 
     step_abs = s.visit( node.step )
-    step_abs = step_abs if node.step.value > 0 else step_abs[ 1 : ]
+    if node.step._value[31] and step_abs[0] == '-':
+      step_abs = step_abs[1:]
 
     for stmt in node.body:
       body.extend( s.visit( stmt ) )

--- a/pymtl3/passes/backends/verilog/translation/test/VTranslator_L2_cases_test.py
+++ b/pymtl3/passes/backends/verilog/translation/test/VTranslator_L2_cases_test.py
@@ -6,7 +6,9 @@
 import pytest
 
 from pymtl3.passes.backends.verilog.util.test_utility import check_eq
-from pymtl3.passes.rtlir.util.test_utility import get_parameter
+from pymtl3.passes.backends.verilog.errors import VerilogStructuralTranslationError
+from pymtl3.passes.rtlir.util.test_utility import get_parameter, expected_failure
+from pymtl3.passes.testcases import CaseTypeNameAsFieldNameComp
 
 from ...testcases import (
     CaseConnectPassThroughLongNameComp,
@@ -35,6 +37,10 @@ def test_verilog_L2( case ):
 def test_long_component_name():
   args = [ThisIsABitStructWithSuperLongName]*7
   run_test( CaseConnectPassThroughLongNameComp, CaseConnectPassThroughLongNameComp.DUT(*args) )
+
+def test_type_name_as_field_name():
+  with expected_failure( VerilogStructuralTranslationError, 'same name as BitStruct type' ):
+    run_test( CaseTypeNameAsFieldNameComp, CaseTypeNameAsFieldNameComp.DUT() )
 
 @pytest.mark.xfail(run=False, reason="TODO: resolving BitStructs according to name AND fields")
 def test_struct_uniqueness():

--- a/pymtl3/passes/backends/verilog/translation/test/VTranslator_L2_cases_test.py
+++ b/pymtl3/passes/backends/verilog/translation/test/VTranslator_L2_cases_test.py
@@ -5,9 +5,9 @@
 
 import pytest
 
-from pymtl3.passes.backends.verilog.util.test_utility import check_eq
 from pymtl3.passes.backends.verilog.errors import VerilogStructuralTranslationError
-from pymtl3.passes.rtlir.util.test_utility import get_parameter, expected_failure
+from pymtl3.passes.backends.verilog.util.test_utility import check_eq
+from pymtl3.passes.rtlir.util.test_utility import expected_failure, get_parameter
 from pymtl3.passes.testcases import CaseTypeNameAsFieldNameComp
 
 from ...testcases import (

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
@@ -27,12 +27,12 @@ from pymtl3.passes.testcases import (
     CaseConstSizeSlicingComp,
     CaseFlipFlopAdder,
     CaseForBasicComp,
+    CaseForFreeVarStepComp,
     CaseIfBasicComp,
     CaseReducesInx3OutComp,
     CaseSlicingOverIndexComp,
     CaseSubCompAddComp,
     CaseTwoUpblksSliceComp,
-    CaseForFreeVarStepComp
 )
 
 

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
@@ -46,8 +46,6 @@ def local_do_test( m ):
   m.apply( BehavioralRTLIRVisualizationPass() )
 
   for blk in m.get_update_blocks():
-    tmp = m._pass_behavioral_rtlir_gen.rtlir_upblks[blk]
-    re = ref[blk.__name__]
     assert\
       m._pass_behavioral_rtlir_gen.rtlir_upblks[ blk ] == ref[ blk.__name__ ]
 

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRPass_test.py
@@ -32,6 +32,7 @@ from pymtl3.passes.testcases import (
     CaseSlicingOverIndexComp,
     CaseSubCompAddComp,
     CaseTwoUpblksSliceComp,
+    CaseForFreeVarStepComp
 )
 
 
@@ -45,6 +46,8 @@ def local_do_test( m ):
   m.apply( BehavioralRTLIRVisualizationPass() )
 
   for blk in m.get_update_blocks():
+    tmp = m._pass_behavioral_rtlir_gen.rtlir_upblks[blk]
+    re = ref[blk.__name__]
     assert\
       m._pass_behavioral_rtlir_gen.rtlir_upblks[ blk ] == ref[ blk.__name__ ]
 
@@ -196,6 +199,23 @@ def test_for_basic( do_test ):
               BinOp( BinOp( twice_i, Add(), Number( 1 ) ), Add(), Number( 1 ) )
             )
           ),
+          True
+        )
+      ]
+    ) ] )
+  }
+
+  do_test( a )
+
+def test_for_freevar_step( do_test ):
+  a = CaseForFreeVarStepComp.DUT()
+
+  a._rtlir_test_ref = {
+    'upblk' : CombUpblk( 'upblk', [ For(
+      LoopVarDecl( 'i' ), Number( 0 ), Number( 2 ), FreeVar( 'freevar_at_upblk', 1 ),
+      [ Assign(
+          [Attribute( Base( a ), 'out' )],
+          Slice( Attribute( Base( a ), 'in_' ), Number(0), Number(8) ),
           True
         )
       ]

--- a/pymtl3/passes/rtlir/rtype/RTLIRDataType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRDataType.py
@@ -60,13 +60,15 @@ class Struct( BaseRTLIRDataType ):
     s.properties = properties
     s.cls = cls
     if cls is not None:
-      try:
-        file_name = inspect.getsourcefile( cls )
-        s.file_info = f"{file_name}"
-        # line_no = inspect.getsourcelines( cls )[1]
-        # s.file_info = f"{file_name}:{line_no}"
-      except OSError:
-        s.file_info = f"Dynamically generated class {cls.__name__}"
+      # try:
+      #   file_name = inspect.getsourcefile( cls )
+      #   s.file_info = f"{file_name}"
+      #   # line_no = inspect.getsourcelines( cls )[1]
+      #   # s.file_info = f"{file_name}:{line_no}"
+      # except OSError:
+      # With the current way of generating BitStructs it is no
+      # longer possible to report the file in which it was generated.
+      s.file_info = f"Dynamically generated class {cls.__name__}"
     else:
       s.file_info = "Not available"
 

--- a/pymtl3/passes/rtlir/rtype/RTLIRDataType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRDataType.py
@@ -67,7 +67,7 @@ class Struct( BaseRTLIRDataType ):
       # except OSError:
       # With the current way of generating BitStructs it is no
       # longer possible to report the file in which it was generated.
-      s.file_info = f"Dynamically generated class {cls.__name__}"
+      s.file_info = f"BitStruct {cls.__name__}"
     else:
       s.file_info = "Not available"
 

--- a/pymtl3/passes/rtlir/rtype/RTLIRDataType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRDataType.py
@@ -10,7 +10,6 @@ these type objects. Each instance of the type class defined in this module
 is a data type object or simply a data type. RTLIR instance type Signal
 can be parameterized by the generated type objects.
 """
-import inspect
 from functools import reduce
 
 import pymtl3.dsl as dsl

--- a/pymtl3/passes/testcases/test_cases.py
+++ b/pymtl3/passes/testcases/test_cases.py
@@ -97,6 +97,10 @@ class MultiDimPackedArrayStruct:
   inner: Bits32Bar
   packed_array: [ [ Bits16 ]*2 ] *3
 
+@bitstruct
+class StructTypeNameAsFieldName:
+  StructTypeNameAsFieldName: Bits32
+
 #-------------------------------------------------------------------------
 # Commonly used Interfaces
 #-------------------------------------------------------------------------
@@ -585,6 +589,24 @@ class CaseForBasicComp:
       def for_basic():
         for i in range( 8 ):
           s.out[ 2*i:2*i+1 ] = s.in_[ 2*i:2*i+1 ] + s.in_[ 2*i+1:(2*i+1)+1 ]
+
+class CaseForFreeVarStepComp:
+  class DUT( Component ):
+    def construct( s ):
+      s.in_ = InPort( Bits16 )
+      s.out = OutPort( Bits8 )
+      freevar = 1
+      @s.update
+      def upblk():
+        for i in range( 0, 2, freevar ):
+          s.out = s.in_[0:8]
+
+class CaseTypeNameAsFieldNameComp:
+  class DUT( Component ):
+    def construct( s ):
+      s.in_ = InPort( StructTypeNameAsFieldName )
+      s.out = OutPort( StructTypeNameAsFieldName )
+      s.in_ //= s.out
 
 class CaseForRangeLowerUpperStepPassThroughComp:
   class DUT( Component ):


### PR DESCRIPTION
1. Fixed a bug which occurs when a free variable is used as the step of for loop
2. Improved the translated BitStruct file info
3. Added a check which prevents BitStruct fields from using the names of BitStructs