### PR TITLE
Translation/import bug fix

### DIFF
--- a/pymtl3/passes/backends/verilog/VerilogPlaceholderPass.py
+++ b/pymtl3/passes/backends/verilog/VerilogPlaceholderPass.py
@@ -168,7 +168,7 @@ class VerilogPlaceholderPass( PlaceholderPass ):
     ports = [
       f"  {p.get_direction()} logic [{p.get_dtype().get_length()}-1:0]"\
       f" {name}{'' if idx == len(rtlir_ports)-1 else ','}" \
-      for idx, (_, name, p) in enumerate(rtlir_ports) if name
+      for idx, (_, name, p, _) in enumerate(rtlir_ports) if name
     ]
 
     # The wrapper has to have an unused clk port to make verilator
@@ -188,7 +188,7 @@ class VerilogPlaceholderPass( PlaceholderPass ):
     # Connections between top module and inner module
     connect_ports = [
       f"    .{name}( {name} ){'' if idx == len(rtlir_ports)-1 else ','}"\
-      for idx, (_, name, p) in enumerate(rtlir_ports) if name
+      for idx, (_, name, p, _) in enumerate(rtlir_ports) if name
     ]
 
     lines = [

--- a/pymtl3/passes/backends/verilog/import_/VerilatorImportPass.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilatorImportPass.py
@@ -713,7 +713,7 @@ m->{name}{sub} = {deference}model->{name}{sub};
 
   def gen_port_vector_input( s, lhs, rhs, mangled_rhs, dtype, symbols ):
     dtype_nbits = dtype.get_length()
-    blocks   = [ f's.{mangled_rhs} = Wire( Bits{dtype_nbits} )',
+    blocks   = [ f's.{mangled_rhs} = Wire( {s._gen_bits_decl(dtype_nbits)} )',
                  f'@s.update',
                  f'def isignal_{mangled_rhs}():',
                  f'  s.{mangled_rhs} = {rhs}' ]
@@ -727,7 +727,7 @@ m->{name}{sub} = {deference}model->{name}{sub};
     if dtype_name not in symbols:
       symbols[dtype_name] = dtype.get_class()
 
-    blocks   = [ f's.{mangled_rhs} = Wire( Bits{dtype_nbits} )',
+    blocks   = [ f's.{mangled_rhs} = Wire( {s._gen_bits_decl(dtype_nbits)} )',
                  f'@s.update',
                  f'def istruct_{mangled_rhs}():' ]
 
@@ -804,7 +804,7 @@ m->{name}{sub} = {deference}model->{name}{sub};
 
   def gen_port_vector_output( s, lhs, mangled_lhs, rhs, dtype, symbols ):
     dtype_nbits = dtype.get_length()
-    blocks   = [ f's.{mangled_lhs} = Wire( Bits{dtype_nbits} )',
+    blocks   = [ f's.{mangled_lhs} = Wire( {s._gen_bits_decl(dtype_nbits)} )',
                  f'@s.update',
                  f'def osignal_{mangled_lhs}():',
                  f'  {lhs} = s.{mangled_lhs}' ]
@@ -819,7 +819,7 @@ m->{name}{sub} = {deference}model->{name}{sub};
     if dtype_name not in symbols:
       symbols[dtype_name] = dtype.get_class()
 
-    blocks   = [ f's.{mangled_lhs} = Wire( Bits{dtype_nbits} )',
+    blocks   = [ f's.{mangled_lhs} = Wire( {s._gen_bits_decl(dtype_nbits)} )',
                  f'@s.update',
                  f'def ostruct_{mangled_lhs}():' ]
 
@@ -991,3 +991,9 @@ m->{name}{sub} = {deference}model->{name}{sub};
         _nbits = r - l
         ret.append( f"{lhs}[{l}:{r}] = Bits{_nbits}({rhs}[{idx}])" )
       return ret
+
+  def _gen_bits_decl( s, nbits ):
+    if nbits <= 256:
+      return f'Bits{nbits}'
+    else:
+      return f'mk_bits({nbits})'

--- a/pymtl3/passes/backends/verilog/import_/test/VNameMangle_test.py
+++ b/pymtl3/passes/backends/verilog/import_/test/VNameMangle_test.py
@@ -24,9 +24,9 @@ def test_port_single( do_test ):
       s.in_ = InPort( Bits32 )
   a = A()
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_'], 'in_', rt.Port('input', rdt.Vector(32)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_'], 'in_', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   a._ref_ports_yosys = a._ref_ports
   do_test( a )
@@ -37,16 +37,16 @@ def test_port_array( do_test ):
       s.in_ = [ InPort( Bits32 ) for _ in range( 3 ) ]
   a = A()
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_'], 'in_', rt.Array([3], rt.Port('input', rdt.Vector(32))) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_'], 'in_', rt.Array([3], rt.Port('input', rdt.Vector(32))), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   a._ref_ports_yosys = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_[0]'], 'in___0', rt.Port('input', rdt.Vector(32)) ),
-    ( ['in_[1]'], 'in___1', rt.Port('input', rdt.Vector(32)) ),
-    ( ['in_[2]'], 'in___2', rt.Port('input', rdt.Vector(32)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_[0]'], 'in___0', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['in_[1]'], 'in___1', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['in_[2]'], 'in___2', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   do_test( a )
 
@@ -56,19 +56,19 @@ def test_port_2d_array( do_test ):
       s.in_ = [ [ InPort( Bits32 ) for _ in range(2) ] for _ in range(3) ]
   a = A()
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_'], 'in_', rt.Array( [3, 2], rt.Port('input', rdt.Vector(32)) ) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
-  ]
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_'], 'in_', rt.Array( [3, 2], rt.Port('input', rdt.Vector(32)) ), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
+    ]
   a._ref_ports_yosys = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_[0][0]'], 'in___0__0', rt.Port('input', rdt.Vector(32)) ),
-    ( ['in_[0][1]'], 'in___0__1', rt.Port('input', rdt.Vector(32)) ),
-    ( ['in_[1][0]'], 'in___1__0', rt.Port('input', rdt.Vector(32)) ),
-    ( ['in_[1][1]'], 'in___1__1', rt.Port('input', rdt.Vector(32)) ),
-    ( ['in_[2][0]'], 'in___2__0', rt.Port('input', rdt.Vector(32)) ),
-    ( ['in_[2][1]'], 'in___2__1', rt.Port('input', rdt.Vector(32)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_[0][0]'], 'in___0__0', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['in_[0][1]'], 'in___0__1', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['in_[1][0]'], 'in___1__0', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['in_[1][1]'], 'in___1__1', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['in_[2][0]'], 'in___2__0', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['in_[2][1]'], 'in___2__1', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   do_test( a )
 
@@ -83,16 +83,16 @@ def test_struct_port_single( do_test ):
   a = A()
   st = rdt.Struct('struct', {'bar':rdt.Vector(32), 'foo':rdt.Vector(32)})
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_'], 'in_', rt.Port('input', st ) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_'], 'in_', rt.Port('input', st ), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   a._ref_ports_yosys = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_.bar'], 'in___bar', rt.Port('input', rdt.Vector(32) ) ),
-    ( ['in_.foo'], 'in___foo', rt.Port('input', rdt.Vector(32) ) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
-  ]
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_.bar'], 'in___bar', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_.foo'], 'in___foo', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
+    ]
   do_test( a )
 
 def test_struct_port_array( do_test ):
@@ -106,17 +106,17 @@ def test_struct_port_array( do_test ):
   a = A()
   st = rdt.Struct('struct', {'bar':rdt.Vector(32), 'foo':rdt.Vector(32)})
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_'], 'in_', rt.Array([2], rt.Port('input', st)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_'], 'in_', rt.Array([2], rt.Port('input', st)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   a._ref_ports_yosys = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_[0].bar'], 'in___0__bar', rt.Port('input', rdt.Vector(32) ) ),
-    ( ['in_[0].foo'], 'in___0__foo', rt.Port('input', rdt.Vector(32) ) ),
-    ( ['in_[1].bar'], 'in___1__bar', rt.Port('input', rdt.Vector(32) ) ),
-    ( ['in_[1].foo'], 'in___1__foo', rt.Port('input', rdt.Vector(32) ) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_[0].bar'], 'in___0__bar', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[0].foo'], 'in___0__foo', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].bar'], 'in___1__bar', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].foo'], 'in___1__foo', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   do_test( a )
 
