### PR TITLE
Add more request types to MemMsg

### DIFF
--- a/pymtl3/stdlib/cl/MemoryCL.py
+++ b/pymtl3/stdlib/cl/MemoryCL.py
@@ -76,13 +76,8 @@ class MemoryCL( Component ):
     s.req_qs  = [ DelayPipeDeqCL( req_latency )( enq = s.ifc[i].req ) for i in range(nports) ]
     s.resp_qs = [ DelayPipeSendCL( resp_latency )( send = s.ifc[i].resp ) for i in range(nports) ]
 
-    # Trace
-    s.trace = ""
-
     @s.update
     def up_mem():
-      # init trace
-      s.trace = ""
 
       for i in range(s.nports):
 
@@ -139,15 +134,12 @@ class MemoryCL( Component ):
 
           s.resp_qs[i].enq( resp )
 
-          # update trace
-          s.trace += f"[{i}] {MemMsgType.str[req.type_.uint()]} "
-          s.trace += f"0x{req.addr.uint():0>8x} "
-          s.trace += f"req=0x{req.data.uint():0>8x} "
-          s.trace += f"resp=0x{resp.data.uint():0>8x} "
-
   #-----------------------------------------------------------------------
   # line_trace
   #-----------------------------------------------------------------------
 
   def line_trace( s ):
-    return s.trace
+    msg = ""
+    for i in range( s.nports ):
+      msg += f"[{i}] {str(s.ifc[i].req)} {str(s.ifc[i].resp)} "
+    return msg

--- a/pymtl3/stdlib/cl/MemoryCL.py
+++ b/pymtl3/stdlib/cl/MemoryCL.py
@@ -76,8 +76,13 @@ class MemoryCL( Component ):
     s.req_qs  = [ DelayPipeDeqCL( req_latency )( enq = s.ifc[i].req ) for i in range(nports) ]
     s.resp_qs = [ DelayPipeSendCL( resp_latency )( send = s.ifc[i].resp ) for i in range(nports) ]
 
+    # Trace
+    s.trace = ""
+
     @s.update
     def up_mem():
+      # init trace
+      s.trace = ""
 
       for i in range(s.nports):
 
@@ -89,26 +94,60 @@ class MemoryCL( Component ):
           len_ = int(req.len)
           if len_ == 0: len_ = req_classes[i].data_nbits >> 3
 
+          #
+          # READ
+          #
           if   req.type_ == MemMsgType.READ:
             resp = resp_classes[i]( req.type_, req.opaque, 0, req.len,
                                     s.mem.read( req.addr, len_ ) )
 
-          elif req.type_ == MemMsgType.WRITE:
+          #
+          # WRITE
+          #
+          elif  req.type_ == MemMsgType.WRITE:
             s.mem.write( req.addr, len_, req.data )
             # FIXME do we really set len=0 in response when doing subword wr?
             # resp = resp_classes[i]( req.type_, req.opaque, 0, req.len, 0 )
             resp = resp_classes[i]( req.type_, req.opaque, 0, 0, 0 )
 
-          else: # AMOS
+          #
+          # AMOs
+          #
+          elif  req.type_ == MemMsgType.AMO_ADD   or \
+                req.type_ == MemMsgType.AMO_AND   or \
+                req.type_ == MemMsgType.AMO_MAX   or \
+                req.type_ == MemMsgType.AMO_MAXU  or \
+                req.type_ == MemMsgType.AMO_MIN   or \
+                req.type_ == MemMsgType.AMO_MINU  or \
+                req.type_ == MemMsgType.AMO_OR    or \
+                req.type_ == MemMsgType.AMO_SWAP  or \
+                req.type_ == MemMsgType.AMO_XOR:
             resp = resp_classes[i]( req.type_, req.opaque, 0, req.len,
                s.mem.amo( req.type_, req.addr, len_, req.data ) )
 
+          # INV
+          elif  req.type_ == MemMsgType.INV:
+            resp = resp_classes[i]( req.type_, req.opaque, 0, 0, 0 )
+
+          # FLUSH
+          elif  req.type_ == MemMsgType.FLUSH:
+            resp = resp_classes[i]( req.type_, req.opaque, 0, 0, 0 )
+
+          # Invalid type
+          else:
+            assert( False )
+
           s.resp_qs[i].enq( resp )
+
+          # update trace
+          s.trace += f"[{i}] {MemMsgType.str[req.type_.uint()]} "
+          s.trace += f"0x{req.addr.uint():0>8x} "
+          s.trace += f"req=0x{req.data.uint():0>8x} "
+          s.trace += f"resp=0x{resp.data.uint():0>8x} "
 
   #-----------------------------------------------------------------------
   # line_trace
   #-----------------------------------------------------------------------
-  # TODO: better line trace.
 
   def line_trace( s ):
-    return "|".join( [ x[0].line_trace() + x[1].line_trace() for x in zip(s.req_qs, s.resp_qs) ] )
+    return s.trace

--- a/pymtl3/stdlib/ifcs/MemMsg.py
+++ b/pymtl3/stdlib/ifcs/MemMsg.py
@@ -88,6 +88,10 @@ class MemMsgType:
   AMO_MAX    = 9
   AMO_MAXU   = 10
   AMO_XOR    = 11
+  LR         = 12 # Load-Reserved
+  SC         = 13 # Store-Conditional
+  INV        = 14 # Cache invalidation
+  FLUSH      = 15 # Cache flush
 
   str = {
     READ       : "rd",
@@ -102,4 +106,8 @@ class MemMsgType:
     AMO_MAX    : "mx",
     AMO_MAXU   : "xu",
     AMO_XOR    : "xo",
+    LR         : "lr",
+    SC         : "sc",
+    INV        : "iv",
+    FLUSH      : "fl"
   }


### PR DESCRIPTION
This PR adds more request types needed for LR, SC instructions and cache invalidation/flush. This also adds support for the extra types and a better line trace in MemoryCL.