### PR TITLE
Fix a translation bug of arrays of components

### DIFF
--- a/pymtl3/passes/backends/generic/structural/test/TestStructuralTranslator.py
+++ b/pymtl3/passes/backends/generic/structural/test/TestStructuralTranslator.py
@@ -154,7 +154,7 @@ def mk_TestStructuralTranslator( _StructuralTranslator ):
       return f'component_decls:{decls}\n'
 
     def rtlir_tr_subcomp_decl( s, m, c_id, c_rtype, c_array_type, port_conns, ifc_conns ):
-      c_rtype = repr(c_rtype) if not c_array_type else c_array_type
+      c_rtype = str(c_rtype) if not c_array_type else c_array_type
       ret = [f'component_decl: {c_id} {c_rtype}']
       for port in port_conns:
         make_indent( port, 1 )

--- a/pymtl3/passes/backends/verilog/testcases/test_cases.py
+++ b/pymtl3/passes/backends/verilog/testcases/test_cases.py
@@ -51,6 +51,7 @@ from pymtl3.passes.testcases import (
     CaseElifBranchComp,
     CaseFixedSizeSliceComp,
     CaseForRangeLowerUpperStepPassThroughComp,
+    CaseHeteroCompArrayComp,
     CaseIfBasicComp,
     CaseIfBoolOpInForStmtComp,
     CaseIfDanglingElseInnerComp,
@@ -2116,4 +2117,95 @@ CasePlaceholderTranslationRegIncr = set_attributes( CasePlaceholderTranslationRe
     'REF_PLACEHOLDER_DEPENDENCY',
     '''\
     ''',
+)
+
+CaseHeteroCompArrayComp = set_attributes( CaseHeteroCompArrayComp,
+    'REF_COMP',
+    '''\
+        logic [0:0] comps__clk [0:1] ;
+        logic [31:0] comps__in_ [0:1] ;
+        logic [31:0] comps__out [0:1] ;
+        logic [0:0] comps__reset [0:1] ;
+
+        Bits32DummyFooComp comps__0
+        (
+          .clk( comps__clk[0] ),
+          .in_( comps__in_[0] ),
+          .out( comps__out[0] ),
+          .reset( comps__reset[0] )
+        );
+
+        Bits32DummyBarComp comps__1
+        (
+          .clk( comps__clk[1] ),
+          .in_( comps__in_[1] ),
+          .out( comps__out[1] ),
+          .reset( comps__reset[1] )
+        );
+    ''',
+    'REF_SRC',
+    '''\
+        module Bits32DummyFooComp
+        (
+          input logic [0:0] clk,
+          input logic [31:0] in_,
+          output logic [31:0] out,
+          input logic [0:0] reset
+        );
+          assign out = in_;
+        endmodule
+
+        module Bits32DummyBarComp
+        (
+          input logic [0:0] clk,
+          input logic [31:0] in_,
+          output logic [31:0] out,
+          input logic [0:0] reset
+        );
+          always_comb begin : upblk
+            out = in_ + 32'd42;
+          end
+        endmodule
+
+        module DUT
+        (
+          input logic [0:0] clk,
+          input logic [31:0] in_1,
+          input logic [31:0] in_2,
+          output logic [31:0] out_1,
+          output logic [31:0] out_2,
+          input logic [0:0] reset
+        );
+          logic [0:0] comps__clk [0:1] ;
+          logic [31:0] comps__in_ [0:1] ;
+          logic [31:0] comps__out [0:1] ;
+          logic [0:0] comps__reset [0:1] ;
+
+          Bits32DummyFooComp comps__0
+          (
+            .clk( comps__clk[0] ),
+            .in_( comps__in_[0] ),
+            .out( comps__out[0] ),
+            .reset( comps__reset[0] )
+          );
+
+          Bits32DummyBarComp comps__1
+          (
+            .clk( comps__clk[1] ),
+            .in_( comps__in_[1] ),
+            .out( comps__out[1] ),
+            .reset( comps__reset[1] )
+          );
+
+          assign comps__clk[0] = clk;
+          assign comps__reset[0] = reset;
+          assign comps__clk[1] = clk;
+          assign comps__reset[1] = reset;
+          assign comps__in_[0] = in_1;
+          assign comps__in_[1] = in_2;
+          assign out_1 = comps__out[0];
+          assign out_2 = comps__out[1];
+
+        endmodule
+    '''
 )

--- a/pymtl3/passes/backends/verilog/translation/structural/VStructuralTranslatorL4.py
+++ b/pymtl3/passes/backends/verilog/translation/structural/VStructuralTranslatorL4.py
@@ -11,6 +11,7 @@ from pymtl3.passes.backends.generic.structural.StructuralTranslatorL4 import (
 )
 from pymtl3.passes.rtlir import RTLIRDataType as rdt
 from pymtl3.passes.rtlir import RTLIRType as rt
+from pymtl3.passes.rtlir import get_component_ifc_rtlir
 
 from ...util.utility import make_indent, pretty_concat
 from .VStructuralTranslatorL3 import VStructuralTranslatorL3
@@ -80,8 +81,6 @@ class VStructuralTranslatorL4(
 
   def rtlir_tr_subcomp_decl( s, m, c_id, c_rtype, c_array_type, port_conns, ifc_conns ):
 
-    _c_name = s.rtlir_tr_component_unique_name( c_rtype )
-
     def pretty_comment( string ):
       comments = [
           '  //-------------------------------------------------------------',
@@ -91,7 +90,7 @@ class VStructuralTranslatorL4(
       return '\n'.join(comments)
 
     def gen_subcomp_array_decl( c_id, port_conns, ifc_conns, n_dim, c_n_dim ):
-      nonlocal _c_name, m, s
+      nonlocal m, s
       tplt = dedent(
           """\
             {c_name} {c_id}
@@ -103,6 +102,9 @@ class VStructuralTranslatorL4(
         _n_dim = list(int(num_str) for num_str in c_n_dim.split('__') if num_str)
         attr = c_id + ''.join(f'[{dim}]' for dim in _n_dim)
         obj = eval(f'm.{attr}')
+        # Get the translated component name
+        obj_c_rtype = get_component_ifc_rtlir(obj)
+        _c_name = s.rtlir_tr_component_unique_name(obj_c_rtype)
 
         if isinstance(obj, Placeholder):
           c_name = obj.config_placeholder.pickled_top_module

--- a/pymtl3/passes/backends/verilog/translation/structural/test/VStructuralTranslatorL4_test.py
+++ b/pymtl3/passes/backends/verilog/translation/structural/test/VStructuralTranslatorL4_test.py
@@ -16,6 +16,7 @@ from ....testcases import (
     CaseBits32ArrayConnectSubCompAttrComp,
     CaseBits32ConnectSubCompAttrComp,
     CaseConnectArraySubCompArrayStructIfcComp,
+    CaseHeteroCompArrayComp,
 )
 from ..VStructuralTranslatorL4 import VStructuralTranslatorL4
 
@@ -36,6 +37,7 @@ def run_test( case, m ):
     CaseBits32ConnectSubCompAttrComp,
     CaseConnectArraySubCompArrayStructIfcComp,
     CaseBits32ArrayConnectSubCompAttrComp,
+    CaseHeteroCompArrayComp,
   ]
 )
 def test_verilog_structural_L4( case ):

--- a/pymtl3/passes/rtlir/rtype/RTLIRType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRType.py
@@ -365,8 +365,7 @@ class Component( BaseRTLIRType ):
     return hash((type(s), s.name, tuple(s.params)))
 
   def __str__( s ):
-    port_strs = ["{}:{}".format(name, repr(rtype)) for name, rtype in s.get_ports_packed()]
-    return f'Component with interface: {", ".join(port_strs)}'
+    return f'Component {s.name}'
 
   def __repr__( s ):
     port_strs = ["{}:{}".format(name, repr(rtype)) for name, rtype in s.get_ports_packed()]
@@ -479,7 +478,7 @@ def _handle_Array( _id, _obj ):
     return None
   ref_type = get_rtlir( obj[0] )
   assert all( get_rtlir(i) == ref_type for i in obj ), \
-    f'all elements of array {obj} must have the same type {ref_type}!'
+    f'all elements of array {obj} must have the same type {repr(ref_type)}!'
   dim_sizes = []
   while isinstance( obj, list ):
     if len( obj ) == 0:

--- a/pymtl3/passes/rtlir/rtype/RTLIRType.py
+++ b/pymtl3/passes/rtlir/rtype/RTLIRType.py
@@ -359,17 +359,18 @@ class Component( BaseRTLIRType ):
 
   def __eq__( s, other ):
     # Two Components are considered equal iff they expose the same interface
-    return isinstance(other, Component) and s.name == other.name and \
-           s._has_same_interface( other )
+    return isinstance(other, Component) and s._has_same_interface( other )
 
   def __hash__( s ):
     return hash((type(s), s.name, tuple(s.params)))
 
   def __str__( s ):
-    return 'Component'
+    port_strs = ["{}:{}".format(name, repr(rtype)) for name, rtype in s.get_ports_packed()]
+    return f'Component with interface: {", ".join(port_strs)}'
 
   def __repr__( s ):
-    return f'Component {s.name}'
+    port_strs = ["{}:{}".format(name, repr(rtype)) for name, rtype in s.get_ports_packed()]
+    return f'Component with interface: {", ".join(port_strs)}'
 
   def get_name( s ):
     return s.name

--- a/pymtl3/passes/testcases/test_cases.py
+++ b/pymtl3/passes/testcases/test_cases.py
@@ -237,6 +237,20 @@ class Bits32ArrayStructIfcComp( Component ):
     s.ifc = [ Bits32ArrayStructInIfc() for _ in range(1) ]
     connect( s.out, s.ifc[0].foo[0].foo )
 
+class Bits32DummyFooComp( Component ):
+  def construct( s ):
+    s.in_ = InPort( Bits32 )
+    s.out = OutPort( Bits32 )
+    connect( s.out, s.in_ )
+
+class Bits32DummyBarComp( Component ):
+  def construct( s ):
+    s.in_ = InPort( Bits32 )
+    s.out = OutPort( Bits32 )
+    @s.update
+    def upblk():
+      s.out = s.in_ + Bits32(42)
+
 #-------------------------------------------------------------------------
 # Test Components
 #-------------------------------------------------------------------------
@@ -974,6 +988,20 @@ class CaseScopeTmpWireOverwriteConflictComp:
         else:
           u = s.in_2 + Bits16(1)
           s.out = u
+
+class CaseHeteroCompArrayComp:
+  class DUT( Component ):
+    def construct( s ):
+      s.in_1 = InPort( Bits32 )
+      s.in_2 = InPort( Bits32 )
+      s.out_1 = OutPort( Bits32 )
+      s.out_2 = OutPort( Bits32 )
+      comp_types = [ Bits32DummyFooComp, Bits32DummyBarComp ]
+      s.comps = [ comp_types[i]() for i in range(2) ]
+      s.comps[0].in_ //= s.in_1
+      s.comps[1].in_ //= s.in_2
+      s.comps[0].out //= s.out_1
+      s.comps[1].out //= s.out_2
 
 #-------------------------------------------------------------------------
 # Test cases without errors

--- a/pymtl3/passes/testcases/test_cases.py
+++ b/pymtl3/passes/testcases/test_cases.py
@@ -1002,6 +1002,22 @@ class CaseHeteroCompArrayComp:
       s.comps[1].in_ //= s.in_2
       s.comps[0].out //= s.out_1
       s.comps[1].out //= s.out_2
+  TV_IN = \
+  _set(
+      'in_1', Bits32, 0,
+      'in_2', Bits32, 1,
+  )
+  TV_OUT = \
+  _check(
+      'out_1', Bits32, 2,
+      'out_2', Bits32, 3,
+  )
+  TEST_VECTOR = \
+  [
+      [    0,     -1,     0,    41],
+      [   42,      0,    42,    42],
+      [   -1,     42,    -1,    84],
+  ]
 
 #-------------------------------------------------------------------------
 # Test cases without errors


### PR DESCRIPTION
1. Fixed a bug where each element of a component array is not correctly translated
2. Now two `rt.Component` IR types are considered equal iff they have the same interface. This allows exotic heterogenous component arrays such as

 ```
  s.comps = [ HeteroCompTypes[i]() for i in range(N) ]
 ```
as long as each component type in `HeteroCompTypes` have the same interface.