@@ -132,27 +132,27 @@ def test_packed_array_port_array( do_test ):
   foo = rdt.PackedArray([3,2], rdt.Vector(32))
   st = rdt.Struct('struct', {'bar':rdt.Vector(32), 'foo':foo})
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_'], 'in_', rt.Array([2], rt.Port('input', st ))),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_'], 'in_', rt.Array([2], rt.Port('input', st)), 0),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   a._ref_ports_yosys = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_[0].bar'], 'in___0__bar', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[0].foo[0][0]'], 'in___0__foo__0__0', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[0].foo[0][1]'], 'in___0__foo__0__1', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[0].foo[1][0]'], 'in___0__foo__1__0', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[0].foo[1][1]'], 'in___0__foo__1__1', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[0].foo[2][0]'], 'in___0__foo__2__0', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[0].foo[2][1]'], 'in___0__foo__2__1', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[1].bar'], 'in___1__bar', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[1].foo[0][0]'], 'in___1__foo__0__0', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[1].foo[0][1]'], 'in___1__foo__0__1', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[1].foo[1][0]'], 'in___1__foo__1__0', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[1].foo[1][1]'], 'in___1__foo__1__1', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[1].foo[2][0]'], 'in___1__foo__2__0', rt.Port('input', rdt.Vector(32) )),
-    ( ['in_[1].foo[2][1]'], 'in___1__foo__2__1', rt.Port('input', rdt.Vector(32) )),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_[0].bar'], 'in___0__bar', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[0].foo[0][0]'], 'in___0__foo__0__0', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[0].foo[0][1]'], 'in___0__foo__0__1', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[0].foo[1][0]'], 'in___0__foo__1__0', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[0].foo[1][1]'], 'in___0__foo__1__1', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[0].foo[2][0]'], 'in___0__foo__2__0', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[0].foo[2][1]'], 'in___0__foo__2__1', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].bar'], 'in___1__bar', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].foo[0][0]'], 'in___1__foo__0__0', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].foo[0][1]'], 'in___1__foo__0__1', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].foo[1][0]'], 'in___1__foo__1__0', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].foo[1][1]'], 'in___1__foo__1__1', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].foo[2][0]'], 'in___1__foo__2__0', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].foo[2][1]'], 'in___1__foo__2__1', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   do_test( a )
 
