### PR TITLE
Better constant extraction during RTLIR generation

### DIFF
--- a/examples/ex03_proc/NullXcel.py
+++ b/examples/ex03_proc/NullXcel.py
@@ -18,7 +18,6 @@ class NullXcelRTL(Component):
   def construct( s, nbits=32 ):
 
     dtype = mk_bits(32)
-    XcelMsgType_WRITE = XcelMsgType.WRITE
     xreq_class, xresp_class = mk_xcel_msg( 5,nbits )
 
     s.xcel = XcelMinionIfcRTL( xreq_class, xresp_class )
@@ -35,7 +34,7 @@ class NullXcelRTL(Component):
         s.xcel.resp.en     = b1(1)
         s.xcel.resp.msg.type_ = s.xcelreq_q.deq.ret.type_
 
-        if s.xcelreq_q.deq.ret.type_ == XcelMsgType_WRITE:
+        if s.xcelreq_q.deq.ret.type_ == XcelMsgType.WRITE:
           s.xr0.en             = b1(1)
           s.xcel.resp.msg.data = dtype(0)
         else:

--- a/examples/ex03_proc/ProcCtrlRTL.py
+++ b/examples/ex03_proc/ProcCtrlRTL.py
@@ -17,9 +17,6 @@ class ProcCtrl( Component ):
 
   def construct( s ):
 
-    XcelMsgType_READ  = XcelMsgType.READ
-    XcelMsgType_WRITE = XcelMsgType.WRITE
-
     #---------------------------------------------------------------------
     # Interface
     #---------------------------------------------------------------------
@@ -368,11 +365,11 @@ class ProcCtrl( Component ):
 
       # accelerator
       if s.csrr_D and (s.inst_D[CSRNUM] != CSR_MNGR2PROC):
-        s.xcelreq_type_D = XcelMsgType_READ
+        s.xcelreq_type_D = XcelMsgType.READ
         s.xcelreq_D = b1(1)
 
       elif s.csrw_D and (s.inst_D[CSRNUM] != CSR_PROC2MNGR):
-        s.xcelreq_type_D = XcelMsgType_WRITE
+        s.xcelreq_type_D = XcelMsgType.WRITE
         s.xcelreq_D = b1(1)
       else:
         s.xcelreq_type_D = b1(0)

--- a/examples/ex04_xcel/ChecksumXcelRTL.py
+++ b/examples/ex04_xcel/ChecksumXcelRTL.py
@@ -32,11 +32,6 @@ class ChecksumXcelRTL( Component ):
     s.WAIT = b2(1)
     s.BUSY = b2(2)
 
-    # Local parameters
-
-    s.RD = XcelMsgType.READ
-    s.WR = XcelMsgType.WRITE
-
     # Components
 
     s.in_q = NormalQueueRTL( ReqType, num_entries=2 )
@@ -62,7 +57,7 @@ class ChecksumXcelRTL( Component ):
     def up_start_pulse():
       s.start_pulse = (
         s.xcel.resp.en and
-        s.in_q.deq.ret.type_ == s.WR and
+        s.in_q.deq.ret.type_ == XcelMsgType.WRITE and
         s.in_q.deq.ret.addr == b5(4)
       )
 
@@ -112,7 +107,7 @@ class ChecksumXcelRTL( Component ):
     def up_resp_msg():
       s.xcel.resp.msg.type_ = s.in_q.deq.ret.type_
       s.xcel.resp.msg.data  = b32(0)
-      if s.in_q.deq.ret.type_ == s.RD:
+      if s.in_q.deq.ret.type_ == XcelMsgType.READ:
         s.xcel.resp.msg.data = s.reg_file[ s.in_q.deq.ret.addr[0:3] ].out
 
     @s.update
@@ -120,7 +115,7 @@ class ChecksumXcelRTL( Component ):
       for i in range(6):
         s.reg_file[i].in_ = s.reg_file[i].out
 
