### PR TITLE
Fixed amo method in MemIfcFL2CLAdapter

### DIFF
--- a/pymtl3/stdlib/ifcs/mem_ifcs.py
+++ b/pymtl3/stdlib/ifcs/mem_ifcs.py
@@ -236,7 +236,7 @@ class MemIfcFL2CLAdapter( Component ):
     while not s.right.req.rdy():
       greenlet.getcurrent().parent.switch(0)
 
-    s.right.req( s.ReqType( amo, 0, addr, nbytes ) )
+    s.right.req( s.ReqType( amo, 0, addr, nbytes, data ) )
 
     while s.entry is None:
       greenlet.getcurrent().parent.switch(0)


### PR DESCRIPTION
There was a missing data field in requests made in `amo` method of `MemIfcFL2CLAdapter`.