@@ -171,17 +171,17 @@ def test_nested_struct( do_test ):
   inner = rdt.Struct('inner_struct', {'foo':rdt.Vector(32)})
   st = rdt.Struct('struct', {'bar':rdt.Vector(32), 'inner':inner})
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_'], 'in_', rt.Array([2], rt.Port('input', st )) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_'], 'in_', rt.Array([2], rt.Port('input', st )), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   a._ref_ports_yosys = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['in_[0].bar'], 'in___0__bar', rt.Port('input', rdt.Vector(32) ) ),
-    ( ['in_[0].inner.foo'], 'in___0__inner__foo', rt.Port('input', rdt.Vector(32) ) ),
-    ( ['in_[1].bar'], 'in___1__bar', rt.Port('input', rdt.Vector(32) ) ),
-    ( ['in_[1].inner.foo'], 'in___1__inner__foo', rt.Port('input', rdt.Vector(32) ) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['in_[0].bar'], 'in___0__bar', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[0].inner.foo'], 'in___0__inner__foo', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].bar'], 'in___1__bar', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['in_[1].inner.foo'], 'in___1__inner__foo', rt.Port('input', rdt.Vector(32) ), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   do_test( a )
 
@@ -196,11 +196,11 @@ def test_interface( do_test ):
       s.ifc = Ifc()
   a = A()
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) ),
-    ( ['ifc.msg'], 'ifc__msg', rt.Port('input', rdt.Vector(32)) ),
-    ( ['ifc.rdy'], 'ifc__rdy', rt.Port('output', rdt.Vector(1)) ),
-    ( ['ifc.val'], 'ifc__val', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['ifc.msg'], 'ifc__msg', rt.Port('input', rdt.Vector(32)), 0 ),
+    ( ['ifc.rdy'], 'ifc__rdy', rt.Port('output', rdt.Vector(1)), 0 ),
+    ( ['ifc.val'], 'ifc__val', rt.Port('input', rdt.Vector(1)), 0 ),
   ]
   a._ref_ports_yosys = a._ref_ports
   do_test( a )