-      if s.in_q.deq.en and s.in_q.deq.ret.type_ == s.WR:
+      if s.in_q.deq.en and s.in_q.deq.ret.type_ == XcelMsgType.WRITE:
         for i in range(6):
           s.reg_file[i].in_ = (
             s.in_q.deq.ret.data if b5(i) == s.in_q.deq.ret.addr else

--- a/pymtl3/passes/backends/generic/testcases/test_cases.py
+++ b/pymtl3/passes/backends/generic/testcases/test_cases.py
@@ -889,7 +889,6 @@ CaseBits32ArrayClosureConstruct = set_attributes( CaseBits32ArrayClosureConstruc
         );
         const_decls:
         freevars:
-          freevar: foo_at_upblk
         wire_decls:
         component_decls:
         tmpvars:
@@ -905,10 +904,7 @@ CaseBits32ArrayClosureConstruct = set_attributes( CaseBits32ArrayClosureConstruc
           upblk_src: upblk
     ''',
     'REF_FREEVAR',
-    '''\
-        freevars:
-          freevar: foo_at_upblk
-    '''
+    'freevars:\n'
 )
 
 CaseConnectBitSelToOutComp = set_attributes( CaseConnectBitSelToOutComp,

--- a/pymtl3/passes/backends/verilog/testcases/test_cases.py
+++ b/pymtl3/passes/backends/verilog/testcases/test_cases.py
@@ -66,6 +66,7 @@ from pymtl3.passes.testcases import (
     CaseNestedIfComp,
     CaseNestedStructPackedArrayUpblkComp,
     CasePassThroughComp,
+    CasePythonClassAttr,
     CaseReducesInx3OutComp,
     CaseSequentialPassThroughComp,
     CaseSizeCastPaddingStructPort,
@@ -512,6 +513,33 @@ CaseBits64PartSelUpblkComp = set_attributes( CaseBits64PartSelUpblkComp,
 
           always_comb begin : upblk
             out = in_[35:4];
+          end
+
+        endmodule
+    '''
+)
+
+CasePythonClassAttr = set_attributes( CasePythonClassAttr,
+    'REF_UPBLK',
+    '''\
+        always_comb begin : upblk
+          out1 = 42;
+          out2 = 32'd1;
+        end
+    ''',
+    'REF_SRC',
+    '''\
+        module DUT
+        (
+          input logic [0:0] clk,
+          output logic [31:0] out1,
+          output logic [31:0] out2,
+          input logic [0:0] reset
+        );
+
+          always_comb begin : upblk
+            out1 = 42;
+            out2 = 32'd1;
           end
 
         endmodule
@@ -1003,25 +1031,20 @@ CaseConstStructInstComp = set_attributes( CaseConstStructInstComp,
     'REF_UPBLK',
     '''\
         always_comb begin : upblk
-          out = in_.foo;
+          out = 32'd0;
         end
     ''',
     'REF_SRC',
     '''\
-        typedef struct packed {
-          logic [31:0] foo;
-        } Bits32Foo;
-
         module DUT
         (
           input logic [0:0] clk,
           output logic [31:0] out,
           input logic [0:0] reset
         );
-          localparam Bits32Foo in_ = { 32'd0 };
 
           always_comb begin : upblk
-            out = in_.foo;
+            out = 32'd0;
           end
 
         endmodule

--- a/pymtl3/passes/backends/verilog/translation/behavioral/test/VBehavioralTranslatorL1_test.py
+++ b/pymtl3/passes/backends/verilog/translation/behavioral/test/VBehavioralTranslatorL1_test.py
@@ -23,6 +23,7 @@ from ....testcases import (
     CaseBits64SextInComp,
     CaseBits64ZextInComp,
     CasePassThroughComp,
+    CasePythonClassAttr,
     CaseSequentialPassThroughComp,
     CaseVerilogReservedComp,
 )
@@ -57,6 +58,7 @@ def run_test( case, m ):
       CaseBits32x2ConcatUnpackedSignalComp,
       CaseBits32BitSelUpblkComp,
       CaseBits64PartSelUpblkComp,
+      CasePythonClassAttr,
     ]
 )
 def test_verilog_behavioral_L1( case ):

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRL1Pass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRL1Pass_test.py
@@ -324,7 +324,7 @@ def test_L1_call_sext_num_args( do_test ):
     do_test( CaseSextTwoArgsComp )
 
 def test_L1_call_unrecognized( do_test ):
-  with expected_failure( PyMTLSyntaxError, "Unrecognized method" ):
+  with expected_failure( PyMTLSyntaxError, "foo function is not found!" ):
     do_test( CaseUnrecognizedFuncComp )
 
 #-------------------------------------------------------------------------

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRL2Pass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRL2Pass_test.py
@@ -172,7 +172,7 @@ def test_L2_binop_non_vector( do_test ):
 #-------------------------------------------------------------------------
 
 def test_L2_call_bool( do_test ):
-  with expected_failure( PyMTLSyntaxError, "bool values cannot be instantiated explicitly" ):
+  with expected_failure( PyMTLSyntaxError, "Bool function is not found!" ):
     do_test( CaseExplicitBoolComp )
 
 def test_L2_tmp_var_used_before_assignement( do_test ):

--- a/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRL3Pass_test.py
+++ b/pymtl3/passes/rtlir/behavioral/test/BehavioralRTLIRL3Pass_test.py
@@ -79,8 +79,7 @@ def test_L3_struct_inst( do_test ):
 def test_L3_const_struct( do_test ):
   a = CaseConstStructInstComp.DUT()
   a._rtlir_test_ref = { 'upblk' : CombUpblk( 'upblk', [ Assign(
-      [Attribute( Base( a ), 'out' )], Attribute(
-        Attribute( Base( a ), 'in_' ), 'foo' ), True ) ] ) }
+      [Attribute( Base( a ), 'out' )], SizeCast(32, Number(0)), True ) ] ) }
   do_test( a )
 
 #-------------------------------------------------------------------------

--- a/pymtl3/passes/testcases/test_cases.py
+++ b/pymtl3/passes/testcases/test_cases.py
@@ -352,6 +352,30 @@ class CaseStructClosureGlobal:
       def upblk():
         s.out = foo.foo
 
+class CasePythonClassAttr:
+  class DUT( Component ):
+    def construct( s ):
+      class Enum:
+        int_attr = 42
+        bit_attr = Bits32(1)
+      s.out1 = OutPort( Bits32 )
+      s.out2 = OutPort( Bits32 )
+      @s.update
+      def upblk():
+        s.out1 = Enum.int_attr
+        s.out2 = Enum.bit_attr
+  TV_IN = _set()
+  TV_OUT = \
+  _check(
+      'out1', Bits32, 0,
+      'out2', Bits32, 1,
+  )
+  TEST_VECTOR = \
+  [
+      [  42,   1,  ],
+      [  42,   1,  ],
+  ]
+
 class CaseReducesInx3OutComp:
   class DUT( Component ):
     def construct( s ):


### PR DESCRIPTION
This PR allows the use of complex expressions in translatable update blocks, as long as they evaluate to a constant object at translation time. The following Python objects are considered to be "constant":
1. BitsN and BitStruct
2. BitsN() and BitStruct()
3. Python int objects
4. PyMTL functions: sext, zext, concat, reduce_*