### PR TITLE
Add v_libs option

### DIFF
--- a/pymtl3/passes/backends/verilog/VerilogPlaceholderConfigs.py
+++ b/pymtl3/passes/backends/verilog/VerilogPlaceholderConfigs.py
@@ -35,6 +35,10 @@ class VerilogPlaceholderConfigs( PlaceholderConfigs ):
     # Expects the path to the flist file; "" to disable this option
     "v_flist" : "",
 
+    # -v
+    # Expects a list of paths to Verilog files; [] to disable this option
+    "v_libs" : [],
+
     # -I ( alias of -y and +incdir+ )
     # Expects a list of include paths; [] to disable this option
     "v_include" : [],
@@ -50,6 +54,9 @@ class VerilogPlaceholderConfigs( PlaceholderConfigs ):
 
     "v_flist": Checker( lambda v: isinstance(v, str) and os.path.isfile(expand(v)) or v == "",
                          "expects a path to a file" ),
+
+    "v_libs": Checker( lambda v: isinstance(v, list) and all(os.path.exists(expand(p)) for p in v),
+                            "expects a list of paths to files"),
 
     "v_include": Checker( lambda v: isinstance(v, list) and all(os.path.isdir(expand(p)) for p in v),
                             "expects a list of paths to directory"),

--- a/pymtl3/passes/backends/verilog/import_/VerilatorImportConfigs.py
+++ b/pymtl3/passes/backends/verilog/import_/VerilatorImportConfigs.py
@@ -193,6 +193,7 @@ class VerilatorImportConfigs( BasePassConfigs ):
     s.translated_top_module = m_tr_namespace.translated_top_module
     s.translated_source_file = m_tr_namespace.translated_filename
     s.v_include = m.config_placeholder.v_include
+    s.v_libs = m.config_placeholder.v_libs
     # s.src_file = m.config_placeholder.src_file
     s.port_map = m.config_placeholder.port_map
     s.params = m.config_placeholder.params
@@ -235,6 +236,8 @@ class VerilatorImportConfigs( BasePassConfigs ):
     mk_dir      = f"--Mdir {s.vl_mk_dir}"
     # flist       = "" if s.is_default("v_flist") else \
     #               f"-f {s.v_flist}"
+    vlibs       = "" if not s.v_libs else \
+                  " ".join([f"-v {lib}" for lib in s.v_libs])
     include     = "" if not s.v_include else \
                   " ".join("-I" + path for path in s.v_include)
     en_assert   = "--assert" if s.vl_enable_assert else ""
@@ -252,7 +255,7 @@ class VerilatorImportConfigs( BasePassConfigs ):
     all_opts = [
       top_module, mk_dir, include, en_assert, opt_level, loop_unroll,
       # stmt_unroll, trace, warnings, flist, src, coverage,
-      stmt_unroll, trace, warnings, src, coverage,
+      stmt_unroll, trace, warnings, src, vlibs, coverage,
       line_cov, toggle_cov,
     ]
 


### PR DESCRIPTION
Verilog placeholder config `v_libs` allows you to specify a Verilog library to be Verilated together with the Verilog source file. 