@@ -216,21 +216,21 @@ def test_interface_array( do_test ):
       s.ifc = [ Ifc() for _ in range(2) ]
   a = A()
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) ),
-    ( ['ifc[0].msg', 'ifc[1].msg'], 'ifc__msg', rt.Array([2], rt.Port('input', rdt.Vector(32))) ),
-    ( ['ifc[0].rdy', 'ifc[1].rdy'], 'ifc__rdy', rt.Array([2], rt.Port('output', rdt.Vector(1))) ),
-    ( ['ifc[0].val', 'ifc[1].val'], 'ifc__val', rt.Array([2], rt.Port('input', rdt.Vector(1))) ),
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['ifc[0].msg', 'ifc[1].msg'], 'ifc__msg', rt.Array([2], rt.Port('input', rdt.Vector(32))), 1 ),
+    ( ['ifc[0].rdy', 'ifc[1].rdy'], 'ifc__rdy', rt.Array([2], rt.Port('output', rdt.Vector(1))), 1 ),
+    ( ['ifc[0].val', 'ifc[1].val'], 'ifc__val', rt.Array([2], rt.Port('input', rdt.Vector(1))), 1 ),
   ]
   a._ref_ports_yosys = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) ),
-    ( ['ifc[0].msg'], 'ifc__0__msg', rt.Port('input', rdt.Vector(32)) ),
-    ( ['ifc[0].rdy'], 'ifc__0__rdy', rt.Port('output', rdt.Vector(1)) ),
-    ( ['ifc[0].val'], 'ifc__0__val', rt.Port('input', rdt.Vector(1)) ),
-    ( ['ifc[1].msg'], 'ifc__1__msg', rt.Port('input', rdt.Vector(32)) ),
-    ( ['ifc[1].rdy'], 'ifc__1__rdy', rt.Port('output', rdt.Vector(1)) ),
-    ( ['ifc[1].val'], 'ifc__1__val', rt.Port('input', rdt.Vector(1)) ),
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['ifc[0].msg'], 'ifc__0__msg', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[0].rdy'], 'ifc__0__rdy', rt.Port('output', rdt.Vector(1)), 1 ),
+    ( ['ifc[0].val'], 'ifc__0__val', rt.Port('input', rdt.Vector(1)), 1 ),
+    ( ['ifc[1].msg'], 'ifc__1__msg', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[1].rdy'], 'ifc__1__rdy', rt.Port('output', rdt.Vector(1)), 1 ),
+    ( ['ifc[1].val'], 'ifc__1__val', rt.Port('input', rdt.Vector(1)), 1 ),
   ]
   do_test( a )
 
@@ -250,27 +250,27 @@ def test_nested_interface( do_test ):
       s.ifc = [ Ifc() for _ in range(2) ]
   a = A()
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) ),
-    ( ['ifc[0].ctrl_bar', 'ifc[1].ctrl_bar'], 'ifc__ctrl_bar', rt.Array([2], rt.Port('input', rdt.Vector(32)))),
-    ( ['ifc[0].ctrl_foo', 'ifc[1].ctrl_foo'], 'ifc__ctrl_foo', rt.Array([2], rt.Port('output', rdt.Vector(32)))),
-    ( ['ifc[0].valrdy_ifc.msg', 'ifc[1].valrdy_ifc.msg'], 'ifc__valrdy_ifc__msg', rt.Array([2], rt.Port('input', rdt.Vector(32)))),
-    ( ['ifc[0].valrdy_ifc.rdy', 'ifc[1].valrdy_ifc.rdy'], 'ifc__valrdy_ifc__rdy', rt.Array([2], rt.Port('output', rdt.Vector(1)))),
-    ( ['ifc[0].valrdy_ifc.val', 'ifc[1].valrdy_ifc.val'], 'ifc__valrdy_ifc__val', rt.Array([2], rt.Port('input', rdt.Vector(1)))),
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['ifc[0].ctrl_bar', 'ifc[1].ctrl_bar'], 'ifc__ctrl_bar', rt.Array([2], rt.Port('input', rdt.Vector(32))), 1 ),
+    ( ['ifc[0].ctrl_foo', 'ifc[1].ctrl_foo'], 'ifc__ctrl_foo', rt.Array([2], rt.Port('output', rdt.Vector(32))), 1 ),
+    ( ['ifc[0].valrdy_ifc.msg', 'ifc[1].valrdy_ifc.msg'], 'ifc__valrdy_ifc__msg', rt.Array([2], rt.Port('input', rdt.Vector(32))), 1 ),
+    ( ['ifc[0].valrdy_ifc.rdy', 'ifc[1].valrdy_ifc.rdy'], 'ifc__valrdy_ifc__rdy', rt.Array([2], rt.Port('output', rdt.Vector(1))), 1 ),
+    ( ['ifc[0].valrdy_ifc.val', 'ifc[1].valrdy_ifc.val'], 'ifc__valrdy_ifc__val', rt.Array([2], rt.Port('input', rdt.Vector(1))), 1 ),
   ]
   a._ref_ports_yosys = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) ),
