### PR TITLE
Improve verilog tbgen pass

### DIFF
--- a/pymtl3/passes/backends/verilog/tbgen/VerilogTBGenPass.py
+++ b/pymtl3/passes/backends/verilog/tbgen/VerilogTBGenPass.py
@@ -124,7 +124,7 @@ class VerilogTBGenPass( BasePass ):
     src =  """
 def dump_case():
   if top.simulated_cycles >= 2: # skip reset
-    print(f"`T({});", file=case_file)
+    print(f"`T({});", file=case_file, flush=True)
 """.format( ",".join(port_srcs) )
     _locals = {}
     custom_exec( py.code.Source(src).compile(), {'top': top, 'x': x, 'to_bits': to_bits, 'case_file': case_file}, _locals)

--- a/pymtl3/passes/backends/verilog/tbgen/verilog_tbgen_v_template.py
+++ b/pymtl3/passes/backends/verilog/tbgen/verilog_tbgen_v_template.py
@@ -1,24 +1,31 @@
 template = \
 '''
-`define HOLD_TIME 1
-`define INTRA_CYCLE_TIME 2
-`define SETUP_TIME 1
-`define CYCLE_TIME (`HOLD_TIME+`INTRA_CYCLE_TIME+`SETUP_TIME)
+// VT_INPUT_DELAY, VTB_OUTPUT_ASSERT_DELAY are timestamps relative to the rising edge.
+`define VTB_INPUT_DELAY 1
+`define VTB_OUTPUT_ASSERT_DELAY 3
+
+// CYCLE_TIME and INTRA_CYCLE_TIME are duration of time.
+`define CYCLE_TIME 4
+`define INTRA_CYCLE_TIME `VTB_OUTPUT_ASSERT_DELAY-`VTB_INPUT_DELAY
 
 `timescale 1ns/1ns
 
 `define T({args_strs}) \\
         t({args_strs},`__LINE__)
 
+// Tick two extra cycles upon an error.
 `define CHECK(lineno, out, ref, port_name) \\
   if (out != ref) begin \\
     $display(""); \\
     $display("The test bench received an incorrect value!"); \\
-    $display("- row number     : %0d", lineno); \\
+    $display("- line %0d in {cases_file_name}", lineno); \\
+    $display("- cycle number   : %0d", lineno+2); \\
     $display("- port name      : %s", port_name); \\
     $display("- expected value : 0x%x", ref); \\
     $display("- actual value   : 0x%x", out); \\
     $display(""); \\
+    #`CYCLE_TIME; \\
+    #`CYCLE_TIME; \\
     $fatal; \\
   end
 
@@ -37,7 +44,7 @@ module {harness_name};
     {task_assign_strs};
     #`INTRA_CYCLE_TIME;
     {task_check_strs};
-    #(`SETUP_TIME+`HOLD_TIME);
+    #(`CYCLE_TIME-INTRA_CYCLE_TIME);
   end
   endtask
 
@@ -52,14 +59,18 @@ module {harness_name};
   );
 
   initial begin
+    assert(0 <= VTB_INPUT_DELAY);
+    assert(VTB_INPUT_DELAY < VTB_OUTPUT_ASSERT_DELAY);
+    assert(VTB_OUTPUT_ASSERT_DELAY <= CYCLE_TIME);
+
     clk   = 1'b1; // NEED TO DO THIS TO HAVE RISING EDGE AT TIME 0
     reset = 1'b0; // TODO reset active low/high
 
-    #`HOLD_TIME;
+    #`VTB_INPUT_DELAY;
     reset = 1'b1;
     #`CYCLE_TIME;
     #`CYCLE_TIME;
-    // 2 cycles plus hold
+    // 2 cycles plus input delay
     reset = 1'b0;
 
     `include "{cases_file_name}"
@@ -67,6 +78,10 @@ module {harness_name};
     $display("");
     $display("  [ passed ]");
     $display("");
+
+    // Tick two extra cycles for better waveform
+    #`CYCLE_TIME;
+    #`CYCLE_TIME;
     $finish;
   end
 endmodule


### PR DESCRIPTION
- Flush the output to avoid empty case file
- Rename setup/hold time to input/output delays
- Add timestamp to error message
- Tick two extra cycles before exiting simulation