-    ( ['ifc[0].ctrl_bar'], 'ifc__0__ctrl_bar', rt.Port('input', rdt.Vector(32))),
-    ( ['ifc[0].ctrl_foo'], 'ifc__0__ctrl_foo', rt.Port('output', rdt.Vector(32))),
-    ( ['ifc[0].valrdy_ifc.msg'], 'ifc__0__valrdy_ifc__msg', rt.Port('input', rdt.Vector(32))),
-    ( ['ifc[0].valrdy_ifc.rdy'], 'ifc__0__valrdy_ifc__rdy', rt.Port('output', rdt.Vector(1))),
-    ( ['ifc[0].valrdy_ifc.val'], 'ifc__0__valrdy_ifc__val', rt.Port('input', rdt.Vector(1))),
-    ( ['ifc[1].ctrl_bar'], 'ifc__1__ctrl_bar', rt.Port('input', rdt.Vector(32))),
-    ( ['ifc[1].ctrl_foo'], 'ifc__1__ctrl_foo', rt.Port('output', rdt.Vector(32))),
-    ( ['ifc[1].valrdy_ifc.msg'], 'ifc__1__valrdy_ifc__msg', rt.Port('input', rdt.Vector(32))),
-    ( ['ifc[1].valrdy_ifc.rdy'], 'ifc__1__valrdy_ifc__rdy', rt.Port('output', rdt.Vector(1))),
-    ( ['ifc[1].valrdy_ifc.val'], 'ifc__1__valrdy_ifc__val', rt.Port('input', rdt.Vector(1))),
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['ifc[0].ctrl_bar'], 'ifc__0__ctrl_bar', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[0].ctrl_foo'], 'ifc__0__ctrl_foo', rt.Port('output', rdt.Vector(32)), 1 ),
+    ( ['ifc[0].valrdy_ifc.msg'], 'ifc__0__valrdy_ifc__msg', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[0].valrdy_ifc.rdy'], 'ifc__0__valrdy_ifc__rdy', rt.Port('output', rdt.Vector(1)), 1 ),
+    ( ['ifc[0].valrdy_ifc.val'], 'ifc__0__valrdy_ifc__val', rt.Port('input', rdt.Vector(1)), 1 ),
+    ( ['ifc[1].ctrl_bar'], 'ifc__1__ctrl_bar', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[1].ctrl_foo'], 'ifc__1__ctrl_foo', rt.Port('output', rdt.Vector(32)), 1 ),
+    ( ['ifc[1].valrdy_ifc.msg'], 'ifc__1__valrdy_ifc__msg', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[1].valrdy_ifc.rdy'], 'ifc__1__valrdy_ifc__rdy', rt.Port('output', rdt.Vector(1)), 1 ),
+    ( ['ifc[1].valrdy_ifc.val'], 'ifc__1__valrdy_ifc__val', rt.Port('input', rdt.Vector(1)), 1 ),
   ]
   do_test( a )
 
@@ -290,28 +290,28 @@ def test_nested_interface_port_array( do_test ):
       s.ifc = [ Ifc() for _ in range(2) ]
   a = A()
   a._ref_ports = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) ),
-    ( ['ifc[0].ctrl_bar', 'ifc[1].ctrl_bar'], 'ifc__ctrl_bar', rt.Array([2], rt.Port('input', rdt.Vector(32)))),
-    ( ['ifc[0].ctrl_foo', 'ifc[1].ctrl_foo'], 'ifc__ctrl_foo', rt.Array([2], rt.Port('output', rdt.Vector(32)))),
-    ( ['ifc[0].valrdy_ifc.msg', 'ifc[1].valrdy_ifc.msg'], 'ifc__valrdy_ifc__msg', rt.Array([2, 2], rt.Port('input', rdt.Vector(32)))),
-    ( ['ifc[0].valrdy_ifc.rdy', 'ifc[1].valrdy_ifc.rdy'], 'ifc__valrdy_ifc__rdy', rt.Array([2], rt.Port('output', rdt.Vector(1)))),
-    ( ['ifc[0].valrdy_ifc.val', 'ifc[1].valrdy_ifc.val'], 'ifc__valrdy_ifc__val', rt.Array([2], rt.Port('input', rdt.Vector(1)))),
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['ifc[0].ctrl_bar', 'ifc[1].ctrl_bar'], 'ifc__ctrl_bar', rt.Array([2], rt.Port('input', rdt.Vector(32))), 1 ),
+    ( ['ifc[0].ctrl_foo', 'ifc[1].ctrl_foo'], 'ifc__ctrl_foo', rt.Array([2], rt.Port('output', rdt.Vector(32))), 1 ),
+    ( ['ifc[0].valrdy_ifc.msg', 'ifc[1].valrdy_ifc.msg'], 'ifc__valrdy_ifc__msg', rt.Array([2, 2], rt.Port('input', rdt.Vector(32))), 1 ),
+    ( ['ifc[0].valrdy_ifc.rdy', 'ifc[1].valrdy_ifc.rdy'], 'ifc__valrdy_ifc__rdy', rt.Array([2], rt.Port('output', rdt.Vector(1))), 1 ),
+    ( ['ifc[0].valrdy_ifc.val', 'ifc[1].valrdy_ifc.val'], 'ifc__valrdy_ifc__val', rt.Array([2], rt.Port('input', rdt.Vector(1))), 1 ),
   ]
   a._ref_ports_yosys = [
-    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)) ),
-    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)) ),
-    ( ['ifc[0].ctrl_bar'], 'ifc__0__ctrl_bar', rt.Port('input', rdt.Vector(32)) ),
-    ( ['ifc[0].ctrl_foo'], 'ifc__0__ctrl_foo', rt.Port('output', rdt.Vector(32)) ),
-    ( ['ifc[0].valrdy_ifc.msg[0]'], 'ifc__0__valrdy_ifc__msg__0', rt.Port('input', rdt.Vector(32)) ),
-    ( ['ifc[0].valrdy_ifc.msg[1]'], 'ifc__0__valrdy_ifc__msg__1', rt.Port('input', rdt.Vector(32)) ),
-    ( ['ifc[0].valrdy_ifc.rdy'], 'ifc__0__valrdy_ifc__rdy', rt.Port('output', rdt.Vector(1)) ),
-    ( ['ifc[0].valrdy_ifc.val'], 'ifc__0__valrdy_ifc__val', rt.Port('input', rdt.Vector(1)) ),
-    ( ['ifc[1].ctrl_bar'], 'ifc__1__ctrl_bar', rt.Port('input', rdt.Vector(32)) ),
-    ( ['ifc[1].ctrl_foo'], 'ifc__1__ctrl_foo', rt.Port('output', rdt.Vector(32)) ),
-    ( ['ifc[1].valrdy_ifc.msg[0]'], 'ifc__1__valrdy_ifc__msg__0', rt.Port('input', rdt.Vector(32)) ),
-    ( ['ifc[1].valrdy_ifc.msg[1]'], 'ifc__1__valrdy_ifc__msg__1', rt.Port('input', rdt.Vector(32)) ),
-    ( ['ifc[1].valrdy_ifc.rdy'], 'ifc__1__valrdy_ifc__rdy', rt.Port('output', rdt.Vector(1)) ),
-    ( ['ifc[1].valrdy_ifc.val'], 'ifc__1__valrdy_ifc__val', rt.Port('input', rdt.Vector(1)) )
+    ( ['clk'], 'clk', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['reset'], 'reset', rt.Port('input', rdt.Vector(1)), 0 ),
+    ( ['ifc[0].ctrl_bar'], 'ifc__0__ctrl_bar', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[0].ctrl_foo'], 'ifc__0__ctrl_foo', rt.Port('output', rdt.Vector(32)), 1 ),
+    ( ['ifc[0].valrdy_ifc.msg[0]'], 'ifc__0__valrdy_ifc__msg__0', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[0].valrdy_ifc.msg[1]'], 'ifc__0__valrdy_ifc__msg__1', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[0].valrdy_ifc.rdy'], 'ifc__0__valrdy_ifc__rdy', rt.Port('output', rdt.Vector(1)), 1 ),
+    ( ['ifc[0].valrdy_ifc.val'], 'ifc__0__valrdy_ifc__val', rt.Port('input', rdt.Vector(1)), 1 ),
+    ( ['ifc[1].ctrl_bar'], 'ifc__1__ctrl_bar', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[1].ctrl_foo'], 'ifc__1__ctrl_foo', rt.Port('output', rdt.Vector(32)), 1 ),
+    ( ['ifc[1].valrdy_ifc.msg[0]'], 'ifc__1__valrdy_ifc__msg__0', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[1].valrdy_ifc.msg[1]'], 'ifc__1__valrdy_ifc__msg__1', rt.Port('input', rdt.Vector(32)), 1 ),
+    ( ['ifc[1].valrdy_ifc.rdy'], 'ifc__1__valrdy_ifc__rdy', rt.Port('output', rdt.Vector(1)), 1 ),
+    ( ['ifc[1].valrdy_ifc.val'], 'ifc__1__valrdy_ifc__val', rt.Port('input', rdt.Vector(1)), 1 ),
   ]
   do_test( a )

--- a/pymtl3/passes/backends/verilog/util/utility.py
+++ b/pymtl3/passes/backends/verilog/util/utility.py
@@ -53,6 +53,7 @@ def pretty_concat( *strings ):
     ret += ';'
   else:
     ret += f' {strings[-1]}'
+  return ret
 
 def get_dir( cur_file ):
   return os.path.dirname(os.path.abspath(cur_file))+os.path.sep

--- a/pymtl3/passes/backends/verilog/util/utility.py
+++ b/pymtl3/passes/backends/verilog/util/utility.py
@@ -48,7 +48,11 @@ def expand( v ):
   return os.path.expanduser(os.path.expandvars(v))
 
 def pretty_concat( *strings ):
-  return ' '.join([s for s in strings if s])
+  ret = ' '.join([s for s in strings[:-1] if s])
+  if strings[-1] == ';':
+    ret += ';'
+  else:
+    ret += f' {strings[-1]}'
 
 def get_dir( cur_file ):
   return os.path.dirname(os.path.abspath(cur_file))+os.path.sep

--- a/pymtl3/passes/backends/yosys/util/utility.py
+++ b/pymtl3/passes/backends/yosys/util/utility.py
@@ -80,7 +80,7 @@ def gen_mapped_ports( m, port_map, has_clk=True, has_reset=True ):
     else:
       ret = []
       for i in range(n_dim[0]):
-        ret += _mangle_port(f"{pname}[{i}]", f"{vname}__{i}", port, n_dim[1:], port_idx+1)
+        ret += _mangle_port(f"{pname}[{i}]", f"{vname}__{i}", port, n_dim[1:], port_idx)
       return ret
 
   def _mangle_ifc( pname, vname, ifc, n_dim, port_idx ):


### PR DESCRIPTION
1. Fixed a bug where the Python import wrapper has incorrect connections for single element arrays
2. Fixed a bug where the Python import wrapper has unresolved name references for nbits > 256
3. Fixed a bug where nested arrays of nested interfaces are not correctly translated
4. Removed the space between `;` and the last word in the translation result